### PR TITLE
Extract solution annotation & include in report

### DIFF
--- a/acceptance/examples/happy_day.rego
+++ b/acceptance/examples/happy_day.rego
@@ -7,6 +7,7 @@ package main
 # custom:
 #   short_name: acceptor
 #   failure_msg: Always succeeds
+#   solution: Easy
 #   collections:
 #   - A
 deny[result] {

--- a/acceptance/examples/reject.rego
+++ b/acceptance/examples/reject.rego
@@ -7,6 +7,7 @@ package main
 # custom:
 #   short_name: rejector
 #   failure_msg: Fails always
+#   solution: None
 #   collections:
 #   - A
 deny[result] {

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -590,6 +590,7 @@ Feature: evaluate enterprise contract
               "metadata": {
                 "title": "Reject rule",
                 "description": "This rule will always fail",
+                "solution": "None",
                 "code": "main.rejector",
                 "collections": ["A"],
                 "effective_on": "2022-01-01T00:00:00Z"

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -69,6 +69,7 @@ const (
 	metadataCollections = "collections"
 	metadataDescription = "description"
 	metadataEffectiveOn = "effective_on"
+	metadataSolution    = "solution"
 	metadataTerm        = "term"
 	metadataTitle       = "title"
 )
@@ -314,6 +315,9 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) (Check
 			result.Metadata[metadataEffectiveOn] = rule.EffectiveOn
 		}
 
+		// Let's omit the solution text here because if the rule is passing
+		// already then the user probably doesn't care about the solution.
+
 		if !isResultEffective(result, effectiveTime) {
 			log.Debugf("Skipping result success: %#v", result)
 			continue
@@ -383,6 +387,9 @@ func addMetadataToResults(r *output.Result, rule rule.Info) {
 	}
 	if rule.Description != "" {
 		r.Metadata[metadataDescription] = rule.Description
+	}
+	if rule.Solution != "" {
+		r.Metadata[metadataSolution] = rule.Solution
 	}
 	if len(rule.Collections) > 0 {
 		r.Metadata[metadataCollections] = rule.Collections

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -362,6 +362,12 @@ func addRuleMetadata(result *output.Result, rules policyRules) (string, bool) {
 }
 
 func addMetadataToResults(r *output.Result, rule rule.Info) {
+	// Note that r.Metadata already includes some fields that we get from
+	// the real conftest violation and warning results, (as provided by
+	// lib.result_helper in the ec-policies rego). Here we augment it with
+	// other fields from rule.Metadata, which we get by opa-inspecting the
+	// rego source.
+
 	if r.Metadata == nil {
 		return
 	}

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -39,14 +39,22 @@ func description(a *ast.AnnotationsRef) string {
 	return a.Annotations.Description
 }
 
-func effectiveOn(a *ast.AnnotationsRef) string {
+func customAnnotationString(a *ast.AnnotationsRef, fieldName string) string {
 	if a == nil || a.Annotations == nil || a.Annotations.Custom == nil {
 		return ""
 	}
-	if value, ok := a.Annotations.Custom["effective_on"].(string); ok {
+	if value, ok := a.Annotations.Custom[fieldName].(string); ok {
 		return value
 	}
 	return ""
+}
+
+func effectiveOn(a *ast.AnnotationsRef) string {
+	return customAnnotationString(a, "effective_on")
+}
+
+func solution(a *ast.AnnotationsRef) string {
+	return customAnnotationString(a, "solution")
 }
 
 func lastTerm(a *ast.AnnotationsRef) string {
@@ -224,6 +232,7 @@ type Info struct {
 	Description      string
 	DocumentationUrl string
 	EffectiveOn      string
+	Solution         string
 	Kind             RuleKind
 	Package          string
 	ShortName        string
@@ -238,6 +247,7 @@ func RuleInfo(a *ast.AnnotationsRef) Info {
 		Description:      description(a),
 		DocumentationUrl: documentationUrl(a),
 		EffectiveOn:      effectiveOn(a),
+		Solution:         solution(a),
 		Kind:             kind(a),
 		Package:          packageName(a),
 		ShortName:        shortName(a),

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -289,6 +289,33 @@ func TestEffectiveOn(t *testing.T) {
 	}
 }
 
+func TestSolution(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		// I don't want to redo all the edge cases here. I think there's enough
+		// coverage for those code paths already in TestEffectiveOn above.
+		{
+			name: "with solution",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   solution: Chunky bacon
+				deny() { true }`)),
+			expected: "Chunky bacon",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, solution(c.annotation))
+		})
+	}
+}
+
 func TestCollections(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
It shows up if you use the --info flag.

As per the commentary I decided not to include it in the success output. This is demonstrated by the fact that the "Easy" solution in the acceptance test example rego doesn't show up in the output for the always passing test when ec is run with the --info flag.

JIRA: [HACBS-2049](https://issues.redhat.com/browse/HACBS-2049)