### PR TITLE
Test coverage around the `STRICT` Task parameter

### DIFF
--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -543,6 +543,20 @@ func XMLAttestationSignaturesFrom(ctx context.Context) (string, error) {
 	}
 }
 
+func RawAttestationSignaturesFrom(ctx context.Context) map[string]string {
+	sigs, ok := ctx.Value(imageAttestationSignaturesKey).([]cosign.Signatures)
+	if !ok {
+		return nil
+	}
+
+	ret := map[string]string{}
+	for i, signature := range sigs {
+		ret[fmt.Sprintf("ATTESTATION_SIGNATURE_%d", i)] = signature.Sig
+	}
+
+	return ret
+}
+
 func applyPatches(statement *in_toto.ProvenanceStatement, patches *godog.Table) (*in_toto.ProvenanceStatement, error) {
 	if statement == nil || patches == nil || len(patches.Rows) == 0 {
 		return statement, nil

--- a/acceptance/kubernetes/kind/kind.go
+++ b/acceptance/kubernetes/kind/kind.go
@@ -52,6 +52,7 @@ import (
 	"github.com/enterprise-contract/ec-cli/acceptance/kubernetes/types"
 	"github.com/enterprise-contract/ec-cli/acceptance/kustomize"
 	"github.com/enterprise-contract/ec-cli/acceptance/log"
+	"github.com/enterprise-contract/ec-cli/acceptance/registry"
 )
 
 type key int
@@ -76,6 +77,7 @@ type testState struct {
 	policy    string
 	taskRun   string
 	snapshot  string
+	registry  string
 }
 
 func (n testState) Key() any {
@@ -255,6 +257,8 @@ func Start(givenCtx context.Context) (ctx context.Context, kCluster types.Cluste
 		logger.Error("Unable to start the cluster")
 	}
 
+	ctx, err = registry.Register(ctx, fmt.Sprintf("localhost:%d", globalCluster.registryPort))
+
 	return ctx, globalCluster, err
 }
 
@@ -416,4 +420,8 @@ func Destroy(ctx context.Context) {
 		}
 		logger.Log("[Destroy] Destroyed global cluster")
 	})
+}
+
+func (k *kindCluster) Registry(ctx context.Context) (string, error) {
+	return fmt.Sprintf("registry.image-registry.svc.cluster.local:%d", k.registryPort), nil
 }

--- a/acceptance/kubernetes/kubernetes_test.go
+++ b/acceptance/kubernetes/kubernetes_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndent(t *testing.T) {
+	assert.Equal(t, "", indent("", 0))
+	assert.Equal(t, "   ", indent("", 3))
+	assert.Equal(t, "   A", indent("A", 3))
+	assert.Equal(t, "   A\n   B", indent("A\nB", 3))
+	assert.Equal(t, "   A\n   B", indent("A\nB\n", 3))
+}

