### PR TITLE
Don't expose the registry on all interfaces

### DIFF
--- a/acceptance/kubernetes/kind/kind.go
+++ b/acceptance/kubernetes/kind/kind.go
@@ -168,6 +168,7 @@ func Start(ctx context.Context) (context.Context, types.Cluster, error) {
 							ContainerPort: kCluster.registryPort,
 							HostPort:      kCluster.registryPort,
 							Protocol:      v1alpha4.PortMappingProtocolTCP,
+							ListenAddress: "127.0.0.1",
 						},
 					},
 				},

--- a/hack/setup-dev-environment.sh
+++ b/hack/setup-dev-environment.sh
@@ -53,6 +53,7 @@ nodes:
   extraPortMappings:
   - containerPort: ${REGISTRY_PORT:-5000}
     hostPort: ${REGISTRY_PORT:-5000}
+    listenAddress: 127.0.0.1
     protocol: TCP
 EOF
 else

--- a/hack/setup-test-environment.sh
+++ b/hack/setup-test-environment.sh
@@ -53,6 +53,7 @@ nodes:
   extraPortMappings:
   - containerPort: ${REGISTRY_PORT:-5000}
     hostPort: ${REGISTRY_PORT:-5000}
+    listenAddress: 127.0.0.1
     protocol: TCP
 EOF
 else


### PR DESCRIPTION
The OCI registry running in the Kind cluster doesn't need to be exposed on all interfaces.