### PR TITLE
fix: change test output timestamp to string

### DIFF
--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -76,7 +76,7 @@ type componentSummary struct {
 // it is always an empty string from the ec-cli as a way to indicate all
 // namespaces were used.
 type hacbsReport struct {
-	Timestamp int64  `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
 	Namespace string `json:"namespace"`
 	Successes int    `json:"successes"`
 	Failures  int    `json:"failures"`
@@ -216,7 +216,7 @@ func condensedMsg(results []conftestOutput.Result) map[string][]string {
 // (Note: the name of the Tekton task result where this generally
 // gets written is now TEST_OUTPUT instead of HACBS_TEST_OUTPUT)
 func (r *Report) toHACBS() hacbsReport {
-	result := hacbsReport{Timestamp: r.created.UTC().Unix()}
+	result := hacbsReport{Timestamp: fmt.Sprint(r.created.UTC().Unix())}
 
 	hasFailures := false
 	for _, component := range r.Components {

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -393,7 +393,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "SUCCESS",
 				"successes": 3,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 0
 			}`,
 			components: []Component{{Success: true}, {Success: true}, {Success: true}},
@@ -407,7 +407,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "WARNING",
 				"successes": 2,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 1
 			}`,
 			components: []Component{
@@ -424,7 +424,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "FAILURE",
 				"successes": 1,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 0
 			}`,
 			components: []Component{
@@ -441,7 +441,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "FAILURE",
 				"successes": 1,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 0
 			}`,
 			components: []Component{{Success: false}, {Success: true}},
@@ -455,7 +455,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "FAILURE",
 				"successes": 1,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 1
 			}`,
 			components: []Component{
@@ -473,7 +473,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "SKIPPED",
 				"successes": 0,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 0
 			}`,
 			components: []Component{},
@@ -487,7 +487,7 @@ func Test_ReportHACBS(t *testing.T) {
 				"namespace": "",
 				"result": "SUCCESS",
 				"successes": 3,
-				"timestamp": 0,
+				"timestamp": "0",
 				"warnings": 0
 			}`,
 			snapshot:   "snappy",


### PR DESCRIPTION
Address the issue with [schema](https://redhat-appstudio.github.io/book/ADR/0013-integration-service-api-contracts.html#tekton-result-schema-validation) mismatch for the timestamp in TEST_OUTPUT format.