### PR TITLE
Revert "Image signature & attestation checks in Successes output"

### DIFF
--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -42,15 +42,6 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "successes": [
             {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
-            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -144,15 +135,6 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "successes": [
             {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
-            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -202,17 +184,6 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
-          "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            }
-          ],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -254,17 +225,6 @@ Feature: evaluate enterprise contract
                 "effective_on": "2099-01-01T00:00:00Z"
               },
               "msg": "Fails in 2099"
-            }
-          ],
-          "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
             }
           ],
           "success": false,
@@ -331,15 +291,6 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {
               "msg": "Pass",
               "metadata": {
@@ -425,15 +376,6 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {
               "msg": "Pass",
               "metadata": {
@@ -541,17 +483,6 @@ Feature: evaluate enterprise contract
               "msg": "Failure due to spider attack"
             }
           ],
-          "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            }
-          ],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -607,17 +538,6 @@ Feature: evaluate enterprise contract
                 "effective_on": "2099-01-01T00:00:00Z"
               },
               "msg": "Fails in 2099"
-            }
-          ],
-          "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
             }
           ],
           "success": false,
@@ -678,15 +598,6 @@ Feature: evaluate enterprise contract
             }
           ],
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {
               "msg": "Pass",
               "metadata": {
@@ -751,15 +662,6 @@ Feature: evaluate enterprise contract
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {"metadata": {"code": "filtering.always_pass"}, "msg": "Pass"},
             {"metadata": {"code": "filtering.always_pass_with_collection"}, "msg": "Pass"}
           ]
@@ -827,21 +729,7 @@ Feature: evaluate enterprise contract
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
-            {
-              "metadata": {
-                "code": "filtering.always_pass"
-              },
-              "msg": "Pass"
-            }
+            {"metadata": {"code": "filtering.always_pass"}, "msg": "Pass"}
           ]
         }
       ],
