### PR TITLE
Add successes output to `validate definition`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -108,6 +108,20 @@
                 "--output",
                 "data=data.yaml"
             ]
+        },
+        {
+            "name": "ec validate definition",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "validate",
+                "definition",
+                "--file",
+                "${workspaceFolder}/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml",
+                "--show-successes"
+            ]
         }
     ]
 }

--- a/acceptance/examples/pipeline_basic.rego
+++ b/acceptance/examples/pipeline_basic.rego
@@ -2,8 +2,12 @@ package pipeline.main
 
 expected_kind := "Pipeline"
 
+# METADATA
+# title: Pipeline kind is expected
+# description: Check that the pipeline is a kind of "Pipeline"
+# custom:
+#   short_name: expected_kind
 deny[result] {
 	expected_kind != input.kind
 	result := "invalid kind"
 }
-

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -58,13 +58,13 @@ func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 	assert.JSONEq(t, `{"definitions": [
 		{
 		  "filename": "/path/file1.yaml",
-		  "success": true,
+		  "successes": [],
 		  "violations": [],
 		  "warnings": []
 		},
 		{
 		  "filename": "/path/file2.yaml",
-		  "success": true,
+		  "successes": [],
 		  "violations": [],
 		  "warnings": []
 		}
@@ -109,12 +109,12 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 }
 
 func TestDefinitionFileOutputFormats(t *testing.T) {
-	testJSONText := `{"definitions":[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true}],"success":true,"ec-version":"development"}`
+	testJSONText := `{"definitions":[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"successes":[]}],"success":true,"ec-version":"development"}`
 
 	testYAMLTest := hd.Doc(`
 	definitions:
 	- filename: /path/file1.yaml
-	  success: true
+	  successes: []
 	  violations: []
 	  warnings: []
 	ec-version: development

--- a/features/__snapshots__/task_validate_definition.snap
+++ b/features/__snapshots__/task_validate_definition.snap
@@ -6,7 +6,7 @@
       "filename": "${TEMP}/definition-file-${RANDOM}",
       "violations": [],
       "warnings": [],
-      "success": true
+      "successes": []
     }
   ],
   "success": true,

--- a/features/__snapshots__/validate_definition.snap
+++ b/features/__snapshots__/validate_definition.snap
@@ -6,7 +6,7 @@
       "filename": "pipeline_definition.yaml",
       "violations": [],
       "warnings": [],
-      "success": true
+      "successes": []
     }
   ],
   "success": true,
@@ -15,5 +15,33 @@
 ---
 
 [:stderr - 1]
+
+---
+
+[Showing successes:stdout - 1]
+{
+  "definitions": [
+    {
+      "filename": "pipeline_definition.yaml",
+      "violations": [],
+      "warnings": [],
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.expected_kind",
+            "description": "Check that the pipeline is a kind of \"Pipeline\"",
+            "title": "Pipeline kind is expected"
+          }
+        }
+      ]
+    }
+  ],
+  "success": true,
+  "ec-version": "${EC_VERSION}"
+}
+---
+
+[Showing successes:stderr - 1]
 
 ---

--- a/features/validate_definition.feature
+++ b/features/validate_definition.feature
@@ -25,3 +25,24 @@ Feature: validate pipeline definition
     When ec command is run with "validate definition --file pipeline_definition.yaml --policy git::https://${GITHOST}/git/happy-day-policy.git"
     Then the exit status should be 0
     Then the output should match the snapshot
+
+  Scenario: Showing successes
+    Given a git repository named "happy-day-policy" with
+      | main.rego | examples/pipeline_basic.rego |
+    Given a pipeline definition file named "pipeline_definition.yaml" containing
+    """
+    ---
+    apiVersion: tekton.dev/v1beta1
+    kind: Pipeline
+    metadata:
+      name: basic-build
+    spec:
+      tasks:
+      - name: appstudio-init
+        taskRef:
+          name: init
+          version: "0.1"
+    """
+    When ec command is run with "validate definition --file pipeline_definition.yaml --policy git::https://${GITHOST}/git/happy-day-policy.git --show-successes"
+    Then the exit status should be 0
+    Then the output should match the snapshot

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -32,7 +32,7 @@ type ReportItem struct {
 	Filename   string           `json:"filename"`
 	Violations []cOutput.Result `json:"violations"`
 	Warnings   []cOutput.Result `json:"warnings"`
-	Success    bool             `json:"success"`
+	Successes  []cOutput.Result `json:"successes"`
 }
 
 type ReportFormat string
@@ -67,19 +67,19 @@ func (r *Report) Add(o output.Output) {
 			itemsByFile[check.FileName] = ReportItem{
 				Violations: []cOutput.Result{},
 				Warnings:   []cOutput.Result{},
+				Successes:  []cOutput.Result{},
 			}
 		}
 		item := itemsByFile[check.FileName]
 		item.Violations = append(item.Violations, check.Failures...)
 		item.Warnings = append(item.Warnings, check.Warnings...)
+		item.Successes = append(item.Successes, check.Successes...)
 		item.Filename = check.FileName
 		itemsByFile[check.FileName] = item
 	}
 
 	for _, value := range itemsByFile {
-		value.Success = true
 		if len(value.Violations) > 0 {
-			value.Success = false
 			// set Report.Success to false if any violations
 			r.Success = false
 		}

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -44,7 +44,7 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [],
 				"warnings": [],
-				"success": true,
+				"successes": [],
 			}],
 			"ec-version": "development",
 			"success": true
@@ -71,7 +71,7 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [],
 				"warnings": [{"msg": "running low in spam"},{"msg": "not all like spam"}],
-				"success": true,
+				"successes": [],
 			}],
 			"ec-version": "development",
 			"success": true
@@ -98,10 +98,37 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [{"msg": "out of spam!"},{"msg": "spam 💔"}],
 				"warnings": [],
-				"success": false,
+				"successes": [],
 			}],
 			"ec-version": "development",
 			"success": false
+			}`,
+		},
+		{
+			name: "successes",
+			output: []output.Output{
+				{
+					PolicyCheck: evaluator.CheckResults{
+						{
+							CheckResult: conftest.CheckResult{
+								FileName: "/path/to/pipeline.json",
+							},
+							Successes: []conftest.Result{
+								{Message: "Nice"},
+								{Message: "Day"},
+							},
+						},
+					},
+				},
+			},
+			expect: `{"definitions": [{
+				"filename": "/path/to/pipeline.json",
+				"violations": [],
+				"warnings": [],
+				"successes": [{"msg": "Nice"},{"msg": "Day"}],
+			}],
+			"ec-version": "development",
+			"success": true
 			}`,
 		},
 		{


### PR DESCRIPTION
Also adds support for `--show-successes` command line flag.

Ref. https://issues.redhat.com/browse/HACBS-2288