### PR TITLE
adding parameter snapshot-source to validate image

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -48,10 +48,10 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		certificateOIDCIssuer       string
 		certificateOIDCIssuerRegExp string
 		effectiveTime               string
-		filePath                    string
+		filePath                    string // Deprecated: images replaced this
 		imageRef                    string
 		info                        bool
-		input                       string
+		input                       string // Deprecated: images replaced this
 		output                      []string
 		outputFile                  string
 		policy                      policy.Policy
@@ -102,11 +102,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 
 			Validate multiple images from an ApplicationSnapshot Spec file:
 
-			  ec validate image --file-path my-app.yaml
+			  ec validate image --images my-app.yaml
 
 			Validate attestation of images from an inline ApplicationSnapshot Spec:
 
-			  ec validate image --json-input '{"components":[{"containerImage":"<image url>"}]}'
+			  ec validate image --images '{"components":[{"containerImage":"<image url>"}]}'
 
 			Use a different public key than the one from the EnterpriseContractPolicy resource:
 
@@ -156,6 +156,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			Write the data used in the policy evaluation to a file in YAML format
 
 			  ec validate image --image registry/name:tag --output data=<path>
+			  
 
 
 			Validate a single image with keyless workflow. This is an experimental feature
@@ -370,9 +371,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	cmd.Flags().StringVar(&data.certificateOIDCIssuerRegExp, "certificate-oidc-issuer-regexp", data.certificateOIDCIssuerRegExp,
 		"EXPERIMENTAL. Regular expresssion for the URL of the certificate OIDC issuer for keyless verification")
 
+	// Deprecated: images replaced this
 	cmd.Flags().StringVarP(&data.filePath, "file-path", "f", data.filePath,
 		"path to ApplicationSnapshot Spec JSON file")
 
+	// Deprecated: images replaced this
 	cmd.Flags().StringVarP(&data.input, "json-input", "j", data.input,
 		"JSON representation of an ApplicationSnapshot Spec")
 
@@ -407,7 +410,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		violations, include the title and the description of the failed policy
 		rule.`))
 
-	if len(data.input) > 0 || len(data.filePath) > 0 {
+	if len(data.input) > 0 || len(data.filePath) > 0 || len(data.images) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {
 			panic(err)
 		}

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -61,6 +61,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		snapshot                    string
 		spec                        *app.SnapshotSpec
 		strict                      bool
+		snapshotSource              string
 	}{
 
 		// Default policy from an ECP cluster resource
@@ -177,10 +178,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
 			ctx := cmd.Context()
 			if s, err := applicationsnapshot.DetermineInputSpec(ctx, applicationsnapshot.Input{
-				File:     data.filePath,
-				JSON:     data.input,
-				Image:    data.imageRef,
-				Snapshot: data.snapshot,
+				File:           data.filePath,
+				JSON:           data.input,
+				Image:          data.imageRef,
+				Snapshot:       data.snapshot,
+				SnapshotSource: data.snapshotSource,
 			}); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
@@ -373,6 +375,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 
 	cmd.Flags().StringVarP(&data.input, "json-input", "j", data.input,
 		"JSON representation of an ApplicationSnapshot Spec")
+
+	cmd.Flags().StringVarP(&data.snapshotSource, "snapshot-source", "a", data.snapshotSource,
+		"path to ApplicationSnapshot Spec JSON file or JSON representation of an ApplicationSnapshot Spec")
 
 	cmd.Flags().StringSliceVar(&data.output, "output", data.output, hd.Doc(`
 		write output to a file in a specific format. Use empty string path for stdout.

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -61,7 +61,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		snapshot                    string
 		spec                        *app.SnapshotSpec
 		strict                      bool
