### PR TITLE
Disable harden-runner during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,12 @@ jobs:
       TAG: ${{ github.sha }}
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-        with:
-          egress-policy: audit
-          disable-telemetry: true
+      # TODO: Enabling this seems to cause the host to run out of disk space.
+      # - name: Harden Runner
+      #   uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+      #   with:
+      #     egress-policy: audit
+      #     disable-telemetry: true
 
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
This seems to cause the host to run out of disk space.