@@ -894,15 +782,6 @@ Feature: evaluate enterprise contract
           "name": "Happy",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day@sha256:[0-9a-f]{64}",
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {
               "msg": "Pass",
               "metadata": {
@@ -968,15 +847,6 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day@sha256:[0-9a-f]{64}",
           "successes": [
             {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
-            {
               "msg": "Pass",
               "metadata": {
                 "code": "main.acceptor"
@@ -1020,7 +890,7 @@ Feature: evaluate enterprise contract
     Then the exit status should be 1
     Then the standard output should contain
     """
-    <testsuites><testsuite name="Unnamed \(localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}\)" tests="5" errors="0" failures="1" time="0" timestamp="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{1,9}Z" hostname="">(<property name="image" value="localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}"><\/property>|<property name="key" value="-----BEGIN PUBLIC KEY-----[^"]+"><\/property>|<property name="success" value="false"><\/property>|<property name="keyId" value=""><\/property>|<property name="signature" value="[a-zA-Z0-9+\/]+={0,2}"><\/property>|<property name="metadata.predicateType" value="https:\/\/slsa.dev\/provenance\/v0.2"><\/property>|<property name="metadata.type" value="https:\/\/in-toto.io\/Statement\/v0.1"><\/property>|<property name="metadata.predicateBuildType" value="https:\/\/tekton.dev\/attestations\/chains\/pipelinerun@v2"><\/property>)+<testcase name="Image attestation check passed" classname="Image attestation check passed" time="0"><\/testcase><testcase name="Image attestation syntax check passed" classname="Image attestation syntax check passed" time="0"><\/testcase><testcase name="Image signature check passed" classname="Image signature check passed" time="0"><\/testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass" time="0"><\/testcase><testcase name="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" classname="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" time="0"><failure message="Fails always" type=""><!\[CDATA\[Fails always\]\]><\/failure><\/testcase><\/testsuite><\/testsuites>
+    <testsuites><testsuite name="Unnamed \(localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}\)" tests="2" errors="0" failures="1" time="0" timestamp="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{1,9}Z" hostname="">(<property name="image" value="localhost:\d+\/acceptance\/image@sha256:[0-9a-f]{64}"><\/property>|<property name="key" value="-----BEGIN PUBLIC KEY-----[^"]+"><\/property>|<property name="success" value="false"><\/property>|<property name="keyId" value=""><\/property>|<property name="signature" value="[a-zA-Z0-9+\/]+={0,2}"><\/property>|<property name="metadata.predicateType" value="https:\/\/slsa.dev\/provenance\/v0.2"><\/property>|<property name="metadata.type" value="https:\/\/in-toto.io\/Statement\/v0.1"><\/property>|<property name="metadata.predicateBuildType" value="https:\/\/tekton.dev\/attestations\/chains\/pipelinerun@v2"><\/property>)+<testcase name="main.acceptor: Pass" classname="main.acceptor: Pass" time="0"><\/testcase><testcase name="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" classname="main.rejector: Fails always \[effective_on=2022-01-01T00:00:00Z\]" time="0"><failure message="Fails always" type=""><!\[CDATA\[Fails always\]\]><\/failure><\/testcase><\/testsuite><\/testsuites>
     """
 
   Scenario: Using OCI bundles
@@ -1058,15 +928,6 @@ Feature: evaluate enterprise contract
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/my-image@sha256:[0-9a-f]{64}",
           "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            },
             {
               "msg": "Pass",
               "metadata": {
@@ -1168,18 +1029,7 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/image@sha256:[0-9a-f]{64}",
           "name": "Unnamed",
           "signatures": ${ATTESTATION_SIGNATURES_JSON},
-          "success": true,
-          "successes": [
-            {
-              "msg": "Image attestation check passed"
-            },
-            {
-              "msg": "Image attestation syntax check passed"
-            },
-            {
-              "msg": "Image signature check passed"
-            }
-          ]
+          "success": true
         }
       ],
       "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -57,20 +57,6 @@ func (v VerificationStatus) addToViolations(violations []output.Result) []output
 	return result
 }
 
-// addToSuccesses appends the success result to the successes slice.
-func (v VerificationStatus) addToSuccesses(successes []output.Result) []output.Result {
-	if !v.Passed {
-		return successes
-	}
-
-	result := successes
-	if v.Result != nil {
-		result = append(successes, *v.Result)
-	}
-
-	return result
-}
-
 type EntitySignature struct {
 	KeyID     string            `json:"keyid"`
 	Signature string            `json:"sig"`
@@ -93,10 +79,8 @@ type Output struct {
 // SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.
 func (o *Output) SetImageAccessibleCheckFromError(err error) {
 	if err == nil {
-		message := "Image URL is accessible"
-		log.Debug(message)
+		log.Debug("Image access check passed")
 		o.ImageAccessibleCheck.Passed = true
-		o.ImageAccessibleCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -109,10 +93,8 @@ func (o *Output) SetImageAccessibleCheckFromError(err error) {
 // SetImageSignatureCheck sets the passed and result.message fields of the ImageSignatureCheck to the given values.
 func (o *Output) SetImageSignatureCheckFromError(err error) {
 	if err == nil {
-		message := "Image signature check passed"
-		log.Debug(message)
+		log.Debug("Image signature check passed")
 		o.ImageSignatureCheck.Passed = true
-		o.ImageSignatureCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -133,10 +115,8 @@ func (o *Output) SetImageSignatureCheckFromError(err error) {
 // SetAttestationSignatureCheck sets the passed and result.message fields of the AttestationSignatureCheck to the given values.
 func (o *Output) SetAttestationSignatureCheckFromError(err error) {
 	if err == nil {
-		message := "Image attestation check passed"
-		log.Debug(message)
+		log.Debug("Image signature check passed")
 		o.AttestationSignatureCheck.Passed = true
-		o.AttestationSignatureCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -157,10 +137,8 @@ func (o *Output) SetAttestationSignatureCheckFromError(err error) {
 // SetAttestationSyntaxCheck sets the passed and result.message fields of the AttestationSyntaxCheck to the given values.
 func (o *Output) SetAttestationSyntaxCheckFromError(err error) {
 	if err == nil {
-		message := "Image attestation syntax check passed"
-		log.Debug(message)
+		log.Debug("Image attestation syntax check passed")
 		o.AttestationSyntaxCheck.Passed = true
-		o.AttestationSyntaxCheck.Result = &output.Result{Message: message}
 		return
 	}
 
@@ -241,10 +219,6 @@ func (o Output) Successes() []output.Result {
 	for _, result := range o.PolicyCheck {
 		successes = append(successes, result.Successes...)
 	}
-
-	successes = o.ImageSignatureCheck.addToSuccesses(successes)
-	successes = o.AttestationSignatureCheck.addToSuccesses(successes)
-	successes = o.AttestationSyntaxCheck.addToSuccesses(successes)
 
 	successes = sortResults(successes)
 	return successes

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -484,144 +484,6 @@ func Test_Violations(t *testing.T) {
 	}
 }
 
-func Test_Successes(t *testing.T) {
-	cases := []struct {
-		name     string
-		output   Output
-		expected []output.Result
-	}{
-		{
-			name: "passing",
-			output: Output{
-				ImageSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image signature passed"},
-				},
-				AttestationSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation signature passed"},
-				},
-				ImageAccessibleCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image accessible passed"},
-				},
-				AttestationSyntaxCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation syntax passed"},
-				},
-				PolicyCheck: evaluator.CheckResults{
-					{
-						Successes: []output.Result{
-							{
-								Message: "passed policy check",
-							},
-						},
-					},
-				},
-			},
-			expected: []output.Result{
-				{Message: "attestation signature passed"},
-				{Message: "attestation syntax passed"},
-				{Message: "image signature passed"},
-				{Message: "passed policy check"},
-			},
-		},
-		{
-			name: "failing image signature",
-			output: Output{
-				ImageSignatureCheck: VerificationStatus{
-					Passed: false,
-					Result: &output.Result{Message: "image signature failed"},
-				},
-				AttestationSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation signature passed"},
-				},
-				ImageAccessibleCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image accessible passed"},
-				},
-				AttestationSyntaxCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation syntax passed"},
-				},
-			},
-			expected: []output.Result{
-				{Message: "attestation signature passed"},
-				{Message: "attestation syntax passed"},
-			},
-		},
-		{
-			name: "failing attestation signature",
-			output: Output{
-				ImageSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image signature passed"},
-				},
-				AttestationSignatureCheck: VerificationStatus{
-					Passed: false,
-					Result: &output.Result{Message: "attestation signature failed"},
-				},
-				ImageAccessibleCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image accessible passed"},
-				},
-				AttestationSyntaxCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation syntax passed"},
-				},
-			},
-			expected: []output.Result{
-				{Message: "attestation syntax passed"},
-				{Message: "image signature passed"},
-			},
-		},
-		{
-			name: "failing policy check",
-			output: Output{
-				ImageSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image signature passed"},
-				},
-				AttestationSignatureCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation signature passed"},
-				},
-				ImageAccessibleCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "image accessible passed"},
-				},
-				AttestationSyntaxCheck: VerificationStatus{
-					Passed: true,
-					Result: &output.Result{Message: "attestation syntax passed"},
-				},
-				PolicyCheck: evaluator.CheckResults{
-					{
-						CheckResult: output.CheckResult{
-							Failures: []output.Result{
-								{
-									Message: "failed policy check",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: []output.Result{
-				{Message: "attestation signature passed"},
-				{Message: "attestation syntax passed"},
-				{Message: "image signature passed"},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			assert.Equal(t, c.expected, c.output.Successes())
-		})
-	}
-}
-
 func Test_Warnings(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -740,9 +602,6 @@ func TestSetImageAccessibleCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
-			expectedResult: &output.Result{
-				Message: "Image URL is accessible",
-			},
 		},
 		{
 			name:           "failure",
@@ -778,9 +637,6 @@ func TestSetImageSignatureCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
-			expectedResult: &output.Result{
-				Message: "Image signature check passed",
-			},
 		},
 		{
 			name:           "generic failure",
@@ -823,9 +679,6 @@ func TestSetAttestationSignatureCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
-			expectedResult: &output.Result{
-				Message: "Image attestation check passed",
-			},
 		},
 		{
 			name:           "generic failure",
@@ -866,9 +719,6 @@ func TestSetAttestationSyntaxCheckFromError(t *testing.T) {
 		{
 			name:           "success",
 			expectedPassed: true,
-			expectedResult: &output.Result{
-				Message: "Image attestation syntax check passed",
-			},
 		},
 		{
 			name:           "failure",


### PR DESCRIPTION
The lack of metadata.title and probably also metadata.description in
the result output is breaking the security tab UI.

The revert is intended to get that unbroken quickly. Once the patch
for HACBS-2106 is done, this can be un-reverted.

The change being reverted is from HACBS-2057.

This reverts commit e47b6024fa3cb89f0e437ccd630b6e9bfca2c53a.
