### PR TITLE
Don't deserialize `internal.policy`

### DIFF
--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -529,7 +529,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 				`{"invalid": "json""}`,
 			},
 			expected: `1 error occurred:
-	* unable to parse EnterpriseContractPolicy Spec: error converting YAML to JSON: yaml: found unexpected end of stream
+	* unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream
 
 `,
 		},
@@ -556,7 +556,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 			},
 			expected: `2 errors occurred:
 	* unable to parse Snapshot specification from input: error converting YAML to JSON: yaml: found unexpected end of stream
-	* unable to parse EnterpriseContractPolicy Spec: error converting YAML to JSON: yaml: found unexpected end of stream
+	* unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream
 
 `,
 		},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -186,9 +186,9 @@ func (p *policy) loadPolicy(ctx context.Context, policyRef string) error {
 
 	if strings.Contains(policyRef, ":") { // Should detect JSON or YAML objects 🤞
 		log.Debug("Read EnterpriseContractPolicy as YAML")
-		if err := yaml.Unmarshal([]byte(policyRef), &p); err != nil {
-			log.Debugf("Problem parsing EnterpriseContractPolicy Spec from %q", policyRef)
-			return fmt.Errorf("unable to parse EnterpriseContractPolicy Spec: %w", err)
+		if err := yaml.Unmarshal([]byte(policyRef), &p.EnterpriseContractPolicySpec); err != nil {
+			log.Debugf("Problem parsing EnterpriseContractPolicySpec from %q", policyRef)
+			return fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
 		}
 	} else {
 		log.Debug("Read EnterpriseContractPolicy as k8s resource")


### PR DESCRIPTION
We need to deserialize `EnterpriseContractPolicySpec` instead. Deserializing `internal.policy` could lead to setting internal data, if we ever add JSON annotations, say for debugging.