### PR TITLE
Remove generics for attestation statement

### DIFF
--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -32,9 +32,9 @@ var (
 // Attestation holds the raw attestation data, usually fetched from the
 // signature envelope's payload; statement of a particular type and any
 // signing information.
-type Attestation[T any] interface {
+type Attestation interface {
 	Data() []byte
-	Statement() T
+	Statement() any
 	Signatures() []signature.EntitySignature
 }
 

--- a/internal/attestation/slsa_provenance_02.go
+++ b/internal/attestation/slsa_provenance_02.go
@@ -40,7 +40,7 @@ type ProvenanceStatementSLSA02 struct {
 // SLSAProvenanceFromSignature parses the SLSA Provenance v0.2 from the provided OCI
 // layer. Expects that the layer contains DSSE JSON with the embeded SLSA
 // Provenance v0.2 payload.
-func SLSAProvenanceFromSignature(sig oci.Signature) (Attestation[ProvenanceStatementSLSA02], error) {
+func SLSAProvenanceFromSignature(sig oci.Signature) (Attestation, error) {
 	if sig == nil {
 		return nil, AT001
 	}
@@ -142,7 +142,7 @@ func (a slsaProvenance) Data() []byte {
 	return a.bytes
 }
 
-func (a slsaProvenance) Statement() ProvenanceStatementSLSA02 {
+func (a slsaProvenance) Statement() any {
 	return a.statement
 }
 

--- a/internal/attestation/slsa_provenance_02_test.go
+++ b/internal/attestation/slsa_provenance_02_test.go
@@ -326,6 +326,7 @@ func TestSLSAProvenanceFromSignature(t *testing.T) {
 			} else {
 				assert.JSONEq(t, c.data, string(sp.Data()))
 			}
+
 			snaps.MatchSnapshot(t, sp.Statement())
 		})
 	}

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -65,7 +65,7 @@ type ApplicationSnapshotImage struct {
 	reference    name.Reference
 	checkOpts    cosign.CheckOpts
 	signatures   []signature.EntitySignature
-	attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]
+	attestations []attestation.Attestation
 	Evaluators   []evaluator.Evaluator
 }
 
@@ -160,7 +160,7 @@ func (a *ApplicationSnapshotImage) SetImageURL(url string) error {
 	a.reference = ref
 
 	// Reset internal state relevant to the image
-	a.attestations = []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{}
+	a.attestations = []attestation.Attestation{}
 	a.signatures = []signature.EntitySignature{}
 
 	return nil
@@ -262,7 +262,7 @@ func (a ApplicationSnapshotImage) ValidateAttestationSyntax(ctx context.Context)
 }
 
 // Attestations returns the value of the attestations field of the ApplicationSnapshotImage struct
-func (a *ApplicationSnapshotImage) Attestations() []attestation.Attestation[attestation.ProvenanceStatementSLSA02] {
+func (a *ApplicationSnapshotImage) Attestations() []attestation.Attestation {
 	return a.attestations
 }
 
@@ -274,12 +274,10 @@ func (a *ApplicationSnapshotImage) Signatures() []signature.EntitySignature {
 func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context) (string, error) {
 	log.Debugf("Attempting to write %d attestations to input file", len(a.attestations))
 
-	var statements []attestation.ProvenanceStatementSLSA02
+	var statements []any
 	for _, sp := range a.attestations {
 		statements = append(statements, sp.Statement())
 	}
-
-	// var richStatements []
 
 	type Image struct {
 		Ref        string                      `json:"ref"`
@@ -287,8 +285,8 @@ func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context) (string, 
 	}
 
 	input := struct {
-		Attestations []attestation.ProvenanceStatementSLSA02 `json:"attestations"`
-		Image        Image                                   `json:"image"`
+		Attestations []any `json:"attestations"`
+		Image        Image `json:"image"`
 	}{
 		Attestations: statements,
 		Image: Image{

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -61,7 +61,7 @@ func TestApplicationSnapshotImage_ValidateImageAccess(t *testing.T) {
 	type fields struct {
 		reference    name.Reference
 		checkOpts    cosign.CheckOpts
-		attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]
+		attestations []attestation.Attestation
 		Evaluator    evaluator.Evaluator
 	}
 	type args struct {
@@ -129,7 +129,7 @@ func (f fakeAtt) Data() []byte {
 	return bytes
 }
 
-func (f fakeAtt) Statement() attestation.ProvenanceStatementSLSA02 {
+func (f fakeAtt) Statement() any {
 	return f.statement
 }
 
@@ -137,7 +137,7 @@ func (f fakeAtt) Signatures() []signature.EntitySignature {
 	return nil
 }
 
-func createSimpleAttestation(statement *attestation.ProvenanceStatementSLSA02) attestation.Attestation[attestation.ProvenanceStatementSLSA02] {
+func createSimpleAttestation(statement *attestation.ProvenanceStatementSLSA02) attestation.Attestation {
 	if statement == nil {
 		statement = &attestation.ProvenanceStatementSLSA02{
 			ProvenanceStatementSLSA02: in_toto.ProvenanceStatementSLSA02{
@@ -181,7 +181,7 @@ func TestWriteInputFile(t *testing.T) {
 			name: "single attestations",
 			snapshot: ApplicationSnapshotImage{
 				reference:    name.MustParseReference("registry.io/repository/image:tag"),
-				attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{createSimpleAttestation(nil)},
+				attestations: []attestation.Attestation{createSimpleAttestation(nil)},
 			},
 			want: `{"attestations": [` + simpleAttestationJSONText + `], "image": {"ref": "registry.io/repository/image:tag"}}`,
 		},
@@ -189,7 +189,7 @@ func TestWriteInputFile(t *testing.T) {
 			name: "multiple attestations",
 			snapshot: ApplicationSnapshotImage{
 				reference: name.MustParseReference("registry.io/repository/image:tag"),
-				attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+				attestations: []attestation.Attestation{
 					createSimpleAttestation(nil),
 					createSimpleAttestation(nil),
 				},
@@ -211,7 +211,7 @@ func TestWriteInputFile(t *testing.T) {
 						Signature: "signature2",
 					},
 				},
-				attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+				attestations: []attestation.Attestation{
 					createSimpleAttestation(nil),
 				},
 			},
@@ -243,7 +243,7 @@ func TestWriteInputFileMultipleAttestations(t *testing.T) {
 	att := createSimpleAttestation(nil)
 	a := ApplicationSnapshotImage{
 		reference:    name.MustParseReference("registry.io/repository/image:tag"),
-		attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att},
+		attestations: []attestation.Attestation{att},
 	}
 
 	fs := afero.NewMemMapFs()
@@ -320,32 +320,32 @@ func TestSyntaxValidation(t *testing.T) {
 
 	cases := []struct {
 		name         string
-		attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]
+		attestations []attestation.Attestation
 		err          *regexp.Regexp
 	}{
 		{
 			name: "invalid",
-			attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+			attestations: []attestation.Attestation{
 				invalid,
 			},
 			err: regexp.MustCompile(`EV003: Attestation syntax validation failed, .*, caused by:\nSchema ID: https://slsa.dev/provenance/v0.2\n - /predicate/builder/id: "invalid" invalid uri: uri missing scheme prefix`),
 		},
 		{
 			name: "valid",
-			attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+			attestations: []attestation.Attestation{
 				valid,
 			},
 		},
 		{
 			name: "empty",
-			attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+			attestations: []attestation.Attestation{
 				createSimpleAttestation(&attestation.ProvenanceStatementSLSA02{}),
 			},
 			err: regexp.MustCompile(`EV002: Unable to decode attestation data from attestation image, .*, caused by: unexpected end of JSON input`),
 		},
 		{
 			name: "valid and invalid",
-			attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{
+			attestations: []attestation.Attestation{
 				valid,
 				invalid,
 			},

--- a/internal/image/fake.go
+++ b/internal/image/fake.go
@@ -35,7 +35,7 @@ func (f fakeAtt) Data() []byte {
 	return bytes
 }
 
-func (f fakeAtt) Statement() attestation.ProvenanceStatementSLSA02 {
+func (f fakeAtt) Statement() any {
 	return f.statement
 }
 

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -140,7 +140,7 @@ func resolveAndSetImageUrl(url string, asi *application_snapshot_image.Applicati
 	return resolved, nil
 }
 
-func determineAttestationTime(ctx context.Context, attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]) *time.Time {
+func determineAttestationTime(ctx context.Context, attestations []attestation.Attestation) *time.Time {
 	if len(attestations) == 0 {
 		log.Debug("No attestations provided to determine attestation time")
 		return nil

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -180,13 +180,13 @@ func TestDetermineAttestationTime(t *testing.T) {
 
 	cases := []struct {
 		name         string
-		attestations []attestation.Attestation[attestation.ProvenanceStatementSLSA02]
+		attestations []attestation.Attestation
 		expected     *time.Time
 	}{
 		{name: "no attestations"},
-		{name: "one attestation", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1}, expected: &time1},
-		{name: "two attestations", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1, att2}, expected: &time2},
-		{name: "two attestations and one without time", attestations: []attestation.Attestation[attestation.ProvenanceStatementSLSA02]{att1, att2, att3}, expected: &time2},
+		{name: "one attestation", attestations: []attestation.Attestation{att1}, expected: &time1},
+		{name: "two attestations", attestations: []attestation.Attestation{att1, att2}, expected: &time2},
+		{name: "two attestations and one without time", attestations: []attestation.Attestation{att1, att2, att3}, expected: &time2},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Using generics for this was to invasive on the rest of the code and didn't offer much flexibility.

Includes #810