### PR TITLE
Expose sig certs of attestations to rego

### DIFF
--- a/acceptance/examples/keyless.rego
+++ b/acceptance/examples/keyless.rego
@@ -13,6 +13,14 @@ deny contains err(rego.metadata.rule(), "No signature info") if {
 
 # METADATA
 # custom:
+#   short_name: no_attestation_signature_info
+deny contains err(rego.metadata.rule(), "No attestation signature info") if {
+	some att in input.attestations
+	count(att.extra.signatures) == 0
+}
+
+# METADATA
+# custom:
 #   short_name: no_signer_certificate
 deny contains err(rego.metadata.rule(), "No signer certificate") if {
 	count(crypto.x509.parse_certificates(input.image.signatures[0].certificate)) == 0
@@ -20,9 +28,29 @@ deny contains err(rego.metadata.rule(), "No signer certificate") if {
 
 # METADATA
 # custom:
+#   short_name: no_attestation_signer_certificate
+deny contains err(rego.metadata.rule(), "No attestation signer certificate") if {
+	some att in input.attestations
+	count(crypto.x509.parse_certificates(att.extra.signatures[0].certificate)) == 0
+}
+
+# METADATA
+# custom:
 #   short_name: unexpected_signer
 deny contains err(rego.metadata.rule(), "Unexpected signer") if {
 	certs := crypto.x509.parse_certificates(input.image.signatures[0].certificate)
+	cert := certs[0]
+
+	# check a single attribute of SAN:URIs
+	cert.URIs[0].Path != "/namespaces/default/serviceaccounts/default"
+}
+
+# METADATA
+# custom:
+#   short_name: unexpected_attestation_signer
+deny contains err(rego.metadata.rule(), "Unexpected attestation signer") if {
+	some att in input.attestations
+	certs := crypto.x509.parse_certificates(att.extra.signatures[0].certificate)
 	cert := certs[0]
 
 	# check a single attribute of SAN:URIs

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -220,6 +220,18 @@ Error: success criteria not met
         {
           "msg": "Pass",
           "metadata": {
+            "code": "keyless.no_attestation_signature_info"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "keyless.no_attestation_signer_certificate"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
             "code": "keyless.no_signature_info"
           }
         },
@@ -227,6 +239,12 @@ Error: success criteria not met
           "msg": "Pass",
           "metadata": {
             "code": "keyless.no_signer_certificate"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "keyless.unexpected_attestation_signer"
           }
         },
         {

--- a/internal/attestation/__snapshots__/slsa_provenance_02_test.snap
+++ b/internal/attestation/__snapshots__/slsa_provenance_02_test.snap
@@ -1,0 +1,76 @@
+
+[TestSLSAProvenanceFromSignature/valid_with_signature_from_payload - 1]
+attestation.ProvenanceStatementSLSA02{
+    ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
+        StatementHeader: in_toto.StatementHeader{
+            Type:          "https://in-toto.io/Statement/v0.1",
+            PredicateType: "https://slsa.dev/provenance/v0.2",
+            Subject:       nil,
+        },
+        Predicate: v02.ProvenancePredicate{
+            Builder:     common.ProvenanceBuilder{},
+            BuildType:   "https://my.build.type",
+            Invocation:  v02.ProvenanceInvocation{},
+            BuildConfig: nil,
+            Metadata:    (*v02.ProvenanceMetadata)(nil),
+            Materials:   nil,
+        },
+    },
+    Extra: attestation.extra{
+        Signatures: {
+            {
+                KeyID:       "key-id-1",
+                Signature:   "sig-1",
+                Certificate: "",
+                Chain:       nil,
+                Metadata:    {"predicateBuildType":"https://my.build.type", "predicateType":"https://slsa.dev/provenance/v0.2", "type":"https://in-toto.io/Statement/v0.1"},
+            },
+            {
+                KeyID:       "key-id-2",
+                Signature:   "sig-2",
+                Certificate: "",
+                Chain:       nil,
+                Metadata:    {"predicateBuildType":"https://my.build.type", "predicateType":"https://slsa.dev/provenance/v0.2", "type":"https://in-toto.io/Statement/v0.1"},
+            },
+        },
+    },
+}
+---
+
+[TestSLSAProvenanceFromSignature/valid_with_signature_from_certificate - 1]
+attestation.ProvenanceStatementSLSA02{
+    ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
+        StatementHeader: in_toto.StatementHeader{
+            Type:          "https://in-toto.io/Statement/v0.1",
+            PredicateType: "https://slsa.dev/provenance/v0.2",
+            Subject:       nil,
+        },
+        Predicate: v02.ProvenancePredicate{
+            Builder:     common.ProvenanceBuilder{},
+            BuildType:   "https://my.build.type",
+            Invocation:  v02.ProvenanceInvocation{},
+            BuildConfig: nil,
+            Metadata:    (*v02.ProvenanceMetadata)(nil),
+            Materials:   nil,
+        },
+    },
+    Extra: attestation.extra{
+        Signatures: {
+            {
+                KeyID:       "6add046e38418d021a562c6a8633d5eca7379595",
+                Signature:   "sig-from-cert",
+                Certificate: "-----BEGIN CERTIFICATE-----\nMIIG2TCCBl+gAwIBAgIUdtQgx3Mj6A3T0X7Oh8bS1nNABTEwCgYIKoZIzj0EAwMw\nNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl\ncm1lZGlhdGUwHhcNMjMwNjA3MDMxNDEyWhcNMjMwNjA3MDMyNDEyWjAAMFkwEwYH\nKoZIzj0CAQYIKoZIzj0DAQcDQgAEz6tsPZHx7njElmbGbMYxKiYneuofINbOE8Tg\n1gkyQcckWyu1xA/Fs0O1SpPkn/KJYLJ3J5ziqgd1EguuCqK3Z6OCBX4wggV6MA4G\nA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUat0E\nbjhBjQIaVixqhjPV7Kc3lZUwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y\nZD8waAYDVR0RAQH/BF4wXIZaaHR0cHM6Ly9naXRodWIuY29tL2NoYWluZ3VhcmQt\naW1hZ2VzL2ltYWdlcy8uZ2l0aHViL3dvcmtmbG93cy9yZWxlYXNlLnlhbWxAcmVm\ncy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9rZW4uYWN0aW9u\ncy5naXRodWJ1c2VyY29udGVudC5jb20wEgYKKwYBBAGDvzABAgQEcHVzaDA2Bgor\nBgEEAYO/MAEDBChlMWRjZGY3MGJlMzI2YTQ5NDI5NTc1NDYyMmZlMzQ2MzE2MDA1\nMzFhMCwGCisGAQQBg78wAQQEHi5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UueWFt\nbDAmBgorBgEEAYO/MAEFBBhjaGFpbmd1YXJkLWltYWdlcy9pbWFnZXMwHQYKKwYB\nBAGDvzABBgQPcmVmcy9oZWFkcy9tYWluMDsGCisGAQQBg78wAQgELQwraHR0cHM6\nLy90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTBqBgorBgEEAYO/\nMAEJBFwMWmh0dHBzOi8vZ2l0aHViLmNvbS9jaGFpbmd1YXJkLWltYWdlcy9pbWFn\nZXMvLmdpdGh1Yi93b3JrZmxvd3MvcmVsZWFzZS55YW1sQHJlZnMvaGVhZHMvbWFp\nbjA4BgorBgEEAYO/MAEKBCoMKGUxZGNkZjcwYmUzMjZhNDk0Mjk1NzU0NjIyZmUz\nNDYzMTYwMDUzMWEwHQYKKwYBBAGDvzABCwQPDA1naXRodWItaG9zdGVkMDsGCisG\nAQQBg78wAQwELQwraHR0cHM6Ly9naXRodWIuY29tL2NoYWluZ3VhcmQtaW1hZ2Vz\nL2ltYWdlczA4BgorBgEEAYO/MAENBCoMKGUxZGNkZjcwYmUzMjZhNDk0Mjk1NzU0\nNjIyZmUzNDYzMTYwMDUzMWEwHwYKKwYBBAGDvzABDgQRDA9yZWZzL2hlYWRzL21h\naW4wGQYKKwYBBAGDvzABDwQLDAk1NjM1MTA5NTIwNAYKKwYBBAGDvzABEAQmDCRo\ndHRwczovL2dpdGh1Yi5jb20vY2hhaW5ndWFyZC1pbWFnZXMwGQYKKwYBBAGDvzAB\nEQQLDAkxMTMxOTg1NDUwagYKKwYBBAGDvzABEgRcDFpodHRwczovL2dpdGh1Yi5j\nb20vY2hhaW5ndWFyZC1pbWFnZXMvaW1hZ2VzLy5naXRodWIvd29ya2Zsb3dzL3Jl\nbGVhc2UueWFtbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABEwQqDChlMWRj\nZGY3MGJlMzI2YTQ5NDI5NTc1NDYyMmZlMzQ2MzE2MDA1MzFhMBQGCisGAQQBg78w\nARQEBgwEcHVzaDBeBgorBgEEAYO/MAEVBFAMTmh0dHBzOi8vZ2l0aHViLmNvbS9j\naGFpbmd1YXJkLWltYWdlcy9pbWFnZXMvYWN0aW9ucy9ydW5zLzUxOTU1MDc2MzYv\nYXR0ZW1wdHMvMTCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJln\nNwKiSl643jyt/4eKcoAvKe6OAAABiJPZADAAAAQDAEcwRQIgdHXB0QGS/GWkBnY1\nAZXSwb6/tbnnaVeWzde3t0fkkRMCIQC0bwdhWep548Cp4LzBPgGD0eioadqQdJHe\nXtVXBkD1dDAKBggqhkjOPQQDAwNoADBlAjBPpXDUSaAk5D6T1Eaqh+TRSQXr6rqV\nYxAJb/NgDbq8tTVLKustJDu2V9TQcpSzuKICMQDt0EAHmTISmKC8H3dciTrySh2l\nuS2rfl+L2AFS6DxAmVTBR3dlbrxQsUxshBWyH5s=\n-----END CERTIFICATE-----\n",
+                Chain:       {"-----BEGIN CERTIFICATE-----\nMIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0C\nAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV7\n7LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS\n0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYB\nBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjp\nKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZI\nzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJR\nnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsP\nmygUY7Ii2zbdCdliiow=\n-----END CERTIFICATE-----\n", "-----BEGIN CERTIFICATE-----\nMIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7\nXeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex\nX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j\nYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY\nwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ\nKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM\nWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9\nTNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ\n-----END CERTIFICATE-----\n"},
+                Metadata:    {"Fulcio Build Config Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Build Config URI":"https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "Fulcio Build Signer Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Build Signer URI":"https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "Fulcio Build Trigger":"push", "Fulcio GitHub Workflow Name":".github/workflows/release.yaml", "Fulcio GitHub Workflow Ref":"refs/heads/main", "Fulcio GitHub Workflow Repository":"chainguard-images/images", "Fulcio GitHub Workflow SHA":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio GitHub Workflow Trigger":"push", "Fulcio Issuer":"https://token.actions.githubusercontent.com", "Fulcio Issuer (V2)":"https://token.actions.githubusercontent.com", "Fulcio Run Invocation URI":"https://github.com/chainguard-images/images/actions/runs/5195507636/attempts/1", "Fulcio Runner Environment":"github-hosted", "Fulcio Source Repository Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Source Repository Identifier":"563510952", "Fulcio Source Repository Owner Identifier":"113198545", "Fulcio Source Repository Owner URI":"https://github.com/chainguard-images", "Fulcio Source Repository Ref":"refs/heads/main", "Fulcio Source Repository URI":"https://github.com/chainguard-images/images", "Issuer":"CN=sigstore-intermediate,O=sigstore.dev", "Not After":"2023-06-07T03:24:12Z", "Not Before":"2023-06-07T03:14:12Z", "Serial Number":"76d420c77323e80dd3d17ece87c6d2d673400531", "Subject Alternative Name":"URIs:https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "predicateBuildType":"https://my.build.type", "predicateType":"https://slsa.dev/provenance/v0.2", "type":"https://in-toto.io/Statement/v0.1"},
+            },
+            {
+                KeyID:       "6add046e38418d021a562c6a8633d5eca7379595",
+                Signature:   "sig-from-cert",
+                Certificate: "-----BEGIN CERTIFICATE-----\nMIIG2TCCBl+gAwIBAgIUdtQgx3Mj6A3T0X7Oh8bS1nNABTEwCgYIKoZIzj0EAwMw\nNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl\ncm1lZGlhdGUwHhcNMjMwNjA3MDMxNDEyWhcNMjMwNjA3MDMyNDEyWjAAMFkwEwYH\nKoZIzj0CAQYIKoZIzj0DAQcDQgAEz6tsPZHx7njElmbGbMYxKiYneuofINbOE8Tg\n1gkyQcckWyu1xA/Fs0O1SpPkn/KJYLJ3J5ziqgd1EguuCqK3Z6OCBX4wggV6MA4G\nA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUat0E\nbjhBjQIaVixqhjPV7Kc3lZUwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y\nZD8waAYDVR0RAQH/BF4wXIZaaHR0cHM6Ly9naXRodWIuY29tL2NoYWluZ3VhcmQt\naW1hZ2VzL2ltYWdlcy8uZ2l0aHViL3dvcmtmbG93cy9yZWxlYXNlLnlhbWxAcmVm\ncy9oZWFkcy9tYWluMDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9rZW4uYWN0aW9u\ncy5naXRodWJ1c2VyY29udGVudC5jb20wEgYKKwYBBAGDvzABAgQEcHVzaDA2Bgor\nBgEEAYO/MAEDBChlMWRjZGY3MGJlMzI2YTQ5NDI5NTc1NDYyMmZlMzQ2MzE2MDA1\nMzFhMCwGCisGAQQBg78wAQQEHi5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UueWFt\nbDAmBgorBgEEAYO/MAEFBBhjaGFpbmd1YXJkLWltYWdlcy9pbWFnZXMwHQYKKwYB\nBAGDvzABBgQPcmVmcy9oZWFkcy9tYWluMDsGCisGAQQBg78wAQgELQwraHR0cHM6\nLy90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTBqBgorBgEEAYO/\nMAEJBFwMWmh0dHBzOi8vZ2l0aHViLmNvbS9jaGFpbmd1YXJkLWltYWdlcy9pbWFn\nZXMvLmdpdGh1Yi93b3JrZmxvd3MvcmVsZWFzZS55YW1sQHJlZnMvaGVhZHMvbWFp\nbjA4BgorBgEEAYO/MAEKBCoMKGUxZGNkZjcwYmUzMjZhNDk0Mjk1NzU0NjIyZmUz\nNDYzMTYwMDUzMWEwHQYKKwYBBAGDvzABCwQPDA1naXRodWItaG9zdGVkMDsGCisG\nAQQBg78wAQwELQwraHR0cHM6Ly9naXRodWIuY29tL2NoYWluZ3VhcmQtaW1hZ2Vz\nL2ltYWdlczA4BgorBgEEAYO/MAENBCoMKGUxZGNkZjcwYmUzMjZhNDk0Mjk1NzU0\nNjIyZmUzNDYzMTYwMDUzMWEwHwYKKwYBBAGDvzABDgQRDA9yZWZzL2hlYWRzL21h\naW4wGQYKKwYBBAGDvzABDwQLDAk1NjM1MTA5NTIwNAYKKwYBBAGDvzABEAQmDCRo\ndHRwczovL2dpdGh1Yi5jb20vY2hhaW5ndWFyZC1pbWFnZXMwGQYKKwYBBAGDvzAB\nEQQLDAkxMTMxOTg1NDUwagYKKwYBBAGDvzABEgRcDFpodHRwczovL2dpdGh1Yi5j\nb20vY2hhaW5ndWFyZC1pbWFnZXMvaW1hZ2VzLy5naXRodWIvd29ya2Zsb3dzL3Jl\nbGVhc2UueWFtbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABEwQqDChlMWRj\nZGY3MGJlMzI2YTQ5NDI5NTc1NDYyMmZlMzQ2MzE2MDA1MzFhMBQGCisGAQQBg78w\nARQEBgwEcHVzaDBeBgorBgEEAYO/MAEVBFAMTmh0dHBzOi8vZ2l0aHViLmNvbS9j\naGFpbmd1YXJkLWltYWdlcy9pbWFnZXMvYWN0aW9ucy9ydW5zLzUxOTU1MDc2MzYv\nYXR0ZW1wdHMvMTCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJln\nNwKiSl643jyt/4eKcoAvKe6OAAABiJPZADAAAAQDAEcwRQIgdHXB0QGS/GWkBnY1\nAZXSwb6/tbnnaVeWzde3t0fkkRMCIQC0bwdhWep548Cp4LzBPgGD0eioadqQdJHe\nXtVXBkD1dDAKBggqhkjOPQQDAwNoADBlAjBPpXDUSaAk5D6T1Eaqh+TRSQXr6rqV\nYxAJb/NgDbq8tTVLKustJDu2V9TQcpSzuKICMQDt0EAHmTISmKC8H3dciTrySh2l\nuS2rfl+L2AFS6DxAmVTBR3dlbrxQsUxshBWyH5s=\n-----END CERTIFICATE-----\n",
+                Chain:       {"-----BEGIN CERTIFICATE-----\nMIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0C\nAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV7\n7LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS\n0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYB\nBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjp\nKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZI\nzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJR\nnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsP\nmygUY7Ii2zbdCdliiow=\n-----END CERTIFICATE-----\n", "-----BEGIN CERTIFICATE-----\nMIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7\nXeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex\nX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j\nYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY\nwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ\nKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM\nWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9\nTNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ\n-----END CERTIFICATE-----\n"},
+                Metadata:    {"Fulcio Build Config Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Build Config URI":"https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "Fulcio Build Signer Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Build Signer URI":"https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "Fulcio Build Trigger":"push", "Fulcio GitHub Workflow Name":".github/workflows/release.yaml", "Fulcio GitHub Workflow Ref":"refs/heads/main", "Fulcio GitHub Workflow Repository":"chainguard-images/images", "Fulcio GitHub Workflow SHA":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio GitHub Workflow Trigger":"push", "Fulcio Issuer":"https://token.actions.githubusercontent.com", "Fulcio Issuer (V2)":"https://token.actions.githubusercontent.com", "Fulcio Run Invocation URI":"https://github.com/chainguard-images/images/actions/runs/5195507636/attempts/1", "Fulcio Runner Environment":"github-hosted", "Fulcio Source Repository Digest":"e1dcdf70be326a494295754622fe34631600531a", "Fulcio Source Repository Identifier":"563510952", "Fulcio Source Repository Owner Identifier":"113198545", "Fulcio Source Repository Owner URI":"https://github.com/chainguard-images", "Fulcio Source Repository Ref":"refs/heads/main", "Fulcio Source Repository URI":"https://github.com/chainguard-images/images", "Issuer":"CN=sigstore-intermediate,O=sigstore.dev", "Not After":"2023-06-07T03:24:12Z", "Not Before":"2023-06-07T03:14:12Z", "Serial Number":"76d420c77323e80dd3d17ece87c6d2d673400531", "Subject Alternative Name":"URIs:https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main", "predicateBuildType":"https://my.build.type", "predicateType":"https://slsa.dev/provenance/v0.2", "type":"https://in-toto.io/Statement/v0.1"},
+            },
+        },
+    },
+}
+---

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -26,6 +26,7 @@ var (
 	AT002 = e.NewError("AT002", "Malformed attestation data", e.ErrorExitStatus)
 	AT003 = e.NewError("AT003", "Unsupported attestation type", e.ErrorExitStatus)
 	AT004 = e.NewError("AT004", "Unsupported attestation predicate type", e.ErrorExitStatus)
+	AT005 = e.NewError("AT005", "Cannot create signed entity", e.ErrorExitStatus)
 )
 
 // Attestation holds the raw attestation data, usually fetched from the
@@ -35,4 +36,10 @@ type Attestation[T any] interface {
 	Data() []byte
 	Statement() T
 	Signatures() []output.EntitySignature
+}
+
+// extra holds the signatures associated with an attestation. It is meant
+// to facilitate embedding signatures in the result of Attestation.Statement().
+type extra struct {
+	Signatures []output.EntitySignature `json:"signatures"`
 }

--- a/internal/attestation/slsa_provenance_02_test.go
+++ b/internal/attestation/slsa_provenance_02_test.go
@@ -14,107 +14,159 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package attestation
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"testing"
 
+	"github.com/gkampitakis/go-snaps/snaps"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/in-toto/in-toto-golang/in_toto"
-	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	ct "github.com/sigstore/cosign/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/enterprise-contract/ec-cli/internal/output"
+	"github.com/enterprise-contract/ec-cli/internal/signature"
 	e "github.com/enterprise-contract/ec-cli/pkg/error"
 )
 
-type mockLayer struct {
+type mockSignature struct {
 	*mock.Mock
 }
 
-func (l mockLayer) Digest() (v1.Hash, error) {
+func (l mockSignature) Annotations() (map[string]string, error) {
+	args := l.Called()
+
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func (l mockSignature) Payload() ([]byte, error) {
+	args := l.Called()
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (l mockSignature) Signature() ([]byte, error) {
+	args := l.Called()
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (l mockSignature) Base64Signature() (string, error) {
+	args := l.Called()
+
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (l mockSignature) Cert() (*x509.Certificate, error) {
+	args := l.Called()
+
+	return args.Get(0).(*x509.Certificate), args.Error(1)
+}
+
+func (l mockSignature) Chain() ([]*x509.Certificate, error) {
+	args := l.Called()
+
+	return args.Get(0).([]*x509.Certificate), args.Error(1)
+}
+
+func (l mockSignature) Bundle() (*bundle.RekorBundle, error) {
+	args := l.Called()
+
+	return args.Get(0).(*bundle.RekorBundle), args.Error(1)
+}
+
+func (l mockSignature) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	args := l.Called()
+
+	return args.Get(0).(*bundle.RFC3161Timestamp), args.Error(1)
+}
+
+func (l mockSignature) Digest() (v1.Hash, error) {
 	args := l.Called()
 
 	return args.Get(0).(v1.Hash), args.Error(1)
 }
 
-func (l mockLayer) DiffID() (v1.Hash, error) {
+func (l mockSignature) DiffID() (v1.Hash, error) {
 	args := l.Called()
 
 	return args.Get(0).(v1.Hash), args.Error(1)
 }
 
-func (l mockLayer) Compressed() (io.ReadCloser, error) {
+func (l mockSignature) Compressed() (io.ReadCloser, error) {
 	args := l.Called()
 
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
-func (l mockLayer) Uncompressed() (io.ReadCloser, error) {
+func (l mockSignature) Uncompressed() (io.ReadCloser, error) {
 	args := l.Called()
 
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
-func (l mockLayer) Size() (int64, error) {
+func (l mockSignature) Size() (int64, error) {
 	args := l.Called()
 
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (l mockLayer) MediaType() (types.MediaType, error) {
+func (l mockSignature) MediaType() (types.MediaType, error) {
 	args := l.Called()
 
 	return args.Get(0).(types.MediaType), args.Error(1)
 }
 
-func TestSLSAProvenanceFromLayerNilLayer(t *testing.T) {
-	sp, err := SLSAProvenanceFromLayer(nil)
+func TestSLSAProvenanceFromSignatureNilSignature(t *testing.T) {
+	sp, err := SLSAProvenanceFromSignature(nil)
 	assert.True(t, AT001.Alike(err), "Expecting `%v` to be alike: `%v`", err, AT001)
 	assert.Nil(t, sp)
 }
 
-func TestSLSAProvenanceFromLayer(t *testing.T) {
+func TestSLSAProvenanceFromSignature(t *testing.T) {
 	cases := []struct {
-		name      string
-		setup     func(l *mockLayer)
-		data      string
-		statement in_toto.ProvenanceStatementSLSA02
-		err       e.Error
+		name  string
+		setup func(l *mockSignature)
+		data  string
+		err   e.Error
 	}{
 		{
 			name: "media type error",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				l.On("MediaType").Return(types.MediaType(""), errors.New("expected"))
 			},
 			err: AT002.CausedByF("expected"),
 		},
 		{
 			name: "no media type",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				l.On("MediaType").Return(types.MediaType(""), nil)
 			},
-			err: AT002.CausedByF("Expecting media type of `application/vnd.dsse.envelope.v1+json`, received: ``"),
+			err: AT002.CausedByF(
+				"Expecting media type of `application/vnd.dsse.envelope.v1+json`, received: ``"),
 		},
 		{
 			name: "unsupported media type",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				l.On("MediaType").Return(types.MediaType("xxx"), nil)
 			},
-			err: AT002.CausedByF("Expecting media type of `application/vnd.dsse.envelope.v1+json`, received: `xxx`"),
+			err: AT002.CausedByF(
+				"Expecting media type of `application/vnd.dsse.envelope.v1+json`, received: `xxx`"),
 		},
 		{
 			name: "no payload JSON",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
 				l.On("Uncompressed").Return(io.NopCloser(&bytes.Buffer{}), nil)
 			},
@@ -123,15 +175,16 @@ func TestSLSAProvenanceFromLayer(t *testing.T) {
 		{
 			name: "empty payload JSON",
 			data: "{}",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
+				payload := base64.StdEncoding.EncodeToString([]byte("{}"))
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(`{"payload":"`+base64.StdEncoding.EncodeToString([]byte("{}"))+`"}`), nil)
+				l.On("Uncompressed").Return(buffy(fmt.Sprintf(`{"payload":"%s"}`, payload)), nil)
 			},
 			err: AT003.CausedByF(""),
 		},
 		{
 			name: "invalid attestation payload JSON",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
 				payload := fmt.Sprintf(`{"signatures": [%s]}}}}}`, sig1)
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
@@ -141,72 +194,124 @@ func TestSLSAProvenanceFromLayer(t *testing.T) {
 		},
 		{
 			name: "invalid statement JSON",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				provenancePayload := "not-base64"
-				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
+				l.On("Uncompressed").Return(buffy(
+					fmt.Sprintf(`{"signatures": [%s], "payload": "not-base64"}`, sig1),
+				), nil)
 			},
 			err: AT002.CausedByF("illegal base64 data at input byte 3"),
 		},
 		{
 			name: "invalid statement JSON",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				provenancePayload := encode(`{
-						"_type": "https://in-toto.io/Statement/v0.1",
-						"predicateType":"https://slsa.dev/provenance/v0.2",
-						"predicate":{} }}}}}}}}}
-					}`)
-				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
+				payload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"https://slsa.dev/provenance/v0.2",
+					"predicate":{} }}}}}}}}}
+				}`)
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
+				l.On("Uncompressed").Return(buffy(
+					fmt.Sprintf(`{"signatures": [%s], "payload": "%s"}`, sig1, payload),
+				), nil)
 			},
 			err: AT002.CausedByF("invalid character '}' after top-level value"),
 		},
 		{
 			name: "unexpected predicate type",
-			setup: func(l *mockLayer) {
+			setup: func(l *mockSignature) {
 				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				provenancePayload := encode(`{
-						"_type": "https://in-toto.io/Statement/v0.1",
-						"predicateType":"kaboom"
-					}`)
-				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
+				payload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"kaboom"
+				}`)
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
+				l.On("Uncompressed").Return(buffy(
+					fmt.Sprintf(`{"signatures": [%s], "payload": "%s"}`, sig1, payload),
+				), nil)
 			},
 			err: AT004.CausedByF("kaboom"),
 		},
 		{
-			name: "valid",
-			data: `{"_type":"https://in-toto.io/Statement/v0.1", "predicateType":"https://slsa.dev/provenance/v0.2","predicate":{"buildType":"https://my.build.type"}}`,
-			setup: func(l *mockLayer) {
+			name: "cannot create entity signature",
+			data: `{
+				"_type": "https://in-toto.io/Statement/v0.1",
+				"predicateType": "https://slsa.dev/provenance/v0.2",
+				"predicate": {"buildType": "https://my.build.type"}
+			}`,
+			setup: func(l *mockSignature) {
+				payload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType": "https://slsa.dev/provenance/v0.2",
+					"predicate": {"buildType":"https://my.build.type"}
+				}`)
 				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(`{"payload":"`+base64.StdEncoding.EncodeToString([]byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","predicate":{"buildType":"https://my.build.type"}}`))+`"}`), nil)
+				l.On("Uncompressed").Return(buffy(fmt.Sprintf(`{"payload":"%s"}`, payload)), nil)
+				l.On("Base64Signature").Return("", errors.New("kaboom"))
 			},
-			statement: in_toto.ProvenanceStatementSLSA02{
-				StatementHeader: in_toto.StatementHeader{
-					Type:          in_toto.StatementInTotoV01,
-					PredicateType: v02.PredicateSLSAProvenance,
-				},
-				Predicate: v02.ProvenancePredicate{
-					BuildType: "https://my.build.type",
-				},
+			err: AT005.CausedByF("kaboom"),
+		},
+		{
+			name: "valid with signature from payload",
+			data: `{
+				"_type": "https://in-toto.io/Statement/v0.1",
+				"predicateType": "https://slsa.dev/provenance/v0.2",
+				"predicate": {"buildType": "https://my.build.type"}
+			}`,
+			setup: func(l *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
+				payload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType": "https://slsa.dev/provenance/v0.2",
+					"predicate": {"buildType": "https://my.build.type"}
+				}`)
+				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
+				l.On("Uncompressed").Return(buffy(
+					fmt.Sprintf(`{"payload": "%s", "signatures": [%s, %s]}`, payload, sig1, sig2),
+				), nil)
+				l.On("Base64Signature").Return("", nil)
+				l.On("Cert").Return(&x509.Certificate{}, nil)
+				l.On("Chain").Return([]*x509.Certificate{}, nil)
+			},
+		},
+		{
+			name: "valid with signature from certificate",
+			data: `{
+				"_type": "https://in-toto.io/Statement/v0.1",
+				"predicateType": "https://slsa.dev/provenance/v0.2",
+				"predicate": {"buildType": "https://my.build.type"}
+			}`,
+			setup: func(l *mockSignature) {
+				sig1 := `{"keyid": "ignored-1", "sig": "ignored-1"}`
+				sig2 := `{"keyid": "ignored-2", "sig": "ignored-2"}`
+				payload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType": "https://slsa.dev/provenance/v0.2",
+					"predicate": {"buildType": "https://my.build.type"}
+				}`)
+				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
+				l.On("Uncompressed").Return(buffy(
+					fmt.Sprintf(`{"payload": "%s", "signatures": [%s, %s]}`, payload, sig1, sig2),
+				), nil)
+				l.On("Base64Signature").Return("sig-from-cert", nil)
+				l.On("Cert").Return(signature.ParseChainguardReleaseCert(), nil)
+				l.On("Chain").Return(signature.ParseSigstoreChainCert(), nil)
 			},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			layer := mockLayer{&mock.Mock{}}
+			sig := mockSignature{&mock.Mock{}}
 
 			if c.setup != nil {
-				c.setup(&layer)
+				c.setup(&sig)
 			}
 
-			sp, err := SLSAProvenanceFromLayer(layer)
+			sp, err := SLSAProvenanceFromSignature(sig)
 			if c.err == nil {
 				require.Nil(t, err)
 				require.NotNil(t, sp)
@@ -221,100 +326,7 @@ func TestSLSAProvenanceFromLayer(t *testing.T) {
 			} else {
 				assert.JSONEq(t, c.data, string(sp.Data()))
 			}
-			assert.Equal(t, c.statement, sp.Statement())
-		})
-	}
-}
-
-func TestEntitySignature(t *testing.T) {
-	cases := []struct {
-		name       string
-		setup      func(l *mockLayer)
-		signatures []output.EntitySignature
-		err        e.Error
-	}{
-		{
-			name: "missing signatures",
-			setup: func(l *mockLayer) {
-				provenancePayload := encode(`{
-						"_type": "https://in-toto.io/Statement/v0.1",
-						"predicateType":"https://slsa.dev/provenance/v0.2"
-					}`)
-				payload := fmt.Sprintf(`{"signatures": [], "payload": "` + provenancePayload + `"}`)
-				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
-			},
-		},
-		{
-			name: "valid",
-			setup: func(l *mockLayer) {
-				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
-				provenancePayload := encode(`{
-						"_type": "https://in-toto.io/Statement/v0.1",
-						"predicateType":"https://slsa.dev/provenance/v0.2",
-						"predicate":{"buildType":"https://my.build.type"}
-					}`)
-				payload := fmt.Sprintf(`{"signatures": [%s, %s], "payload": "`+provenancePayload+`"}`, sig1, sig2)
-				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
-			},
-			signatures: []output.EntitySignature{
-				{KeyID: "key-id-1", Signature: "sig-1", Metadata: map[string]string{
-					"type":               "https://in-toto.io/Statement/v0.1",
-					"predicateBuildType": "https://my.build.type",
-					"predicateType":      "https://slsa.dev/provenance/v0.2",
-				}},
-				{KeyID: "key-id-2", Signature: "sig-2", Metadata: map[string]string{
-					"type":               "https://in-toto.io/Statement/v0.1",
-					"predicateBuildType": "https://my.build.type",
-					"predicateType":      "https://slsa.dev/provenance/v0.2",
-				}},
-			},
-		},
-		{
-			name: "valid, but missing buildType",
-			setup: func(l *mockLayer) {
-				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
-				provenancePayload := encode(`{
-						"_type": "https://in-toto.io/Statement/v0.1",
-						"predicateType":"https://slsa.dev/provenance/v0.2",
-						"predicate":{}
-					}`)
-				payload := fmt.Sprintf(`{"signatures": [%s, %s], "payload": "`+provenancePayload+`"}`, sig1, sig2)
-				l.On("MediaType").Return(types.MediaType(ct.DssePayloadType), nil)
-				l.On("Uncompressed").Return(buffy(payload), nil)
-			},
-			signatures: []output.EntitySignature{
-				{KeyID: "key-id-1", Signature: "sig-1", Metadata: map[string]string{
-					"type":          in_toto.StatementInTotoV01,
-					"predicateType": v02.PredicateSLSAProvenance,
-				}},
-				{KeyID: "key-id-2", Signature: "sig-2", Metadata: map[string]string{
-					"type":          in_toto.StatementInTotoV01,
-					"predicateType": v02.PredicateSLSAProvenance,
-				}},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			layer := mockLayer{&mock.Mock{}}
-			if c.setup != nil {
-				c.setup(&layer)
-			}
-			sp, err := SLSAProvenanceFromLayer(layer)
-			if c.err == nil {
-				require.Nil(t, err)
-				require.NotNil(t, sp)
-			} else {
-				assert.True(t, c.err.Alike(err), "Expecting `%v` to be alike: `%v`", err, c.err)
-				return
-			}
-
-			assert.Equal(t, c.signatures, sp.Signatures())
+			snaps.MatchSnapshot(t, sp.Statement())
 		})
 	}
 }

--- a/internal/image/fake.go
+++ b/internal/image/fake.go
@@ -19,13 +19,12 @@ package image
 import (
 	"encoding/json"
 
-	"github.com/in-toto/in-toto-golang/in_toto"
-
+	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 )
 
 type fakeAtt struct {
-	statement in_toto.ProvenanceStatementSLSA02
+	statement attestation.ProvenanceStatementSLSA02
 }
 
 func (f fakeAtt) Data() []byte {
@@ -36,7 +35,7 @@ func (f fakeAtt) Data() []byte {
 	return bytes
 }
 
-func (f fakeAtt) Statement() in_toto.ProvenanceStatementSLSA02 {
+func (f fakeAtt) Statement() attestation.ProvenanceStatementSLSA02 {
 	return f.statement
 }
 

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/in-toto/in-toto-golang/in_toto"
 	conftestOutput "github.com/open-policy-agent/conftest/output"
 	"github.com/qri-io/jsonpointer"
 	log "github.com/sirupsen/logrus"
@@ -141,7 +140,7 @@ func resolveAndSetImageUrl(url string, asi *application_snapshot_image.Applicati
 	return resolved, nil
 }
 
-func determineAttestationTime(ctx context.Context, attestations []attestation.Attestation[in_toto.ProvenanceStatementSLSA02]) *time.Time {
+func determineAttestationTime(ctx context.Context, attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]) *time.Time {
 	if len(attestations) == 0 {
 		log.Debug("No attestations provided to determine attestation time")
 		return nil

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -141,46 +141,52 @@ func TestDetermineAttestationTime(t *testing.T) {
 	time1 := time.Date(2001, 2, 3, 4, 5, 6, 7, time.UTC)
 	time2 := time.Date(2010, 11, 12, 13, 14, 15, 16, time.UTC)
 	att1 := fakeAtt{
-		statement: in_toto.ProvenanceStatementSLSA02{
-			StatementHeader: in_toto.StatementHeader{
-				PredicateType: v02.PredicateSLSAProvenance,
-			},
-			Predicate: v02.ProvenancePredicate{
-				Metadata: &v02.ProvenanceMetadata{
-					BuildFinishedOn: &time1,
+		statement: attestation.ProvenanceStatementSLSA02{
+			ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
+				StatementHeader: in_toto.StatementHeader{
+					PredicateType: v02.PredicateSLSAProvenance,
+				},
+				Predicate: v02.ProvenancePredicate{
+					Metadata: &v02.ProvenanceMetadata{
+						BuildFinishedOn: &time1,
+					},
 				},
 			},
 		},
 	}
 	att2 := fakeAtt{
-		statement: in_toto.ProvenanceStatementSLSA02{
-			StatementHeader: in_toto.StatementHeader{
-				PredicateType: v02.PredicateSLSAProvenance,
-			},
-			Predicate: v02.ProvenancePredicate{
-				Metadata: &v02.ProvenanceMetadata{
-					BuildFinishedOn: &time2,
+		statement: attestation.ProvenanceStatementSLSA02{
+			ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
+				StatementHeader: in_toto.StatementHeader{
+					PredicateType: v02.PredicateSLSAProvenance,
+				},
+				Predicate: v02.ProvenancePredicate{
+					Metadata: &v02.ProvenanceMetadata{
+						BuildFinishedOn: &time2,
+					},
 				},
 			},
 		},
 	}
 	att3 := fakeAtt{
-		statement: in_toto.ProvenanceStatementSLSA02{
-			StatementHeader: in_toto.StatementHeader{
-				PredicateType: v02.PredicateSLSAProvenance,
+		statement: attestation.ProvenanceStatementSLSA02{
+			ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
+				StatementHeader: in_toto.StatementHeader{
+					PredicateType: v02.PredicateSLSAProvenance,
+				},
 			},
 		},
 	}
 
 	cases := []struct {
 		name         string
-		attestations []attestation.Attestation[in_toto.ProvenanceStatementSLSA02]
+		attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]
 		expected     *time.Time
 	}{
 		{name: "no attestations"},
-		{name: "one attestation", attestations: []attestation.Attestation[in_toto.ProvenanceStatementSLSA02]{att1}, expected: &time1},
-		{name: "two attestations", attestations: []attestation.Attestation[in_toto.ProvenanceStatementSLSA02]{att1, att2}, expected: &time2},
-		{name: "two attestations and one without time", attestations: []attestation.Attestation[in_toto.ProvenanceStatementSLSA02]{att1, att2, att3}, expected: &time2},
+		{name: "one attestation", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1}, expected: &time1},
+		{name: "two attestations", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1, att2}, expected: &time2},
+		{name: "two attestations and one without time", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1, att2, att3}, expected: &time2},
 	}
 
 	for _, c := range cases {

--- a/internal/signature/certificate.go
+++ b/internal/signature/certificate.go
@@ -173,7 +173,7 @@ func NewEntitySignature(sig oci.Signature) (output.EntitySignature, error) {
 	if err != nil {
 		return output.EntitySignature{}, err
 	}
-	if cert != nil {
+	if cert != nil && len(cert.Raw) > 0 {
 		es.Certificate = string(pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
 			Bytes: cert.Raw,
@@ -190,6 +190,9 @@ func NewEntitySignature(sig oci.Signature) (output.EntitySignature, error) {
 		return output.EntitySignature{}, err
 	}
 	for _, c := range chain {
+		if len(c.Raw) == 0 {
+			continue
+		}
 		es.Chain = append(es.Chain, string(pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
 			Bytes: c.Raw,

--- a/internal/signature/testing_certs.go
+++ b/internal/signature/testing_certs.go
@@ -21,7 +21,9 @@
 package signature
 
 import (
+	"crypto/x509"
 	_ "embed"
+	"encoding/pem"
 )
 
 //go:embed other_name_san.cer
@@ -32,3 +34,30 @@ var ChainguardReleaseCert []byte
 
 //go:embed sigstore_chain.cer
 var SigstoreChainCert []byte
+
+func ParseChainguardReleaseCert() *x509.Certificate {
+	p, rest := pem.Decode(ChainguardReleaseCert)
+	if len(rest) != 0 {
+		panic("expected ChainguardReleaseCert to only contain a single cert")
+	}
+	c, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func ParseSigstoreChainCert() []*x509.Certificate {
+	var certs []*x509.Certificate
+	data := SigstoreChainCert
+	for len(data) > 0 {
+		var p *pem.Block
+		p, data = pem.Decode(data)
+		c, err := x509.ParseCertificate(p.Bytes)
+		if err != nil {
+			panic(err)
+		}
+		certs = append(certs, c)
+	}
+	return certs
+}


### PR DESCRIPTION
The `input` to rego policies has been enhanced to include the signature for each attestation. If the signature was created by using a certficiate, e.g. Fulcio, then the certificate is also included.

On a rego policy, these values can be accessed as such:

```rego
some att in input.attestations
some sig in att.extra.signatures
cert := crypto.x509.parse_certificates(sig.certificate)[0]
```

To hold this information, each item in the `input.attestations` list contains the new attribute `extra`. Alternative approaches were considered to avoid modifying the attestation. However, this would make it impossible in most cases to reliably correlate a certain attestation with a certain signature.

https://issues.redhat.com/browse/HACBS-2298