### PR TITLE
Ensure dist dir exists in make reference docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ build: dist/ec_$(shell go env GOOS)_$(shell go env GOARCH) ## Build the ec binar
 
 .PHONY: reference-docs
 reference-docs: ## Generate reference documentation input YAML files
+	@mkdir -p dist
 	@rm -rf dist/cli-reference
 	@go run internal/documentation/documentation.go -yaml dist/cli-reference
 


### PR DESCRIPTION
This fixes a error when running the antora build via `make preview` in the `enterprise-contract.github.io` repo. IIUC it's because the dist directory doesn't exist when `make reference-docs` is run. Should be low risk, so I'm going to insta-merge.