### PR TITLE
Include image signature and attestation checks in Successes output

### DIFF
--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -42,6 +42,15 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "successes": [
             {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
+            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -135,6 +144,15 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "successes": [
             {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
+            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -184,6 +202,17 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
+          "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            }
+          ],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -225,6 +254,17 @@ Feature: evaluate enterprise contract
                 "effective_on": "2099-01-01T00:00:00Z"
               },
               "msg": "Fails in 2099"
+            }
+          ],
+          "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
             }
           ],
           "success": false,
@@ -291,6 +331,15 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {
               "msg": "Pass",
               "metadata": {
@@ -376,6 +425,15 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {
               "msg": "Pass",
               "metadata": {
@@ -483,6 +541,17 @@ Feature: evaluate enterprise contract
               "msg": "Failure due to spider attack"
             }
           ],
+          "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            }
+          ],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -538,6 +607,17 @@ Feature: evaluate enterprise contract
                 "effective_on": "2099-01-01T00:00:00Z"
               },
               "msg": "Fails in 2099"
+            }
+          ],
+          "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
             }
           ],
           "success": false,
@@ -598,6 +678,15 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {
               "msg": "Pass",
               "metadata": {
@@ -662,6 +751,15 @@ Feature: evaluate enterprise contract
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {"metadata": {"code": "filtering.always_pass"}, "msg": "Pass"},
             {"metadata": {"code": "filtering.always_pass_with_collection"}, "msg": "Pass"}
           ]
@@ -729,7 +827,21 @@ Feature: evaluate enterprise contract
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
           "successes": [
-            {"metadata": {"code": "filtering.always_pass"}, "msg": "Pass"}
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
+            {
+              "metadata": {
+                "code": "filtering.always_pass"
+              },
+              "msg": "Pass"
+            }
           ]
         }
       ],
