### PR TITLE
UPDATE: show value of ec version --short in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help: ## Display this help
 $(ALL_SUPPORTED_OS_ARCH): ## Build binaries for specific platform/architecture, e.g. make dist/ec_linux_amd64
 	@GOOS=$(word 2,$(subst _, ,$(notdir $@))); \
 	GOARCH=$(word 3,$(subst _, ,$(notdir $@))); \
-	GOOS=$${GOOS} GOARCH=$${GOARCH} go build -trimpath -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/cmd/version.Version=$(VERSION)" -o dist/ec_$${GOOS}_$${GOARCH}; \
+	GOOS=$${GOOS} GOARCH=$${GOARCH} go build -trimpath -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=$(VERSION)" -o dist/ec_$${GOOS}_$${GOARCH}; \
 	sha256sum -b dist/ec_$${GOOS}_$${GOARCH} > dist/ec_$${GOOS}_$${GOARCH}.sha256
 
 .PHONY: dist

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -69,7 +69,8 @@ func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 		  "warnings": []
 		}
 	  ],
-	  "success": true
+	  "success": true,
+	  "ec-version": "development"
 	  }`, out.String())
 }
 
@@ -108,7 +109,7 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 }
 
 func TestDefinitionFileOutputFormats(t *testing.T) {
-	testJSONText := `{"definitions":[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true}],"success":true}`
+	testJSONText := `{"definitions":[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true}],"success":true,"ec-version":"development"}`
 
 	testYAMLTest := hd.Doc(`
 	definitions:
