### PR TITLE
Add test coverage in conftest_evaluator

### DIFF
--- a/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
+++ b/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
@@ -1,0 +1,165 @@
+
+[TestConftestEvaluatorEvaluate - 1]
+evaluator.CheckResults{
+    {
+        CheckResult: output.CheckResult{
+            FileName:  "$TMPDIR/inputs/data.json",
+            Namespace: "a",
+            Successes: 1,
+            Skipped:   {
+            },
+            Warnings: {
+                {
+                    Message:  "Warning!",
+                    Metadata: {
+                        "code": "a.warning",
+                    },
+                    Outputs: nil,
+                },
+            },
+            Failures: {
+                {
+                    Message:  "Failure!",
+                    Metadata: {
+                        "code": "a.failure",
+                    },
+                    Outputs: nil,
+                },
+            },
+            Exceptions: {
+            },
+            Queries: {
+                {
+                    Query:   "data.a.exception[_][_] == \"\"",
+                    Results: nil,
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.a.deny",
+                    Results: {
+                        {
+                            Message:  "Failure!",
+                            Metadata: {
+                                "code": "a.failure",
+                            },
+                            Outputs: nil,
+                        },
+                    },
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.a.exception[_][_] == \"\"",
+                    Results: nil,
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.a.warn",
+                    Results: {
+                        {
+                            Message:  "Warning!",
+                            Metadata: {
+                                "code": "a.warning",
+                            },
+                            Outputs: nil,
+                        },
+                    },
+                    Traces:  nil,
+                    Outputs: {},
+                },
+            },
+        },
+        Successes: {
+            {
+                Message:  "Pass",
+                Metadata: {
+                    "code": "a.success",
+                },
+                Outputs: nil,
+            },
+        },
+    },
+    {
+        CheckResult: output.CheckResult{
+            FileName:  "$TMPDIR/inputs/data.json",
+            Namespace: "b",
+            Successes: 1,
+            Skipped:   {
+            },
+            Warnings: {
+                {
+                    Message:  "Warning!",
+                    Metadata: {
+                        "code": "b.warning",
+                    },
+                    Outputs: nil,
+                },
+            },
+            Failures: {
+                {
+                    Message:  "Failure!",
+                    Metadata: {
+                        "code": "b.failure",
+                    },
+                    Outputs: nil,
+                },
+            },
+            Exceptions: {
+            },
+            Queries: {
+                {
+                    Query:   "data.b.exception[_][_] == \"\"",
+                    Results: nil,
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.b.deny",
+                    Results: {
+                        {
+                            Message:  "Failure!",
+                            Metadata: {
+                                "code": "b.failure",
+                            },
+                            Outputs: nil,
+                        },
+                    },
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.b.exception[_][_] == \"\"",
+                    Results: nil,
+                    Traces:  nil,
+                    Outputs: {},
+                },
+                {
+                    Query:   "data.b.warn",
+                    Results: {
+                        {
+                            Message:  "Warning!",
+                            Metadata: {
+                                "code": "b.warning",
+                            },
+                            Outputs: nil,
+                        },
+                    },
+                    Traces:  nil,
+                    Outputs: {},
+                },
+            },
+        },
+        Successes: {
+            {
+                Message:  "Pass",
+                Metadata: {
+                    "code": "b.success",
+                },
+                Outputs: nil,
+            },
+        },
+    },
+}
+---

--- a/internal/evaluator/__testdir__/a.rego
+++ b/internal/evaluator/__testdir__/a.rego
@@ -1,0 +1,28 @@
+# A set of policies
+package a
+
+# METADATA
+# custom:
+#   short_name: failure
+deny[result] {
+	result := {
+		"code": "a.failure",
+		"msg": "Failure!",
+	}
+}
+# METADATA
+# custom:
+#   short_name: warning
+warn[result] {
+	result := {
+		"code": "a.warning",
+		"msg": "Warning!",
+	}
+}
+# METADATA
+# custom:
+#   short_name: success
+deny[result] {
+	false
+	result := "Success!"
+}

--- a/internal/evaluator/__testdir__/b.rego
+++ b/internal/evaluator/__testdir__/b.rego
@@ -1,0 +1,28 @@
+# B set of policies
+package b
+
+# METADATA
+# custom:
+#   short_name: failure
+deny[result] {
+	result := {
+		"code": "b.failure",
+		"msg": "Failure!",
+	}
+}
+# METADATA
+# custom:
+#   short_name: warning
+warn[result] {
+	result := {
+		"code": "b.warning",
+		"msg": "Warning!",
+	}
+}
+# METADATA
+# custom:
+#   short_name: success
+deny[result] {
+	false
+	result := "Success!"
+}


### PR DESCRIPTION
Adds a unit test that exercises Conftest and the surrounding logic on augmenting the CheckResults with successes.