### PR TITLE
Task should not fail on warnings in strict mode

### DIFF
--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -150,5 +150,5 @@ spec:
         - "$(params.STRICT)"
         - "-e"
         - >
-          .result == "SUCCESS" or ($strict | not)
+          .result == "SUCCESS" or .result == "WARNING" or ($strict | not)
         - "$(results.HACBS_TEST_OUTPUT.path)"


### PR DESCRIPTION
The new jq test from #572 fails the task when running with the strict param set, unless the result is "SUCCESS", which means that a result of "WARNING" is now failing unexpectedly. Noticed by @shebert.