### PR TITLE
Send summary output to both old & new task results

### DIFF
--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -213,6 +213,8 @@ func condensedMsg(results []conftestOutput.Result) map[string][]string {
 
 // toHACBS returns a version of the report that conforms to the
 // HACBS_TEST_OUTPUT format.
+// (Note: the name of the Tekton task result where this generally
+// gets written is now TEST_OUTPUT instead of HACBS_TEST_OUTPUT)
 func (r *Report) toHACBS() hacbsReport {
 	result := hacbsReport{Timestamp: r.created.UTC().Unix()}
 

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -96,6 +96,9 @@ spec:
 
   results:
     - name: HACBS_TEST_OUTPUT
+      description: Short summary of the policy evaluation for each image (Deprecated)
+
+    - name: TEST_OUTPUT
       description: Short summary of the policy evaluation for each image
 
   stepTemplate:
@@ -130,6 +133,10 @@ spec:
         - "--effective-time=$(params.EFFECTIVE_TIME)"
         - "--output"
         - "yaml=$(params.HOMEDIR)/report.yaml"
+        # Write to both the new and the old deprecated result
+        # HACBS_TEST_OUTPUT will be removed in the future
+        - "--output"
+        - "hacbs=$(results.TEST_OUTPUT.path)"
         - "--output"
         - "hacbs=$(results.HACBS_TEST_OUTPUT.path)"
       env:
@@ -152,7 +159,7 @@ spec:
       command: [jq]
       args:
         - "."
-        - "$(results.HACBS_TEST_OUTPUT.path)"
+        - "$(results.TEST_OUTPUT.path)"
     - name: assert
       image: quay.io/hacbs-contract/ec-cli:snapshot
       command: [jq]


### PR DESCRIPTION
I'm not sure what consumes this, but to be conservative let's write both result fields for a while. The plan is to transition to TEST_OUTPUT and eventually remove the deprecated HACBS_TEST_OUTPUT field.

Note: I didn't change anything in
pkg/schema/examples/hacbs2_valid.json in this commit. I don't think it will matter, but we might do that later I guess.

JIRA: [HACBS-2160](https://issues.redhat.com/browse/HACBS-1595)