### PR TITLE
Enables TUF in development environment

### DIFF
--- a/hack/cosign-sign-blob-fulcio.sh
+++ b/hack/cosign-sign-blob-fulcio.sh
@@ -22,55 +22,79 @@ set -o errexit
 set -o pipefail
 set -o nounset
 set -o errtrace
+# Enable debugging
+# set -o xtrace
 
 if (( $# != 1 )); then
     echo "usage $0 <file to sign>"
     exit 1
 fi
 
+# Setup for the Cosign image from Sigstore
+IMAGE=gcr.io/projectsigstore/cosign
+SIGSTORE_CONF=/home/nonroot/.sigstore
+
+# For custom container this might look like
+# IMAGE=quay.io/zregvart_redhat/cosign-debug
+# SIGSTORE_CONF=/root/.sigstore
+
 LOGS="$(mktemp --tmpdir)"
 SIGNATURE="$(mktemp --tmpdir)"
 CERTIFICATE="$(mktemp --tmpdir)"
 TLOG_ENTRY="$(mktemp --tmpdir)"
 cleanup() {
+    [ -o xtrace ] && echo -e "📜 \033[1mCosign logs\033[0m" && kubectl logs sign-blob --all-containers
+
     rm -f "${LOGS}" "${SIGNATURE}" "${CERTIFICATE}" "${TLOG_ENTRY}"
+    kubectl delete pod sign-blob > /dev/null 2>&1 || true
 }
 trap cleanup exit
 
-kubectl get secret ctlog-public-key > /dev/null 2>&1 || kubectl -n ctlog-system get secret ctlog-public-key -o yaml | yq ".metadata.namespace |= \"$(kubectl get sa -o=jsonpath='{.items[0]..metadata.namespace}')\"" | kubectl apply -f -
-
 kubectl run sign-blob \
     --quiet \
-    --rm \
     --stdin \
     --attach \
-    --image=gcr.io/projectsigstore/cosign \
+    --image="${IMAGE}" \
     --env=SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-    --env=SIGSTORE_CT_LOG_PUBLIC_KEY_FILE=/ctlog/public \
     --override-type=strategic \
     --overrides='{
         "apiVersion": "v1",
         "spec": {
+            "initContainers": [
+                {
+                    "name": "cosign-initialize",
+                    "image": "'"${IMAGE}"'",
+                    "command": [
+                        "cosign",
+                        "initialize",
+                        "--mirror",
+                        "http://tuf-server.tuf-system.svc.cluster.local",
+                        "--root",
+                        "http://tuf-server.tuf-system.svc.cluster.local/root.json"
+                    ],
+                    "volumeMounts": [
+                        {
+                            "name": "sigstore",
+                            "mountPath": "'"${SIGSTORE_CONF}"'"
+                        }
+                    ]
+                }
+            ],
             "containers":[
                 {
                     "name": "sign-blob",
                     "volumeMounts": [
                         {
-                            "name": "ctlog-public-key",
-                            "mountPath": "/ctlog",
-                            "secretName": "ctlog-public-key"
+                            "name": "sigstore",
+                            "mountPath": "'"${SIGSTORE_CONF}"'"
                         }
                     ]
                 }
             ],
             "volumes": [
                 {
-                    "secret": {
-                        "defaultMode": 420,
-                        "name": "ctlog-public-key",
-                        "secretName": "ctlog-public-key"
-                    },
-                    "name": "ctlog-public-key"
+                    "name": "sigstore",
+                    "emptyDir": {}
                 }
             ]
         }
@@ -78,27 +102,22 @@ kubectl run sign-blob \
     -- \
     sign-blob \
     --oidc-issuer https://kubernetes.default.svc.cluster.local \
-    --fulcio-url=http://fulcio-server.fulcio-system.svc.cluster.local \
+    --fulcio-url http://fulcio-server.fulcio-system.svc.cluster.local \
     --identity-token /var/run/secrets/kubernetes.io/serviceaccount/token \
     --rekor-url http://rekor-server.rekor-system.svc.cluster.local \
     --yes \
     --output-file=/dev/fd/1 \
     /dev/fd/0 < "$1" 2> "${LOGS}" > "${SIGNATURE}"
 
-sed -n "/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p" "${LOGS}" > "${CERTIFICATE}"
-
-rekor-cli get --rekor_server http://rekor.localhost --log-index "$(sed -r -n -e 's/tlog entry created with index: ([0-9]+)/\1/p' "${LOGS}")" > "${TLOG_ENTRY}"
-
-echo -e "📜 \033[1mCosign logs\033[0m"
-cat "${LOGS}"
-
 echo -e "🎗️ \033[1mCertificate\033[0m"
+sed -n "/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p" "${LOGS}" > "${CERTIFICATE}"
 cat "${CERTIFICATE}"
 
 echo -e "📝 \033[1mSignature\033[0m"
 cat "${SIGNATURE}"
 
 echo -e "🪵 \033[1mSignature tlog entry\033[0m"
+rekor-cli get --rekor_server http://rekor.localhost --log-index "$(sed -r -n -e 's/tlog entry created with index: ([0-9]+)/\1/p' "${LOGS}")" > "${TLOG_ENTRY}"
 cat "${TLOG_ENTRY}"
 
 echo -e "🔍 \033[1mVerifying signature\033[0m"

--- a/hack/sigstore/kustomization.yaml
+++ b/hack/sigstore/kustomization.yaml
@@ -25,6 +25,7 @@ helmCharts:
   - name: scaffold
     repo: https://sigstore.github.io/helm-charts
     releaseName: sigstore
+    valuesFile: values.yaml
 
 patches:
   - patch: |-
@@ -110,3 +111,11 @@ patches:
       kind: Job
       name: fulcio-createcerts
       namespace: fulcio-system
+  - patch: |-
+      - op: replace
+        path: /metadata/labels
+        value:
+          app.kubernetes.io/instance: tuf-sigstore
+    target:
+      kind: Deployment
+      namespace: tuf-system

--- a/hack/sigstore/values.yaml
+++ b/hack/sigstore/values.yaml
@@ -1,0 +1,19 @@
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+tuf:
+  enabled: true


### PR DESCRIPTION
The TUF HTTP service is available at `http://tuf-server.tuf-system.svc.cluster.local` in-cluster and at `http://tuf.localhost` on the local machine.

The `hack/cosign-sign-blob-fulcio.sh` was modified to perform `cosign initialize` before running `cosign sign-blob` to take advantage of TUF.

Also includes:

[Run cosign locally](https://github.com/enterprise-contract/ec-cli/commit/1bb4c0d3442d9043927a90962b94be00f0d3ed0c)

With TUF, we can now run cosign outside of the cluster, given proper `cosign initialize`.