### PR TITLE
Stub image/attestation signing public key in Rekor

### DIFF
--- a/acceptance/crypto/keys.go
+++ b/acceptance/crypto/keys.go
@@ -70,6 +70,12 @@ func GenerateKeyPairNamed(ctx context.Context, name string) (context.Context, er
 
 	state.Keys[name] = keyPair
 
+	if rekor, ok := ctx.Value(testenv.RekorImpl).(testenv.Rekor); ok {
+		if err := rekor.StubRekorEntryFor(ctx, keyPair.PublicBytes); err != nil {
+			return ctx, err
+		}
+	}
+
 	return ctx, nil
 }
 

--- a/acceptance/rekor/rekor.go
+++ b/acceptance/rekor/rekor.go
@@ -54,6 +54,14 @@ type rekorState struct {
 	KeyPair *cosign.KeysBytes
 }
 
+type rekorImpl struct{}
+
+func (r rekorImpl) StubRekorEntryFor(ctx context.Context, data []byte) error {
+	return stubRekorEntryFor(ctx, data)
+}
+
+var impl testenv.Rekor = rekorImpl{}
+
 func (r rekorState) Key() any {
 	return rekorStateKey
 }
@@ -90,7 +98,7 @@ func stubRekordRunning(ctx context.Context) (context.Context, error) {
 		return ctx, err
 	}
 
-	return ctx, nil
+	return context.WithValue(ctx, testenv.RekorImpl, impl), nil
 }
 
 // randomHex generates a random hex string of the given length

--- a/acceptance/testenv/testenv.go
+++ b/acceptance/testenv/testenv.go
@@ -37,12 +37,17 @@ const (
 	NoColors                              // key to a bool flag telling if the colors should be used in output
 	TestingT                              // key to the *testing.T instance in Context
 	persistedEnv                          // key to a map of persisted environment states
+	RekorImpl                             // key to a implementation of the Rekor interface, used to prevent import cycles
 
 	persistedFile = ".persisted"
 )
 
 var loader = os.ReadFile
 var persister = os.WriteFile
+
+type Rekor interface {
+	StubRekorEntryFor(context.Context, []byte) error
+}
 
 // Persist persists the environment stored in context in a ".persisted" file as JSON
 func Persist(ctx context.Context) (bool, error) {


### PR DESCRIPTION
Adds a stub for a API call to fetch the Rekor log entry for the signing public key.