@@ -782,6 +894,15 @@ Feature: evaluate enterprise contract
           "name": "Happy",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day@sha256:[0-9a-f]{64}",
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {
               "msg": "Pass",
               "metadata": {
@@ -847,6 +968,15 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day@sha256:[0-9a-f]{64}",
           "successes": [
             {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
+            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -890,7 +1020,7 @@ Feature: evaluate enterprise contract
     Then the exit status should be 1
     Then the standard output should contain
     """
-    <testsuites><testsuite name="Unnamed \(localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}\)" tests="2" errors="0" failures="1" time="0" timestamp="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{1,9}Z" hostname="">(<property name="image" value="localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}"><\/property>|<property name="key" value="-----BEGIN PUBLIC KEY-----[^"]+"><\/property>|<property name="success" value="false"><\/property>|<property name="keyId" value=""><\/property>|<property name="signature" value="[a-zA-Z0-9+\/]+={0,2}"><\/property>|<property name="metadata.predicateType" value="https:\/\/slsa.dev\/provenance\/v0.2"><\/property>|<property name="metadata.type" value="https:\/\/in-toto.io\/Statement\/v0.1"><\/property>|<property name="metadata.predicateBuildType" value="https:\/\/tekton.dev\/attestations\/chains\/pipelinerun@v2"><\/property>)+<testcase name="main.acceptor: Pass" classname="main.acceptor: Pass" time="0"><\/testcase><testcase name="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" classname="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" time="0"><failure message="Fails always" type=""><!\[CDATA\[Fails always\]\]><\/failure><\/testcase><\/testsuite><\/testsuites>
+    <testsuites><testsuite name="Unnamed \(localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}\)" tests="5" errors="0" failures="1" time="0" timestamp="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{1,9}Z" hostname="">(<property name="image" value="localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}"><\/property>|<property name="key" value="-----BEGIN PUBLIC KEY-----[^"]+"><\/property>|<property name="success" value="false"><\/property>|<property name="keyId" value=""><\/property>|<property name="signature" value="[a-zA-Z0-9+\/]+={0,2}"><\/property>|<property name="metadata.predicateType" value="https:\/\/slsa.dev\/provenance\/v0.2"><\/property>|<property name="metadata.type" value="https:\/\/in-toto.io\/Statement\/v0.1"><\/property>|<property name="metadata.predicateBuildType" value="https:\/\/tekton.dev\/attestations\/chains\/pipelinerun@v2"><\/property>)+<testcase name="Image attestation check passed" classname="Image attestation check passed" time="0"><\/testcase><testcase name="Image attestation syntax check passed" classname="Image attestation syntax check passed" time="0"><\/testcase><testcase name="Image signature check passed" classname="Image signature check passed" time="0"><\/testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass" time="0"><\/testcase><testcase name="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" classname="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" time="0"><failure message="Fails always" type=""><!\[CDATA\[Fails always\]\]><\/failure><\/testcase><\/testsuite><\/testsuites>
     """
 
   Scenario: Using OCI bundles
@@ -928,6 +1058,15 @@ Feature: evaluate enterprise contract
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/my-image@sha256:[0-9a-f]{64}",
           "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            },
             {
               "msg": "Pass",
               "metadata": {
@@ -1029,7 +1168,18 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/image@sha256:[0-9a-f]{64}",
           "name": "Unnamed",
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
-          "success": true
+          "success": true,
+          "successes": [
+            {
+              "msg": "Image attestation check passed"
+            },
+            {
+              "msg": "Image attestation syntax check passed"
+            },
+            {
+              "msg": "Image signature check passed"
+            }
+          ]
         }
       ],
       "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -57,6 +57,20 @@ func (v VerificationStatus) addToViolations(violations []output.Result) []output
 	return result
 }
 
+// addToSuccesses appends the success result to the successes slice.
+func (v VerificationStatus) addToSuccesses(successes []output.Result) []output.Result {
+	if !v.Passed {
+		return successes
+	}
+
+	result := successes
+	if v.Result != nil {
+		result = append(successes, *v.Result)
+	}
+
+	return result
+}
+
 type EntitySignature struct {
 	KeyID     string            `json:"keyid"`
 	Signature string            `json:"sig"`
@@ -79,8 +93,10 @@ type Output struct {
 // SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.
 func (o *Output) SetImageAccessibleCheckFromError(err error) {
 	if err == nil {
-		log.Debug("Image access check passed")
+		message := "Image URL is accessible"
+		log.Debug(message)
 		o.ImageAccessibleCheck.Passed = true
+		o.ImageAccessibleCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -93,8 +109,10 @@ func (o *Output) SetImageAccessibleCheckFromError(err error) {
 // SetImageSignatureCheck sets the passed and result.message fields of the ImageSignatureCheck to the given values.
 func (o *Output) SetImageSignatureCheckFromError(err error) {
 	if err == nil {
-		log.Debug("Image signature check passed")
+		message := "Image signature check passed"
+		log.Debug(message)
 		o.ImageSignatureCheck.Passed = true
+		o.ImageSignatureCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -115,8 +133,10 @@ func (o *Output) SetImageSignatureCheckFromError(err error) {
 // SetAttestationSignatureCheck sets the passed and result.message fields of the AttestationSignatureCheck to the given values.
 func (o *Output) SetAttestationSignatureCheckFromError(err error) {
 	if err == nil {
-		log.Debug("Image signature check passed")
+		message := "Image attestation check passed"
+		log.Debug(message)
 		o.AttestationSignatureCheck.Passed = true
+		o.AttestationSignatureCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -137,8 +157,10 @@ func (o *Output) SetAttestationSignatureCheckFromError(err error) {
 // SetAttestationSyntaxCheck sets the passed and result.message fields of the AttestationSyntaxCheck to the given values.
 func (o *Output) SetAttestationSyntaxCheckFromError(err error) {
 	if err == nil {
-		log.Debug("Image attestation syntax check passed")
+		message := "Image attestation syntax check passed"
+		log.Debug(message)
 		o.AttestationSyntaxCheck.Passed = true
+		o.AttestationSyntaxCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -219,6 +241,10 @@ func (o Output) Successes() []output.Result {
 	for _, result := range o.PolicyCheck {
 		successes = append(successes, result.Successes...)
 	}
+
+	successes = o.ImageSignatureCheck.addToSuccesses(successes)
+	successes = o.AttestationSignatureCheck.addToSuccesses(successes)
+	successes = o.AttestationSyntaxCheck.addToSuccesses(successes)
 
 	successes = sortResults(successes)
 	return successes

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -484,6 +484,144 @@ func Test_Violations(t *testing.T) {
 	}
 }
 
+func Test_Successes(t *testing.T) {
+	cases := []struct {
+		name     string
+		output   Output
+		expected []output.Result
+	}{
+		{
+			name: "passing",
+			output: Output{
+				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image signature passed"},
+				},
+				AttestationSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation signature passed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image accessible passed"},
+				},
+				AttestationSyntaxCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation syntax passed"},
+				},
+				PolicyCheck: evaluator.CheckResults{
+					{
+						Successes: []output.Result{
+							{
+								Message: "passed policy check",
+							},
+						},
+					},
+				},
+			},
+			expected: []output.Result{
+				{Message: "attestation signature passed"},
+				{Message: "attestation syntax passed"},
+				{Message: "image signature passed"},
+				{Message: "passed policy check"},
+			},
+		},
+		{
+			name: "failing image signature",
+			output: Output{
+				ImageSignatureCheck: VerificationStatus{
+					Passed: false,
+					Result: &output.Result{Message: "image signature failed"},
+				},
+				AttestationSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation signature passed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image accessible passed"},
+				},
+				AttestationSyntaxCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation syntax passed"},
+				},
+			},
+			expected: []output.Result{
+				{Message: "attestation signature passed"},
+				{Message: "attestation syntax passed"},
+			},
+		},
+		{
+			name: "failing attestation signature",
+			output: Output{
+				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image signature passed"},
+				},
+				AttestationSignatureCheck: VerificationStatus{
+					Passed: false,
+					Result: &output.Result{Message: "attestation signature failed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image accessible passed"},
+				},
+				AttestationSyntaxCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation syntax passed"},
+				},
+			},
+			expected: []output.Result{
+				{Message: "attestation syntax passed"},
+				{Message: "image signature passed"},
+			},
+		},
+		{
+			name: "failing policy check",
+			output: Output{
+				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image signature passed"},
+				},
+				AttestationSignatureCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation signature passed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "image accessible passed"},
+				},
+				AttestationSyntaxCheck: VerificationStatus{
+					Passed: true,
+					Result: &output.Result{Message: "attestation syntax passed"},
+				},
+				PolicyCheck: evaluator.CheckResults{
+					{
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{
+									Message: "failed policy check",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []output.Result{
+				{Message: "attestation signature passed"},
+				{Message: "attestation syntax passed"},
+				{Message: "image signature passed"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, c.output.Successes())
+		})
+	}
+}
+
 func Test_Warnings(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -602,6 +740,9 @@ func TestSetImageAccessibleCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
+			expectedResult: &output.Result{
+				Message: "Image URL is accessible",
+			},
 		},
 		{
 			name:           "failure",
@@ -637,6 +778,9 @@ func TestSetImageSignatureCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
+			expectedResult: &output.Result{
+				Message: "Image signature check passed",
+			},
 		},
 		{
 			name:           "generic failure",
@@ -679,6 +823,9 @@ func TestSetAttestationSignatureCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
+			expectedResult: &output.Result{
+				Message: "Image attestation check passed",
+			},
 		},
 		{
 			name:           "generic failure",
@@ -719,6 +866,9 @@ func TestSetAttestationSyntaxCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
+			expectedResult: &output.Result{
+				Message: "Image attestation syntax check passed",
+			},
 		},
 		{
 			name:           "failure",


### PR DESCRIPTION
Still needs tests added, and I'm not able to see the new successes just from a quick manual test (using `hack/simple-demo.sh`). But this might still be sufficient.