--- a/acceptance/kubernetes/stub/stub.go
+++ b/acceptance/kubernetes/stub/stub.go
@@ -173,3 +173,7 @@ func (s stubCluster) Up(ctx context.Context) bool {
 func (s stubCluster) Stop(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
+
+func (s stubCluster) Registry(ctx context.Context) (string, error) {
+	return registry.Url(ctx)
+}

--- a/acceptance/kubernetes/types/types.go
+++ b/acceptance/kubernetes/types/types.go
@@ -31,6 +31,7 @@ type Cluster interface {
 	AwaitUntilTaskIsDone(context.Context) (bool, error)
 	TaskInfo(context.Context) (*TaskInfo, error)
 	CreateNamedSnapshot(context.Context, string, string) error
+	Registry(context.Context) (string, error)
 }
 
 type TaskInfo struct {

--- a/acceptance/registry/registry.go
+++ b/acceptance/registry/registry.go
@@ -274,6 +274,22 @@ func assertImageContent(ctx context.Context, imageRef string, data *godog.DocStr
 	return fmt.Errorf("expected image layer and actual image layer differ:\n%s", b.String())
 }
 
+func Register(ctx context.Context, hostAndPort string) (context.Context, error) {
+	var state *registryState
+	ctx, err := testenv.SetupState(ctx, &state)
+	if err != nil {
+		return ctx, err
+	}
+
+	if state.Up() {
+		return ctx, errors.New("A registry has already been stubbed in this context")
+	}
+
+	state.HostAndPort = hostAndPort
+
+	return ctx, nil
+}
+
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext
 func AddStepsTo(sc *godog.ScenarioContext) {
 	sc.Step(`^stub registry running$`, startStubRegistry)

--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -37,6 +37,7 @@ import (
 
 var currentYear = time.Now().Year()
 var timestampRegex = regexp.MustCompile(fmt.Sprintf(`%d-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z`, currentYear)) // generalized timestamp in the current year
+var logTimestampRegex = regexp.MustCompile(`^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}`)                                 // timestamp as it apears in the logs
 var tempPathRegex = regexp.MustCompile(`\$\{TEMP\}([^: ]+)[: ]?`)                                                    // starts with "${TEMP}" and ends with something not in path, perhaps breaks on Windows due to the colon
 var randomBitsRegex = regexp.MustCompile(`([a-f\d]+)$`)                                                              // in general, we add random bits to paths as suffixes
 
@@ -96,6 +97,9 @@ func MatchSnapshot(ctx context.Context, qualifier, text string, vars map[string]
 
 	// replace any remaining timestamps
 	text = timestampRegex.ReplaceAllString(text, "$${TIMESTAMP}")
+
+	// replace any log timestamps
+	text = logTimestampRegex.ReplaceAllString(text, "$${TIMESTAMP}")
 
 	// handle temp directories, replace local temp path with "${TEMP}"
 	text = strings.ReplaceAll(text, os.TempDir(), "${TEMP}")

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -1,0 +1,293 @@
+
+[Non strict with failures:report - 1]
+components:
+- containerImage: ${REGISTRY}/acceptance/does-not-exist
+  name: ""
+  success: false
+  violations:
+  - metadata:
+      code: builtin.image.accessible
+      title: Image URL is accessible
+    msg: 'Image URL is not accessible: HEAD http://${REGISTRY}/v2/acceptance/does-not-exist/manifests/latest:
+      unexpected status code 404 Not Found (HEAD responses have no body, use GET for
+      details)'
+ec-version: ${EC_VERSION}
+key: |
+${__known_PUBLIC_KEY}
+policy:
+  publicKey: |
+${____known_PUBLIC_KEY}
+success: false
+
+---
+
+[Strict with failures:report - 1]
+components:
+- containerImage: ${REGISTRY}/acceptance/does-not-exist
+  name: ""
+  success: false
+  violations:
+  - metadata:
+      code: builtin.image.accessible
+      title: Image URL is accessible
+    msg: 'Image URL is not accessible: HEAD http://${REGISTRY}/v2/acceptance/does-not-exist/manifests/latest:
+      unexpected status code 404 Not Found (HEAD responses have no body, use GET for
+      details)'
+ec-version: ${EC_VERSION}
+key: |
+${__known_PUBLIC_KEY}
+policy:
+  publicKey: |
+${____known_PUBLIC_KEY}
+success: false
+
+---
+
+[Non strict with warnings:report - 1]
+components:
+- containerImage: ${REGISTRY}/acceptance/non-strict-with-warnings@${REGISTRY_acceptance/non-strict-with-warnings:latest_HASH}
+  name: ""
+  signatures:
+  - keyid: ""
+    metadata:
+      predicateBuildType: https://tekton.dev/attestations/chains/pipelinerun@v2
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: ${ATTESTATION_SIGNATURE_0}
+  success: true
+  successes:
+  - metadata:
+      code: builtin.attestation.signature_check
+      title: Attestation signature check passed
+    msg: Pass
+  - metadata:
+      code: builtin.attestation.syntax_check
+      title: Attestation syntax check passed
+    msg: Pass
+  - metadata:
+      code: builtin.image.signature_check
+      title: Image signature check passed
+    msg: Pass
+  - metadata:
+      code: test.no_skipped_tests
+      description: Reports any test that has its result set to "SKIPPED".
+      title: No tests were skipped
+    msg: Pass
+ec-version: ${EC_VERSION}
+key: |
+${__known_PUBLIC_KEY}
+policy:
+  configuration:
+    include:
+    - test.no_skipped_tests
+  publicKey: |
+${____known_PUBLIC_KEY}
+  sources:
+  - policy:
+    - github.com/enterprise-contract/ec-policies//policy
+success: true
+
+---
+
+[Strict with warnings:report - 1]
+components:
+- containerImage: ${REGISTRY}/acceptance/strict-with-warnings@${REGISTRY_acceptance/strict-with-warnings:latest_HASH}
+  name: ""
+  signatures:
+  - keyid: ""
+    metadata:
+      predicateBuildType: https://tekton.dev/attestations/chains/pipelinerun@v2
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: ${ATTESTATION_SIGNATURE_0}
+  success: true
+  successes:
+  - metadata:
+      code: builtin.attestation.signature_check
+      title: Attestation signature check passed
+    msg: Pass
+  - metadata:
+      code: builtin.attestation.syntax_check
+      title: Attestation syntax check passed
+    msg: Pass
+  - metadata:
+      code: builtin.image.signature_check
+      title: Image signature check passed
+    msg: Pass
+  - metadata:
+      code: test.no_skipped_tests
+      description: Reports any test that has its result set to "SKIPPED".
+      title: No tests were skipped
+    msg: Pass
+ec-version: ${EC_VERSION}
+key: |
+${__known_PUBLIC_KEY}
+policy:
+  configuration:
+    include:
+    - test.no_skipped_tests
+  publicKey: |
+${____known_PUBLIC_KEY}
+  sources:
+  - policy:
+    - github.com/enterprise-contract/ec-policies//policy
+success: true
+
+---
+
+[Golden container image:report - 1]
+components:
+- containerImage: quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d
+  name: ""
+  signatures:
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/TaskRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIHFVZeVR59n9UvN1dwF9Lh3Gv8XWLPDPIIJcnQ8e3TtvAiEA0z/5v6ggvmQyQ1EnYTJo9rwxOYuve4th4P/0639orLg=
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/PipelineRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIQClx1zvZGvyRu5gCHiC+oWVZTmWJGQlocSZMnzx/5omZAIgUiLQuMm+USYE+H0PDn/xPSVVQjkhWjDc3fulkxVzlC0=
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/PipelineRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIGS176zN5aoorLQMukjoCkHm7ocu7UhnKXLhzEdsgp4BAiEAviub3Lf4thLmSTU6ZqnEjw02kkrb9LKBBa1t8hVgAM4=
+  success: true
+  successes:
+  - metadata:
+      code: builtin.attestation.signature_check
+      title: Attestation signature check passed
+    msg: Pass
+  - metadata:
+      code: builtin.attestation.syntax_check
+      title: Attestation syntax check passed
+    msg: Pass
+  - metadata:
+      code: builtin.image.signature_check
+      title: Image signature check passed
+    msg: Pass
+  - metadata:
+      code: slsa_provenance_available.attestation_predicate_type_accepted
+      collections:
+      - minimal
+      - slsa1
+      - slsa2
+      - slsa3
+      description: The predicateType field of the attestation must indicate the in-toto
+        SLSA Provenance format was used to attest the PipelineRun.
+      title: Expected attestation predicate type found
+    msg: Pass
+ec-version: ${EC_VERSION}
+key: |
+  -----BEGIN PUBLIC KEY-----
+  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+  zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+  -----END PUBLIC KEY-----
+policy:
+  configuration:
+    include:
+    - slsa_provenance_available
+  publicKey: |-
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+    zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+    -----END PUBLIC KEY-----
+  sources:
+  - policy:
+    - github.com/enterprise-contract/ec-policies//policy
+success: true
+
+---
+
+[Initialize TUF fails:report - 1]
+${TIMESTAMP} Skipping step because a previous step failed
+
+---
+
+[Initialize TUF fails:initialize-tuf - 1]
+Initializing TUF root...
+Error: Get "http://spam.spam.spam.spam/root.json": dial tcp: lookup spam.spam.spam.spam on 10.96.0.10:53: no such host
+main.go:74: error during command execution: Get "http://spam.spam.spam.spam/root.json": dial tcp: lookup spam.spam.spam.spam on 10.96.0.10:53: no such host
+
+---
+
+[Initialize TUF succeeds:report - 1]
+components:
+- containerImage: quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d
+  name: ""
+  signatures:
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/TaskRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIHFVZeVR59n9UvN1dwF9Lh3Gv8XWLPDPIIJcnQ8e3TtvAiEA0z/5v6ggvmQyQ1EnYTJo9rwxOYuve4th4P/0639orLg=
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/PipelineRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIQClx1zvZGvyRu5gCHiC+oWVZTmWJGQlocSZMnzx/5omZAIgUiLQuMm+USYE+H0PDn/xPSVVQjkhWjDc3fulkxVzlC0=
+  - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+    metadata:
+      predicateBuildType: tekton.dev/v1beta1/PipelineRun
+      predicateType: https://slsa.dev/provenance/v0.2
+      type: https://in-toto.io/Statement/v0.1
+    sig: MEUCIGS176zN5aoorLQMukjoCkHm7ocu7UhnKXLhzEdsgp4BAiEAviub3Lf4thLmSTU6ZqnEjw02kkrb9LKBBa1t8hVgAM4=
+  success: true
+  successes:
+  - metadata:
+      code: builtin.attestation.signature_check
+      title: Attestation signature check passed
+    msg: Pass
+  - metadata:
+      code: builtin.attestation.syntax_check
+      title: Attestation syntax check passed
+    msg: Pass
+  - metadata:
+      code: builtin.image.signature_check
+      title: Image signature check passed
+    msg: Pass
+  - metadata:
+      code: slsa_provenance_available.attestation_predicate_type_accepted
+      collections:
+      - minimal
+      - slsa1
+      - slsa2
+      - slsa3
+      description: The predicateType field of the attestation must indicate the in-toto
+        SLSA Provenance format was used to attest the PipelineRun.
+      title: Expected attestation predicate type found
+    msg: Pass
+ec-version: ${EC_VERSION}
+key: |
+  -----BEGIN PUBLIC KEY-----
+  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+  zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+  -----END PUBLIC KEY-----
+policy:
+  configuration:
+    include:
+    - slsa_provenance_available
+  publicKey: |-
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+    zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+    -----END PUBLIC KEY-----
+  sources:
+  - policy:
+    - github.com/enterprise-contract/ec-policies//policy
+success: true
+
+---
+
+[Initialize TUF succeeds:initialize-tuf - 1]
+TUF_MIRROR not set. Skipping TUF root initialization.
+
+---


### PR DESCRIPTION
In addition to adding coverage the Task acceptance tests were converted to use snapshots, with variable substitutions not to succumb to flakiness.

Snapshots support per-step logs, and currently the `report` step is asserted, others don't offer much value to test (e.g.`assert` logs are evident from the Task status) or change frequently (e.g. `version`).

Ref. https://issues.redhat.com/browse/HACBS-2261