-		snapshotSource              string
+		images                      string
 	}{
 
 		// Default policy from an ECP cluster resource
@@ -178,11 +178,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
 			ctx := cmd.Context()
 			if s, err := applicationsnapshot.DetermineInputSpec(ctx, applicationsnapshot.Input{
-				File:           data.filePath,
-				JSON:           data.input,
-				Image:          data.imageRef,
-				Snapshot:       data.snapshot,
-				SnapshotSource: data.snapshotSource,
+				File:     data.filePath,
+				JSON:     data.input,
+				Image:    data.imageRef,
+				Snapshot: data.snapshot,
+				Images:   data.images,
 			}); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
@@ -376,7 +376,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	cmd.Flags().StringVarP(&data.input, "json-input", "j", data.input,
 		"JSON representation of an ApplicationSnapshot Spec")
 
-	cmd.Flags().StringVarP(&data.snapshotSource, "snapshot-source", "a", data.snapshotSource,
+	cmd.Flags().StringVar(&data.images, "images", data.images,
 		"path to ApplicationSnapshot Spec JSON file or JSON representation of an ApplicationSnapshot Spec")
 
 	cmd.Flags().StringSliceVar(&data.output, "output", data.output, hd.Doc(`

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -41,10 +41,10 @@ import (
 )
 
 type data struct {
-	imageRef       string
-	input          string
-	filePath       string
-	snapshotSource string
+	imageRef string
+	input    string
+	filePath string
+	images   string
 }
 
 func Test_determineInputSpec(t *testing.T) {
@@ -83,9 +83,9 @@ func Test_determineInputSpec(t *testing.T) {
 			err: "unable to parse Snapshot specification from {: error converting YAML to JSON: yaml: line 1: did not find expected node content",
 		},
 		{
-			name: "ApplicationSnapshot JSON string - snapshotSource",
+			name: "ApplicationSnapshot JSON string - images",
 			arguments: data{
-				snapshotSource: `{
+				images: `{
 					"components": [
 					  {
 						"name": "nodejs",
@@ -200,9 +200,9 @@ func Test_determineInputSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "ApplicationSnapshot file - snapshotSource",
+			name: "ApplicationSnapshot file - images",
 			arguments: data{
-				snapshotSource: "test_application_snapshot.json",
+				images: "test_application_snapshot.json",
 			},
 			spec: &app.SnapshotSpec{
 				Application: "app1",
@@ -227,10 +227,10 @@ func Test_determineInputSpec(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			s, err := applicationsnapshot.DetermineInputSpec(context.Background(), applicationsnapshot.Input{
-				File:           c.arguments.filePath,
-				JSON:           c.arguments.input,
-				Image:          c.arguments.imageRef,
-				SnapshotSource: c.arguments.snapshotSource,
+				File:   c.arguments.filePath,
+				JSON:   c.arguments.input,
+				Image:  c.arguments.imageRef,
+				Images: c.arguments.images,
 			})
 			if c.err != "" {
 				assert.EqualError(t, err, c.err)

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -34,8 +34,8 @@ import (
 const unnamed = "Unnamed"
 
 type Input struct {
-	File     string
-	JSON     string
+	File     string // Deprecated: replaced by images
+	JSON     string // Deprecated: replaced by images
 	Image    string
 	Snapshot string
 	Images   string

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -34,11 +34,11 @@ import (
 const unnamed = "Unnamed"
 
 type Input struct {
-	File           string
-	JSON           string
-	Image          string
-	Snapshot       string
-	SnapshotSource string
+	File     string
+	JSON     string
+	Image    string
+	Snapshot string
+	Images   string
 }
 
 type snapshot struct {
@@ -82,18 +82,18 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 	var snapshot snapshot
 	provided := false
 
-	if input.SnapshotSource != "" {
+	if input.Images != "" {
 		var content []byte
 		var err error
 		fs := utils.FS(ctx)
-		content, err = afero.ReadFile(fs, input.SnapshotSource)
+		content, err = afero.ReadFile(fs, input.Images)
 		if err != nil {
-			log.Debugf("could not read --snapshot-source as a file: %v", err)
+			log.Debugf("could not read images from file: %v", err)
 			// could not read as file so expecting string
-			content = []byte(input.SnapshotSource)
+			content = []byte(input.Images)
 		}
 
-		file, err := readSnapshotFile(content)
+		file, err := readSnapshotSource(content)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 		if err != nil {
 			return nil, err
 		}
-		file, err := readSnapshotFile(content)
+		file, err := readSnapshotSource(content)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 
 	// read Snapshot provided as a string
 	if input.JSON != "" {
-		json, err := readSnapshotFile([]byte(input.JSON))
+		json, err := readSnapshotSource([]byte(input.JSON))
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 	return &snapshot.SnapshotSpec, nil
 }
 
-func readSnapshotFile(input []byte) (app.SnapshotSpec, error) {
+func readSnapshotSource(input []byte) (app.SnapshotSpec, error) {
 	var file app.SnapshotSpec
 	err := yaml.Unmarshal(input, &file)
 	if err != nil {

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -34,10 +34,11 @@ import (
 const unnamed = "Unnamed"
 
 type Input struct {
-	File     string
-	JSON     string
-	Image    string
-	Snapshot string
+	File           string
+	JSON           string
+	Image          string
+	Snapshot       string
+	SnapshotSource string
 }
 
 type snapshot struct {
@@ -81,37 +82,46 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 	var snapshot snapshot
 	provided := false
 
+	if input.SnapshotSource != "" {
+		var content []byte
+		var err error
+		fs := utils.FS(ctx)
+		content, err = afero.ReadFile(fs, input.SnapshotSource)
+		if err != nil {
+			log.Debugf("could not read --snapshot-source as a file: %v", err)
+			// could not read as file so expecting string
+			content = []byte(input.SnapshotSource)
+		}
+
+		file, err := readSnapshotFile(content)
+		if err != nil {
+			return nil, err
+		}
+		snapshot.merge(file)
+		provided = true
+	}
+
 	// read Snapshot provided as a file
 	if input.File != "" {
 		fs := utils.FS(ctx)
 		content, err := afero.ReadFile(fs, input.File)
 		if err != nil {
-			log.Debugf("Problem reading application snapshot from file %s", input.File)
 			return nil, err
 		}
-
-		var file app.SnapshotSpec
-		err = yaml.Unmarshal(content, &file)
+		file, err := readSnapshotFile(content)
 		if err != nil {
-			log.Debugf("Problem parsing application snapshot from file %s", input.File)
-			return nil, fmt.Errorf("unable to parse Snapshot specification from %s: %w", input.File, err)
+			return nil, err
 		}
-
-		log.Debugf("Read application snapshot from file %s", input.File)
 		snapshot.merge(file)
 		provided = true
 	}
 
 	// read Snapshot provided as a string
 	if input.JSON != "" {
-		var json app.SnapshotSpec
-		// Unmarshall YAML into struct, exit on failure
-		if err := yaml.Unmarshal([]byte(input.JSON), &json); err != nil {
-			log.Debugf("Problem parsing application snapshot from input param %s", input.JSON)
-			return nil, fmt.Errorf("unable to parse Snapshot specification from input: %w", err)
+		json, err := readSnapshotFile([]byte(input.JSON))
+		if err != nil {
+			return nil, err
 		}
-
-		log.Debug("Read application snapshot from input param")
 		snapshot.merge(json)
 		provided = true
 	}
@@ -153,4 +163,16 @@ func DetermineInputSpec(ctx context.Context, input Input) (*app.SnapshotSpec, er
 	}
 
 	return &snapshot.SnapshotSpec, nil
+}
+
+func readSnapshotFile(input []byte) (app.SnapshotSpec, error) {
+	var file app.SnapshotSpec
+	err := yaml.Unmarshal(input, &file)
+	if err != nil {
+		log.Debugf("Problem parsing application snapshot from file %s", input)
+		return app.SnapshotSpec{}, fmt.Errorf("unable to parse Snapshot specification from %s: %w", input, err)
+	}
+
+	log.Debugf("Read application snapshot from file %s", input)
+	return file, nil
 }

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -81,12 +81,12 @@ func Test_DetermineInputSpec(t *testing.T) {
 		},
 		{
 			name:  "snapShotSource as a string",
-			input: Input{SnapshotSource: string(testJson)},
+			input: Input{Images: string(testJson)},
 			want:  snapshot,
 		},
 		{
 			name:  "snapShotSource as a file",
-			input: Input{SnapshotSource: "/home/list-of-images.json"},
+			input: Input{Images: "/home/list-of-images.json"},
 			want:  snapshot,
 		},
 		{
@@ -158,8 +158,8 @@ func Test_DetermineInputSpec(t *testing.T) {
 				}
 			}
 
-			if tc.input.SnapshotSource == "/home/list-of-images.json" {
-				if err := afero.WriteFile(fs, tc.input.SnapshotSource, []byte(testJson), 0400); err != nil {
+			if tc.input.Images == "/home/list-of-images.json" {
+				if err := afero.WriteFile(fs, tc.input.Images, []byte(testJson), 0400); err != nil {
 					panic(err)
 				}
 			}
@@ -199,7 +199,7 @@ func TestReadSnapshotFile(t *testing.T) {
 
 		content, err := afero.ReadFile(fs, "/correct.json")
 		assert.NoError(t, err)
-		got, err := readSnapshotFile(content)
+		got, err := readSnapshotSource(content)
 		assert.Equal(t, snapshotSpec, got)
 		assert.NoError(t, err)
 	})
@@ -216,7 +216,7 @@ func TestReadSnapshotFile(t *testing.T) {
 
 		content, err := afero.ReadFile(fs, specFile)
 		assert.NoError(t, err)
-		_, err = readSnapshotFile(content)
+		_, err = readSnapshotSource(content)
 		expected := errors.New("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1alpha1.SnapshotSpec")
 		assert.Equal(t, fmt.Errorf("unable to parse Snapshot specification from %s: %w", spec, expected), err)
 	})

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -21,6 +21,8 @@ package applicationsnapshot
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -76,6 +78,16 @@ func Test_DetermineInputSpec(t *testing.T) {
 		{
 			name: "nothing",
 			want: nil,
+		},
+		{
+			name:  "snapShotSource as a string",
+			input: Input{SnapshotSource: string(testJson)},
+			want:  snapshot,
+		},
+		{
+			name:  "snapShotSource as a file",
+			input: Input{SnapshotSource: "/home/list-of-images.json"},
+			want:  snapshot,
 		},
 		{
 			name: "combined (all same)",
@@ -146,6 +158,12 @@ func Test_DetermineInputSpec(t *testing.T) {
 				}
 			}
 
+			if tc.input.SnapshotSource == "/home/list-of-images.json" {
+				if err := afero.WriteFile(fs, tc.input.SnapshotSource, []byte(testJson), 0400); err != nil {
+					panic(err)
+				}
+			}
+
 			got, err := DetermineInputSpec(ctx, tc.input)
 			// expect an error so check for nil
 			if tc.want != nil {
@@ -154,4 +172,53 @@ func Test_DetermineInputSpec(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestReadSnapshotFile(t *testing.T) {
+
+	t.Run("Successful file read and unmarshal", func(t *testing.T) {
+		snapshotSpec := app.SnapshotSpec{
+			Components: []app.SnapshotComponent{
+				{
+					Name:           "Named",
+					ContainerImage: "",
+				},
+				{
+					Name:           "Set name",
+					ContainerImage: "registry.io/repository/image:another",
+				},
+			},
+		}
+		fs := afero.NewMemMapFs()
+		spec := `{"components":[{"name": "Named", "containerImage":""},{"name": "Set name", "containerImage":"registry.io/repository/image:another"}]}`
+
+		err := afero.WriteFile(fs, "/correct.json", []byte(spec), 0644)
+		if err != nil {
+			t.Fatalf("Setup failure: could not write file: %v", err)
+		}
+
+		content, err := afero.ReadFile(fs, "/correct.json")
+		assert.NoError(t, err)
+		got, err := readSnapshotFile(content)
+		assert.Equal(t, snapshotSpec, got)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid Spec", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		spec := `bad spec`
+		specFile := "/badSpec.json"
+
+		err := afero.WriteFile(fs, specFile, []byte(spec), 0644)
+		if err != nil {
+			t.Fatalf("Setup failure: could not write file: %v", err)
+		}
+
+		content, err := afero.ReadFile(fs, specFile)
+		assert.NoError(t, err)
+		_, err = readSnapshotFile(content)
+		expected := errors.New("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1alpha1.SnapshotSpec")
+		assert.Equal(t, fmt.Errorf("unable to parse Snapshot specification from %s: %w", spec, expected), err)
+	})
+
 }

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -99,6 +99,11 @@ spec:
       description: Run policy checks with the provided time.
       default: "now"
 
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+      optional: true
+
   results:
     - name: TEST_OUTPUT
       description: Short summary of the policy evaluation for each image
@@ -137,7 +142,7 @@ spec:
         - validate
         - image
         - "--verbose"
-        - "--json-input"
+        - "--snapshot-source"
         - "$(params.IMAGES)"
         - "--policy"
         - "$(params.POLICY_CONFIGURATION)"

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -142,7 +142,7 @@ spec:
         - validate
         - image
         - "--verbose"
-        - "--snapshot-source"
+        - "--images"
         - "$(params.IMAGES)"
         - "--policy"
         - "$(params.POLICY_CONFIGURATION)"


### PR DESCRIPTION
This new param supports the snapshot spec as a JSON string or a file path to a valid spec.

Resolves: https://issues.redhat.com/browse/HACBS-2329