### PR TITLE
TODO: revert when Tekton Chains bug is fixed

### DIFF
--- a/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
+++ b/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
@@ -730,21 +730,11 @@
 
 [TestPredicateMaterialsUri/case_1 - 1]
 []jsonschema.KeyError{
-    {
-        PropertyPath: "/predicate/materials/0/uri",
-        InvalidValue: "",
-        Message:      "invalid uri: uri missing scheme prefix",
-    },
 }
 ---
 
 [TestPredicateMaterialsUri/case_2 - 1]
 []jsonschema.KeyError{
-    {
-        PropertyPath: "/predicate/materials/0/uri",
-        InvalidValue: "not_uri",
-        Message:      "invalid uri: uri missing scheme prefix",
-    },
 }
 ---
 

--- a/pkg/schema/slsa_provenance_v0.2.json
+++ b/pkg/schema/slsa_provenance_v0.2.json
@@ -155,8 +155,7 @@
             "type": "object",
             "properties": {
               "uri": {
-                "type": "string",
-                "format": "uri"
+                "type": "string"
               },
               "digest": {
                 "$ref": "#/$defs/DigestSet"


### PR DESCRIPTION
Allows `predicate.materials.uri` not to be in URI syntax.

Ref. https://github.com/tektoncd/chains/pull/792
Ref. https://issues.redhat.com/browse/HACBS-2115