### PR TITLE
VSCode launch configuration for validating golden

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,6 +86,23 @@
                 "--output",
                 "oci:tracked/bundle:tag",
             ]
+        },
+        {
+            "name": "ec validate golden image",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "validate",
+                "image",
+                "--public-key",
+                "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA\nnaYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==\n-----END PUBLIC KEY-----",
+                "--policy",
+                "{\"configuration\":{\"collections\":[\"minimal\"]},\"sources\":[{\"policy\":[\"oci::quay.io/hacbs-contract/ec-release-policy:git-d995f67@sha256:9d2cffae5ed8a541b4bff1acbaa9bb0b42290214de969e515e78f97b8cf8ff51\"],\"data\":[\"oci::quay.io/hacbs-contract/ec-policy-data:git-d995f67@sha256:eb713f2c0d9c944cbbb298a2c8a0ca1e5a741d149f033b145296d6f550ebd10b\"]}]}",
+                "--image",
+                "quay.io/redhat-appstudio/ec-golden-image:latest"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Might be useful for folk when debugging to launch `ec validate image` with the golden container image.