### PR TITLE
Add new policy-input output format

### DIFF
--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -300,7 +300,11 @@ func setupRegistry(ctx context.Context, vars map[string]string, environment []st
 	}
 
 	for repositoryAndTag, hash := range hashes {
-		vars[fmt.Sprintf("REGISTRY_%s_HASH", repositoryAndTag)] = hash
+		_, digest, found := strings.Cut(hash, ":")
+		if !found {
+			return environment, vars, fmt.Errorf("hash %q does not contain digest", hash)
+		}
+		vars[fmt.Sprintf("REGISTRY_%s_DIGEST", repositoryAndTag)] = digest
 	}
 
 	return environment, vars, nil

--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -3,12 +3,12 @@
 /-/-/-/
 pipeline-bundles:
   ${REGISTRY}/acceptance/bundle:
-    - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
       effective_on: "${TIMESTAMP}"
       tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
-    - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
       effective_on: "${TIMESTAMP}"
       tag: tag
 

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -4,7 +4,7 @@
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -76,7 +76,7 @@
 ---
 
 [JUnit output format:stdout - 1]
-<testsuites tests="5" failures="1"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH})" tests="5" failures="1" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
+<testsuites tests="5" failures="1"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="5" failures="1" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
 ---
 
 [JUnit output format:stderr - 1]
