### PR TITLE
Rule dependencies

### DIFF
--- a/acceptance/examples/rules_with_dependencies.rego
+++ b/acceptance/examples/rules_with_dependencies.rego
@@ -1,0 +1,64 @@
+package pkg
+
+import future.keywords.contains
+import future.keywords.if
+
+# METADATA
+# custom:
+#   short_name: fails
+deny contains result if {
+	result := {
+		"code": "pkg.fails",
+		"msg": "Failure",
+	}
+}
+
+# METADATA
+# custom:
+#   short_name: warns
+warn contains result if {
+	result := {
+		"code": "pkg.warns",
+		"msg": "Warning",
+	}
+}
+
+# METADATA
+# custom:
+#   short_name: deny_depends_on_failure_succeeds
+#   depends_on: pkg.fails
+deny contains result if {
+	false
+	result := "Should not be reported (does not fail)"
+}
+
+# METADATA
+# custom:
+#   short_name: warn_depends_on_warning_succeeds
+#   depends_on: pkg.warns
+warn contains result if {
+	false
+	result := "Should not be reported (does not fail)"
+}
+
+# METADATA
+# custom:
+#   short_name: deny_depends_on_warning_fails
+#   depends_on: pkg.warns
+deny contains result if {
+	result := {
+		"code": "pkg.deny_depends_on_warning_fails",
+		"msg": "Should not be reported",
+	}
+}
+
+# METADATA
+# custom:
+#   short_name: warn_depends_on_failure_fails
+#   depends_on: pkg.fails
+warn contains result if {
+	result := {
+		"code": "pkg.warn_depends_on_failure_fails",
+		"msg": "Should not be reported",
+	}
+}

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -228,3 +228,12 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:29: rego_type_error: undefi
 [happy day:stderr - 1]
 
 ---
