### PR TITLE
Pre-launch task to build ec for acceptance tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,8 @@
             "program": "${workspaceFolder}/acceptance",
             "args": [
                 "-tags=@focus"
-            ]
+            ],
+            "preLaunchTask": "build"
         },
         {
             "name": "Acceptance tests (persist environment)",
@@ -37,7 +38,8 @@
             "args": [
                 "-persist",
                 "-tags=@focus"
-            ]
+            ],
+            "preLaunchTask": "build"
         },
         {
             "name": "Acceptance tests (restore persisted environment)",
@@ -47,7 +49,8 @@
             "program": "${workspaceFolder}/acceptance",
             "args": [
                 "-restore"
-            ]
+            ],
+            "preLaunchTask": "build"
         },
         {
             "name": "ec validate image (against persisted environment - update as needed)",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make",
+            "args": ["build"]
+        }
+    ]
+}


### PR DESCRIPTION
Adds a task that will run `make build` before acceptance tests are run from Code. This way the current version of `ec` is used in acceptance tests.