### PR TITLE
Tweak debug/trace logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var RootCmd = &cobra.Command{
 	SilenceUsage: true,
 
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		logging.InitLogging(verbose, quiet, debug)
+		logging.InitLogging(verbose, quiet, debug, trace)
 
 		// Create a new context now that flags have been parsed so a custom timeout can be used.
 		ctx := cmd.Context()
@@ -67,12 +67,14 @@ var RootCmd = &cobra.Command{
 var quiet bool = false
 var verbose bool = false
 var debug bool = false
+var trace bool = false
 var globalTimeout = 5 * time.Minute
 
 func init() {
 	RootCmd.PersistentFlags().BoolVar(&quiet, "quiet", quiet, "less verbose output")
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", verbose, "more verbose output")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", debug, "same as verbose but also show function names and line numbers")
+	RootCmd.PersistentFlags().BoolVar(&trace, "trace", trace, "enable trace logging")
 	RootCmd.PersistentFlags().DurationVar(&globalTimeout, "timeout", globalTimeout, "max overall execution duration")
 	kubernetes.AddKubeconfigFlag(RootCmd)
 }


### PR DESCRIPTION
Introduces a `--trace` logging option that will log from Kubernetes Client with level 9 (all messages) and lowers the logging level for `--debug` and `--verbose` to 6 (basic debugging). Also modifies the Kubernetes Client initiated logging messages so they're logged with their configured level, which leads to having `debug` instead of `info` showing up in the logs.

Example of the trace log:

```
time="2023-04-24T11:48:11+02:00" level=debug msg="Generating application snapshot from image reference quay.io/hacbs-contract-demo/single-nodejs-app:abcbdfd92a75f7bba3ab97538b1324bf4677c1fb3eb82ca59cbd8970b3759b7e" func=DetermineInputSpec file=" input.go:121"
time="2023-04-24T11:48:11+02:00" level=debug msg="Read EnterpriseContractPolicy as k8s resource" func=loadPolicy file=" policy.go:214"
time="2023-04-24T11:48:11+02:00" level=debug msg="Config loaded from file:  /home/zregvart/.kube/config\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="Initialized Kubernetes client" func=loadPolicy file=" policy.go:220"
time="2023-04-24T11:48:11+02:00" level=debug msg="Raw policy reference: \"demo/ec-demo\"" func=FetchEnterpriseContractPolicy file=" client.go:104"
time="2023-04-24T11:48:11+02:00" level=debug msg="Parsed policy reference: demo/ec-demo" func=FetchEnterpriseContractPolicy file=" client.go:110"
time="2023-04-24T11:48:11+02:00" level=debug msg="curl -v -XGET  -H \"Accept: application/json\" -H \"User-Agent: __debug_bin/v0.0.0 (linux/amd64) kubernetes/$Format\" 'https://127.0.0.1:39321/apis/appstudio.redhat.com/v1alpha1/namespaces/demo/enterprisecontractpolicies/ec-demo'\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="HTTP Trace: Dial to tcp:127.0.0.1:39321 succeed\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="GET https://127.0.0.1:39321/apis/appstudio.redhat.com/v1alpha1/namespaces/demo/enterprisecontractpolicies/ec-demo 404 Not Found in 6 milliseconds\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="HTTP Statistics: DNSLookup 0 ms Dial 0 ms TLSHandshake 5 ms ServerProcessing 1 ms Duration 6 ms\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="Response Headers:\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="    X-Kubernetes-Pf-Prioritylevel-Uid: b7bde433-ab52-4e2a-8310-7a541d9f4688\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="    Content-Length: 278\n" func=Info file=" logging.go:157"
time="2023-04-24T11:48:11+02:00" level=debug msg="    Date: Mon, 24 Apr 2023 09:48:11 GMT\n" func=Info file=" logging.go:157"
```

Modified debug log:

```
time="2023-04-24T11:54:05+02:00" level=debug msg="Generating application snapshot from image reference quay.io/hacbs-contract-demo/single-nodejs-app:abcbdfd92a75f7bba3ab97538b1324bf4677c1fb3eb82ca59cbd8970b3759b7e" func=DetermineInputSpec file=" input.go:121"
time="2023-04-24T11:54:05+02:00" level=debug msg="Read EnterpriseContractPolicy as k8s resource" func=loadPolicy file=" policy.go:214"
time="2023-04-24T11:54:05+02:00" level=debug msg="Config loaded from file:  /home/zregvart/.kube/config\n" func=Info file=" logging.go:157"
time="2023-04-24T11:54:05+02:00" level=debug msg="Initialized Kubernetes client" func=loadPolicy file=" policy.go:220"
time="2023-04-24T11:54:05+02:00" level=debug msg="Raw policy reference: \"demo/ec-demo\"" func=FetchEnterpriseContractPolicy file=" client.go:104"
time="2023-04-24T11:54:05+02:00" level=debug msg="Parsed policy reference: demo/ec-demo" func=FetchEnterpriseContractPolicy file=" client.go:110"
time="2023-04-24T11:54:05+02:00" level=debug msg="GET https://127.0.0.1:39321/apis/appstudio.redhat.com/v1alpha1/namespaces/demo/enterprisecontractpolicies/ec-demo 404 Not Found in 10 milliseconds\n" func=Info file=" logging.go:157"
time="2023-04-24T11:54:05+02:00" level=debug msg="Failed to fetch the policy from cluster: enterprisecontractpolicies.appstudio.redhat.com \"ec-demo\" not found" func=FetchEnterpriseContractPolicy file=" client.go:117"
time="2023-04-24T11:54:05+02:00" level=debug msg="Failed to fetch the enterprise contract policy from the cluster!" func=loadPolicy file=" policy.go:224"
Error: 1 error occurred:
	* unable to fetch EnterpriseContractPolicy: enterprisecontractpolicies.appstudio.redhat.com "ec-demo" not found
```

Ref. https://issues.redhat.com/browse/HACBS-2090