### PR TITLE
Add one more canned policy for slsa3

### DIFF
--- a/configs/default/policy.yaml
+++ b/configs/default/policy.yaml
@@ -1,6 +1,6 @@
 #
 # To use this configuration:
-#   ec validate image ... --policy github.com/enterprise-contract//configs/default
+#   ec validate image ... --policy github.com/enterprise-contract/ec-cli//configs/default
 #
 description: >
   Use the policy rules from the "minimal" collection. This and other collections are defined in

--- a/configs/everything/policy.yaml
+++ b/configs/everything/policy.yaml
@@ -1,6 +1,6 @@
 #
 # To use this configuration:
-#   ec validate image ... --policy github.com/enterprise-contract//configs/everything
+#   ec validate image ... --policy github.com/enterprise-contract/ec-cli//configs/everything
 #
 description: >
   Identical to the default configuration, but use every rule instead of just the rules

--- a/configs/slsa3/policy.yaml
+++ b/configs/slsa3/policy.yaml
@@ -1,0 +1,28 @@
+#
+# To use this configuration:
+#   ec validate image ... --policy github.com/enterprise-contract//configs/slsa3
+#
+description: >
+  Use the policy rules from the "minimal" collection, plus the rules associated with level one,
+  two and three of the SLSA v0.1 specification. The minimal and slsa collections are defined in
+  https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
+
+publicKey: "k8s://tekton-chains/public-key"
+
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/release
+    data:
+      - github.com/enterprise-contract/ec-policies//data
+
+configuration:
+  include:
+    - "@minimal"
+    - "@slsa1"
+    - "@slsa2"
+    - "@slsa3"
+  exclude:
+    # This can be removed once https://issues.redhat.com/browse/OCPBUGS-8428 is addressed
+    - step_image_registries

--- a/configs/slsa3/policy.yaml
+++ b/configs/slsa3/policy.yaml
@@ -1,6 +1,6 @@
 #
 # To use this configuration:
-#   ec validate image ... --policy github.com/enterprise-contract//configs/slsa3
+#   ec validate image ... --policy github.com/enterprise-contract/ec-cli//configs/slsa3
 #
 description: >
   Use the policy rules from the "minimal" collection, plus the rules associated with level one,


### PR DESCRIPTION
This adds a third policy yaml file alongside "default" and "everything" which were added in #651.