@@ -90,7 +90,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -181,7 +181,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -258,7 +258,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -335,7 +335,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "warnings": [
         {
@@ -414,7 +414,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -495,7 +495,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-multiple-sources@${REGISTRY_acceptance/ec-multiple-sources:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-multiple-sources@sha256:${REGISTRY_acceptance/ec-multiple-sources:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -596,7 +596,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/bad-actor@${REGISTRY_acceptance/bad-actor:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/bad-actor@sha256:${REGISTRY_acceptance/bad-actor:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -669,7 +669,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -763,7 +763,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Happy",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -839,7 +839,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-multiple-sources@${REGISTRY_acceptance/ec-multiple-sources:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-multiple-sources@sha256:${REGISTRY_acceptance/ec-multiple-sources:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -932,7 +932,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/unexpected-keyless-cert@${REGISTRY_acceptance/unexpected-keyless-cert:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/unexpected-keyless-cert@sha256:${REGISTRY_acceptance/unexpected-keyless-cert:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -978,7 +978,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/invalid-image-signature@${REGISTRY_acceptance/invalid-image-signature:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/invalid-image-signature@sha256:${REGISTRY_acceptance/invalid-image-signature:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1025,7 +1025,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1123,7 +1123,7 @@ Error: 1 error occurred:
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1202,7 +1202,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Happy",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1278,7 +1278,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day-keyless@${REGISTRY_acceptance/ec-happy-day-keyless:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day-keyless@sha256:${REGISTRY_acceptance/ec-happy-day-keyless:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1408,7 +1408,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/bad-actor@${REGISTRY_acceptance/bad-actor:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/bad-actor@sha256:${REGISTRY_acceptance/bad-actor:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1456,7 +1456,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/destination@${REGISTRY_IMAGE_acceptance/destination:latest|acceptance/source:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/destination@sha256:${REGISTRY_IMAGE_acceptance/destination:latest|acceptance/source:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1532,7 +1532,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1634,7 +1634,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1714,7 +1714,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/my-image@${REGISTRY_acceptance/my-image:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/my-image@sha256:${REGISTRY_acceptance/my-image:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1806,7 +1806,7 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:29: rego_type_error: undefi
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@${REGISTRY_acceptance/ec-happy-day:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -1883,7 +1883,7 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:29: rego_type_error: undefi
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -1970,7 +1970,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/unique-successes@${REGISTRY_acceptance/unique-successes:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/unique-successes@sha256:${REGISTRY_acceptance/unique-successes:latest_DIGEST}",
       "source": {},
       "violations": [
         {
@@ -2075,7 +2075,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/image-config@${REGISTRY_acceptance/image-config:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/image-config@sha256:${REGISTRY_acceptance/image-config:latest_DIGEST}",
       "source": {},
       "successes": [
         {
@@ -2176,7 +2176,7 @@ Error: success criteria not met
   "components": [
     {
       "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/image@${REGISTRY_acceptance/image:latest_HASH}",
+      "containerImage": "${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}",
       "source": {},
       "success": true,
       "signatures": [
@@ -2221,5 +2221,87 @@ Error: success criteria not met
 ---
 
 [Output attestations:${TMPDIR}/attestation.jsonl - 1]
-{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"acceptance/image","digest":${REGISTRY_acceptance/image:latest_JSON_HASH}}],"predicate":{"builder":{"id":"https://tekton.dev/chains/v2"},"buildType":"https://tekton.dev/attestations/chains/pipelinerun@v2","invocation":{"configSource":{}}}}
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v0.2",
+  "subject": [
+    {
+      "name": "acceptance/image",
+      "digest": {
+        "sha256": "${REGISTRY_acceptance/image:latest_DIGEST}"
+      }
+    }
+  ],
+  "predicate": {
+    "builder": {
+      "id": "https://tekton.dev/chains/v2"
+    },
+    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+    "invocation": {
+      "configSource": {}
+    }
+  }
+}
+---
+
+[policy input output:stdout - 1]
+{
+  "attestations": [
+    {
+      "_type": "https://in-toto.io/Statement/v0.1",
+      "predicateType": "https://slsa.dev/provenance/v0.2",
+      "subject": [
+        {
+          "name": "acceptance/policy-input-output",
+          "digest": {
+            "sha256": "${REGISTRY_acceptance/policy-input-output:latest_DIGEST}"
+          }
+        }
+      ],
+      "predicate": {
+        "builder": {
+          "id": "https://tekton.dev/chains/v2"
+        },
+        "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+        "invocation": {
+          "configSource": {}
+        }
+      },
+      "extra": {
+        "signatures": [
+          {
+            "keyid": "",
+            "sig": "${ATTESTATION_SIGNATURE_acceptance/policy-input-output}"
+          }
+        ]
+      }
+    }
+  ],
+  "image": {
+    "ref": "${REGISTRY}/acceptance/policy-input-output@sha256:${REGISTRY_acceptance/policy-input-output:latest_DIGEST}",
+    "signatures": [
+      {
+        "keyid": "",
+        "sig": "${IMAGE_SIGNATURE_acceptance/policy-input-output}"
+      }
+    ],
+    "config": {
+      "Labels": {
+        "org.opencontainers.image.title": "acceptance/policy-input-output"
+      }
+    },
+    "parent": {
+      "ref": "${REGISTRY}/acceptance/policy-input-output/parent:latest@sha256:${REGISTRY_acceptance/policy-input-output/parent:latest_DIGEST}",
+      "config": {
+        "Labels": {
+          "org.opencontainers.image.title": "acceptance/policy-input-output/parent"
+        }
+      }
+    }
+  }
+}
+---
+
+[policy input output:stderr - 1]
+
 ---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -739,3 +739,21 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     And the output should match the snapshot
     And the "${TMPDIR}/attestation.jsonl" file should match the snapshot
+
+ Scenario: policy input output
+    Given a key pair named "known"
+    Given an image named "acceptance/policy-input-output"
+    Given a valid image signature of "acceptance/policy-input-output" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/policy-input-output"
+    Given a valid attestation of "acceptance/policy-input-output" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/policy-input-output"
+    Given a git repository named "policy-input-output-policy" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {"sources": [{"policy": ["git::https://${GITHOST}/git/policy-input-output-policy.git"]}]}
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/policy-input-output --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --output policy-input"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -248,18 +248,20 @@ func TestWriteInputFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			ctx := utils.WithFS(context.Background(), fs)
-			input, err := tt.snapshot.WriteInputFile(ctx)
+			inputPath, inputJSON, err := tt.snapshot.WriteInputFile(ctx)
 
 			assert.NoError(t, err)
-			assert.NotEmpty(t, input)
-			assert.Regexp(t, `/ecp_input.\d+/input.json`, input)
-			fileExists, err := afero.Exists(fs, input)
+			assert.NotEmpty(t, inputPath)
+			assert.Regexp(t, `/ecp_input.\d+/input.json`, inputPath)
+			fileExists, err := afero.Exists(fs, inputPath)
 			assert.NoError(t, err)
 			assert.True(t, fileExists)
 
-			bytes, err := afero.ReadFile(fs, input)
+			bytes, err := afero.ReadFile(fs, inputPath)
 			assert.NoError(t, err)
 			snaps.MatchJSON(t, bytes)
+
+			assert.JSONEq(t, string(inputJSON), string(bytes))
 		})
 	}
 }
@@ -273,18 +275,20 @@ func TestWriteInputFileMultipleAttestations(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	ctx := utils.WithFS(context.Background(), fs)
-	input, err := a.WriteInputFile(ctx)
+	inputPath, inputJSON, err := a.WriteInputFile(ctx)
 
 	assert.NoError(t, err)
-	assert.NotEmpty(t, input)
-	assert.Regexp(t, `/ecp_input.\d+/input.json`, input)
-	fileExists, err := afero.Exists(fs, input)
+	assert.NotEmpty(t, inputPath)
+	assert.Regexp(t, `/ecp_input.\d+/input.json`, inputPath)
+	fileExists, err := afero.Exists(fs, inputPath)
 	assert.NoError(t, err)
 	assert.True(t, fileExists)
 
-	bytes, err := afero.ReadFile(fs, input)
+	bytes, err := afero.ReadFile(fs, inputPath)
 	assert.NoError(t, err)
 	snaps.MatchJSON(t, bytes)
+
+	assert.JSONEq(t, string(inputJSON), string(bytes))
 }
 
 func TestSyntaxValidationWithoutAttestations(t *testing.T) {

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -99,7 +99,7 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 		return out, nil
 	}
 
-	input, err := a.WriteInputFile(ctx)
+	inputPath, inputJSON, err := a.WriteInputFile(ctx)
 	if err != nil {
 		log.Debug("Problem writing input files!")
 		return nil, err
@@ -108,7 +108,7 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 	var allResults evaluator.CheckResults
 	for _, e := range a.Evaluators {
 		// Todo maybe: Handle each one concurrently
-		results, data, err := e.Evaluate(ctx, []string{input})
+		results, data, err := e.Evaluate(ctx, []string{inputPath})
 		defer e.Destroy()
 
 		if err != nil {
@@ -118,6 +118,8 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 		allResults = append(allResults, results...)
 		out.Data = append(out.Data, data)
 	}
+
+	out.PolicyInput = inputJSON
 
 	log.Debug("Conftest policy check complete")
 	out.SetPolicyCheck(allResults)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -88,6 +88,7 @@ type Output struct {
 	Detailed                  bool                        `json:"-"`
 	Data                      []evaluator.Data            `json:"-"`
 	Policy                    policy.Policy               `json:"-"`
+	PolicyInput               []byte                      `json:"-"`
 }
 
 // SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.


### PR DESCRIPTION
The policy-input format exports the image data that is provided to the policy as `input` in the `validate image` command. Given that multiple images can be validated at the same time, and that ec generates a unique `input` for each image, the output is in the JSONL format. A policy, however, only sees one of the objects at a time.

This PR also changes the variables `REGISTRY_*_HASH` to `REGISTRY_*_DIGEST` in the acceptance tests. The value of this new variable does not include the algorithm, i.e. `sha256`. This is needed because the image-data output contains fields where only the digest is present, without the algorithm. Having both variables is problematic because their values overlap. This means that whether or not the value is replaced with one vs the other is not deterministic.

https://issues.redhat.com/browse/HACBS-2393