+
+[rule dependencies:stdout - 1]
+{"success":false,"components":[{"name":"Unnamed","containerImage":"${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}","violations":[{"msg":"Failure","metadata":{"code":"pkg.fails"}}],"warnings":[{"msg":"Warning","metadata":{"code":"pkg.warns"}}],"successes":[{"msg":"Pass","metadata":{"code":"builtin.attestation.signature_check"}},{"msg":"Pass","metadata":{"code":"builtin.attestation.syntax_check"}},{"msg":"Pass","metadata":{"code":"builtin.image.signature_check"}}],"success":false,"signatures":${ATTESTATION_SIGNATURES_JSON}}],"key":${known_PUBLIC_KEY_JSON},"policy":{"sources":[{"policy":["git::https://${GITHOST}/git/with-dependencies.git"]}],"publicKey":"${known_PUBLIC_KEY}"},"ec-version":"${EC_VERSION}"}
+---
+
+[rule dependencies:stderr - 1]
+Error: success criteria not met
+
+---

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1249,7 +1249,6 @@ func TestRuleMetadata(t *testing.T) {
 		name   string
 		result output.Result
 		rules  policyRules
-		code   string
 		want   output.Result
 	}{
 		{
@@ -1261,7 +1260,6 @@ func TestRuleMetadata(t *testing.T) {
 				},
 			},
 			rules: rules,
-			code:  "warning1",
 			want: output.Result{
 				Metadata: map[string]any{
 					"code":        "warning1",
@@ -1279,7 +1277,6 @@ func TestRuleMetadata(t *testing.T) {
 				},
 			},
 			rules: rules,
-			code:  "failure2",
 			want: output.Result{
 				Metadata: map[string]any{
 					"code":        "failure2",
@@ -1298,7 +1295,6 @@ func TestRuleMetadata(t *testing.T) {
 				},
 			},
 			rules: rules,
-			code:  "warning2",
 			want: output.Result{
 				Metadata: map[string]any{
 					"code":        "warning2",
@@ -1317,7 +1313,6 @@ func TestRuleMetadata(t *testing.T) {
 				},
 			},
 			rules: rules,
-			code:  "warning3",
 			want: output.Result{
 				Metadata: map[string]any{
 					"code":         "warning3",
@@ -1336,7 +1331,6 @@ func TestRuleMetadata(t *testing.T) {
 				},
 			},
 			rules: rules,
-			code:  "",
 			want: output.Result{
 				Metadata: map[string]any{
 					"collections": []any{"A"},
@@ -1346,8 +1340,7 @@ func TestRuleMetadata(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			rule, _ := addRuleMetadata(ctx, &tt.result, tt.rules)
-			assert.Equal(t, rule, tt.code)
+			addRuleMetadata(ctx, &tt.result, tt.rules)
 			assert.Equal(t, tt.result, tt.want)
 		})
 	}

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/util/sets"
 
 	"github.com/enterprise-contract/ec-cli/internal/downloader"
@@ -1195,6 +1196,7 @@ func TestCollectAnnotationData(t *testing.T) {
 		#   short_name: short
 		#   collections: [A, B, C]
 		#   effective_on: 2022-01-01T00:00:00Z
+		#   depends_on: a.b.c
 		deny[msg] {
 			msg := "hi"
 		}`), ast.ParserOptions{
@@ -1202,13 +1204,14 @@ func TestCollectAnnotationData(t *testing.T) {
 	})
 
 	rules := policyRules{}
-	rules.collect(ast.NewAnnotationsRef(module.Annotations[0]))
+	require.NoError(t, rules.collect(ast.NewAnnotationsRef(module.Annotations[0])))
 
 	assert.Equal(t, policyRules{
 		"a.b.c.short": {
 			Code:        "a.b.c.short",
 			CodePackage: "a.b.c",
 			Collections: []string{"A", "B", "C"},
+			DependsOn:   []string{"a.b.c"},
 			Description: "Description",
 			EffectiveOn: "2022-01-01T00:00:00Z",
 			Kind:        rule.Deny,
@@ -1400,6 +1403,219 @@ func TestNameScoring(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			assert.Equal(t, c.score, score(c.name))
+		})
+	}
+}
+
+func TestCheckResultsTrim(t *testing.T) {
+	cases := []struct {
+		name     string
+		given    CheckResults
+		expected CheckResults
+	}{
+		{
+			name: "simple dependency",
+			given: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "failure 1",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure1",
+								},
+							},
+						},
+					},
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success1",
+								metadataDependsOn: []string{"a.failure1"},
+							},
+						},
+					},
+				},
+			},
+			expected: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "failure 1",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure1",
+								},
+							},
+						},
+					},
+					Successes: []output.Result{},
+				},
+			},
+		},
+		{
+			name: "successful dependants are not trimmed",
+			given: CheckResults{
+				CheckResult{
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode: "a.success1",
+							},
+						},
+					},
+				},
+				CheckResult{
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success2",
+								metadataDependsOn: []string{"a.success1"},
+							},
+						},
+					},
+				},
+			},
+			expected: CheckResults{
+				CheckResult{
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode: "a.success1",
+							},
+						},
+					},
+				},
+				CheckResult{
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success2",
+								metadataDependsOn: []string{"a.success1"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "failures, warnings and successes with dependencies",
+			given: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "Fails",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure",
+								},
+							},
+							{
+								Message: "Fails and depends",
+								Metadata: map[string]interface{}{
+									metadataCode:      "a.failure",
+									metadataDependsOn: []string{"a.failure"},
+								},
+							},
+						},
+						Warnings: []output.Result{
+							{
+								Message: "Warning",
+								Metadata: map[string]interface{}{
+									metadataCode:      "a.warning",
+									metadataDependsOn: []string{"a.failure"},
+								},
+							},
+						},
+					},
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success",
+								metadataDependsOn: []string{"a.failure"},
+							},
+						},
+					},
+				},
+			},
+			expected: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "Fails",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure",
+								},
+							},
+						},
+						Warnings: []output.Result{},
+					},
+					Successes: []output.Result{},
+				},
+			},
+		},
+		{
+			name: "unrelated dependency",
+			given: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "failure 1",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure",
+								},
+							},
+						},
+					},
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success1",
+								metadataDependsOn: []string{"a.unrelated"},
+							},
+						},
+					},
+				},
+			},
+			expected: CheckResults{
+				CheckResult{
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{
+								Message: "failure 1",
+								Metadata: map[string]interface{}{
+									metadataCode: "a.failure",
+								},
+							},
+						},
+					},
+					Successes: []output.Result{
+						{
+							Message: "pass",
+							Metadata: map[string]interface{}{
+								metadataCode:      "a.success1",
+								metadataDependsOn: []string{"a.unrelated"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases[2:] {
+		t.Run(c.name, func(t *testing.T) {
+			c.given.trim()
+			assert.Equal(t, c.expected, c.given)
 		})
 	}
 }

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -222,6 +222,30 @@ func documentationUrl(a *ast.AnnotationsRef) string {
 	return ""
 }
 
+func dependsOn(a *ast.AnnotationsRef) []string {
+	if a == nil {
+		return []string{}
+	}
+
+	dependsOn, ok := a.Annotations.Custom["depends_on"]
+
+	if !ok {
+		return []string{}
+	}
+
+	switch d := dependsOn.(type) {
+	case []any:
+		ret := make([]string, 0, len(d))
+		for _, v := range d {
+			ret = append(ret, fmt.Sprint(v))
+		}
+		return ret
+	default:
+		return []string{fmt.Sprint(d)}
+	}
+
+}
+
 type RuleKind string
 
 const (
@@ -234,13 +258,14 @@ type Info struct {
 	Code             string
 	CodePackage      string
 	Collections      []string
+	DependsOn        []string
 	Description      string
 	DocumentationUrl string
 	EffectiveOn      string
-	Solution         string
 	Kind             RuleKind
 	Package          string
 	ShortName        string
+	Solution         string
 	Title            string
 }
 
@@ -250,6 +275,7 @@ func RuleInfo(a *ast.AnnotationsRef) Info {
 		CodePackage:      codePackage(a),
 		Collections:      collections(a),
 		Description:      description(a),
+		DependsOn:        dependsOn(a),
 		DocumentationUrl: documentationUrl(a),
 		EffectiveOn:      effectiveOn(a),
 		Solution:         solution(a),

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -542,3 +542,53 @@ func TestCode(t *testing.T) {
 		})
 	}
 }
+
+func TestDependsOn(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   []string
+	}{
+		{
+			name:       "nothing",
+			annotation: nil,
+			expected:   []string{},
+		},
+		{
+			name: "no depends_on annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: []string{},
+		},
+		{
+			name: "single depends_on annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   depends_on: a.b.c
+				deny() { true }`)),
+			expected: []string{"a.b.c"},
+		},
+		{
+			name: "multiple depends_on annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   depends_on:
+				#     - a.b.c
+				#     - d.e.f
+				#     - g.h.i
+				deny() { true }`)),
+			expected: []string{"a.b.c", "d.e.f", "g.h.i"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, dependsOn(c.annotation))
+		})
+	}
+}


### PR DESCRIPTION
A rule can specify a custom annotation `depends_on` with a string or a list of strings containing the code(s) of the rule(s) that a particular rule depends on. When a rule with dependents is reported as a failure, warning or it is skipped, dependent rules are filtered out and not reported.

Ref. https://issues.redhat.com/browse/HACBS-2208

Also includes:

[Refactor successes computation](https://github.com/enterprise-contract/ec-cli/commit/4250c7ad9e656c9dcfee056c6e85746aaca4bfab)

Pulls in the successes computation into a separate method.

[Refactor and fix consistency](https://github.com/enterprise-contract/ec-cli/commit/0c58b214c75cdce6a58d9d56cc93b5ef9d51327e)

Two rules with the same code, possibly by adding the same policy source twice with different versions, may interfere with each other. Do not allow that. Collect successes when looping over the `output.CheckResult` rather than assign to the first result.