@@ -116,6 +117,7 @@ func TestDefinitionFileOutputFormats(t *testing.T) {
 	  success: true
 	  violations: []
 	  warnings: []
+	ec-version: development
 	success: true
 	`)
 

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -253,6 +253,7 @@ func Test_ValidateImageCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, fmt.Sprintf(`{
 		"success": true,
+		"ec-version": "development",
 		"key": "%s",
 		"components": [
 		  {
@@ -391,6 +392,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, fmt.Sprintf(`{
 		"success": false,
+		"ec-version": "development",
 		"key": "%s",
 		"components": [
 		  {
@@ -446,6 +448,7 @@ func Test_FailureOutput(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, fmt.Sprintf(`{
 		"success": false,
+		"ec-version": "development",
 		"key": "%s",
 		"components": [
 		  {
@@ -508,6 +511,7 @@ func Test_WarningOutput(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, fmt.Sprintf(`{
 		"success": true,
+		"ec-version": "development",
 		"key": "%s",
 		"components": [
 		  {

--- a/features/validate_definition.feature
+++ b/features/validate_definition.feature
@@ -26,5 +26,5 @@ Feature: validate pipeline definition
     Then the exit status should be 0
     Then the standard output should contain
     """
-    {"definitions": [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"success":true}],"success":true}
+    {"definitions": [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"success":true}],"success":true,"ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+"}
     """

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -34,6 +34,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -88,6 +89,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${unknown_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -125,6 +127,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -167,6 +170,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -209,6 +213,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -265,6 +270,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -349,6 +355,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -462,6 +469,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -518,6 +526,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -607,7 +616,8 @@ Feature: evaluate enterprise contract
         ]
       },
       "key": ${known_PUBLIC_KEY_JSON},
-      "success": false
+      "success": false,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+"
     }
     """
 
@@ -642,6 +652,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -708,6 +719,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -762,6 +774,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {
@@ -824,6 +837,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "snapshot": "acceptance/happy",
       "components": [
@@ -906,6 +920,7 @@ Feature: evaluate enterprise contract
     """
     {
       "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
       "key": ${known_PUBLIC_KEY_JSON},
       "components": [
         {

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -31,6 +31,7 @@ import (
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
+	"github.com/enterprise-contract/ec-cli/internal/version"
 )
 
 type Component struct {
@@ -49,6 +50,7 @@ type Report struct {
 	Components []Component                      `json:"components"`
 	Key        string                           `json:"key"`
 	Policy     ecc.EnterpriseContractPolicySpec `json:"policy"`
+	EcVersion  string                           `json:"ec-version"`
 }
 
 type summary struct {
@@ -109,6 +111,8 @@ func NewReport(snapshot string, components []Component, policy policy.Policy) (R
 		return Report{}, err
 	}
 
+	info, _ := version.ComputeInfo()
+
 	return Report{
 		Snapshot:   snapshot,
 		Success:    success,
@@ -116,6 +120,7 @@ func NewReport(snapshot string, components []Component, policy policy.Policy) (R
 		created:    time.Now().UTC(),
 		Key:        string(key),
 		Policy:     policy.Spec(),
+		EcVersion:  info.Version,
 	}, nil
 }
 

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -48,6 +48,7 @@ func Test_ReportJson(t *testing.T) {
 	expected := fmt.Sprintf(`
     {
       "success": false,
+	  "ec-version": "development",
 	  "key": "%s",
 	  "snapshot": "snappy",
       "components": [
@@ -97,6 +98,7 @@ func Test_ReportYaml(t *testing.T) {
 	expected := fmt.Sprintf(`
 success: false
 key: "%s"
+ec-version: development
 snapshot: snappy
 components:
   - name: spam

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/output"
+	"github.com/enterprise-contract/ec-cli/internal/version"
 )
 
 type ReportItem struct {
@@ -44,11 +45,14 @@ const (
 type Report struct {
 	Definitions []ReportItem `json:"definitions"`
 	Success     bool         `json:"success"`
+	EcVersion   string       `json:"ec-version"`
 }
 
 func NewReport() Report {
+	info, _ := version.ComputeInfo()
 	return Report{
-		Success: true,
+		Success:   true,
+		EcVersion: info.Version,
 	}
 }
 

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -46,6 +46,7 @@ func TestReport(t *testing.T) {
 				"warnings": [],
 				"success": true,
 			}],
+			"ec-version": "development",
 			"success": true
 			}`,
 		},
@@ -72,6 +73,7 @@ func TestReport(t *testing.T) {
 				"warnings": [{"msg": "running low in spam"},{"msg": "not all like spam"}],
 				"success": true,
 			}],
+			"ec-version": "development",
 			"success": true
 			}`,
 		},
@@ -98,6 +100,7 @@ func TestReport(t *testing.T) {
 				"warnings": [],
 				"success": false,
 			}],
+			"ec-version": "development",
 			"success": false
 			}`,
 		},

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,109 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	dbg "runtime/debug"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hako/durafmt"
+)
+
+// Version of the `ec` CLI, set at build time to git id
+var Version = "development"
+
+var readBuildInfo = dbg.ReadBuildInfo
+
+type ComponentInfo struct {
+	Name    string
+	Version string
+}
+
+type VersionInfo struct {
+	Version    string
+	Commit     string
+	ChangedOn  time.Time
+	Components []ComponentInfo
+}
+
+func (v VersionInfo) String() string {
+	var buffy bytes.Buffer
+	w := tabwriter.NewWriter(&buffy, 10, 1, 2, ' ', 0)
+	fmt.Fprintf(w, "Version\t%s\n", v.Version)
+	fmt.Fprintf(w, "Source ID\t%s\n", v.Commit)
+	fmt.Fprintf(w, "Change date\t%s (%s ago)\n", v.ChangedOn, durafmt.ParseShort(time.Since(v.ChangedOn)))
+
+	for _, c := range v.Components {
+		fmt.Fprintf(w, "%s\t%s\n", c.Name, c.Version)
+	}
+	w.Flush()
+
+	return buffy.String()
+}
+
+func ComputeInfo() (*VersionInfo, error) {
+	buildInfo, ok := readBuildInfo()
+	if !ok {
+		return nil, errors.New("no build info available")
+	}
+
+	info := VersionInfo{}
+	info.Version = Version
+
+	for _, s := range buildInfo.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			info.Commit = s.Value
+		case "vcs.time":
+			var err error
+			if info.ChangedOn, err = time.Parse(time.RFC3339, s.Value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	info.Components = append(info.Components, dependencyVersion("ECC", "github.com/enterprise-contract/enterprise-contract-controller/api", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("OPA", "github.com/open-policy-agent/opa", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Conftest", "github.com/open-policy-agent/conftest", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Red Hat AppStudio (API)", "github.com/redhat-appstudio/application-api", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Cosign", "github.com/sigstore/cosign", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Sigstore", "github.com/sigstore/sigstore", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Rekor", "github.com/sigstore/rekor", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Tekton Pipeline", "github.com/tektoncd/pipeline", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Kubernetes Client", "k8s.io/api", buildInfo.Deps))
+
+	return &info, nil
+}
+
+func dependencyVersion(name string, path string, dependencies []*dbg.Module) ComponentInfo {
+	ci := ComponentInfo{
+		Name:    name,
+		Version: "N/A",
+	}
+	for _, d := range dependencies {
+		if d.Path == path {
+			ci.Version = d.Version
+			break
+		}
+	}
+
+	return ci
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -73,7 +73,7 @@ func TestComputeInfo(t *testing.T) {
 	Version = "v1"
 	t.Cleanup(func() { readBuildInfo = dbg.ReadBuildInfo; Version = "" })
 
-	vi, err := computeInfo()
+	vi, err := ComputeInfo()
 	assert.NoError(t, err)
 	assert.Equal(t, &VersionInfo{
 		Version:   "v1",


### PR DESCRIPTION
This commit addresses HACBS-2018 and adds the same output as executing `ec version --short` in the report output for `ec validate image` and `ec validate definition`.