### PR TITLE
Rework key/signature variables

### DIFF
--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -213,11 +213,7 @@ func setupKeys(ctx context.Context, vars map[string]string, environment []string
 
 		vars[name+"_PUBLIC_KEY"] = key.Name()
 
-		publicKeyJson, err := json.Marshal(publicKey)
-		if err != nil {
-			return environment, vars, err
-		}
-		vars[name+"_PUBLIC_KEY_JSON"] = string(publicKeyJson)
+		vars[name+"_PUBLIC_KEY_JSON"] = strings.ReplaceAll(publicKey, "\n", "\\n")
 
 		publicKeyXML := bytes.Buffer{}
 		if err := xml.EscapeText(&publicKeyXML, []byte(publicKey)); err != nil {
@@ -246,10 +242,8 @@ func setupSigs(ctx context.Context, vars map[string]string, environment []string
 	}
 
 	for n, v := range map[string]valFunc{
-		"ATTESTATION_SIGNATURE":      image.JSONAttestationSignaturesFrom,
-		"ATTESTATION_SIGNATURES_XML": image.XMLAttestationSignaturesFrom,
-		"IMAGE_SIGNATURE":            image.JSONImageSignaturesFrom,
-		"IMAGE_SIGNATURES_XML":       image.XMLImageSignaturesFrom,
+		"ATTESTATION_SIGNATURE": image.AttestationSignaturesFrom,
+		"IMAGE_SIGNATURE":       image.ImageSignaturesFrom,
 	} {
 		if err := setVar(n, v); err != nil {
 			return environment, vars, err

--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -95,15 +95,7 @@ func MatchSnapshot(ctx context.Context, qualifier, text string, vars map[string]
 	errs := capture(ctx, qualifier)
 
 	for k, v := range vars {
-		// Todo: remove ASAP. Just a hack until a solution is figured out
-		if k == "IMAGE_SIGNATURES_XML_acceptance/image" {
-			continue
-		}
-		if k == "known_PUBLIC_KEY_JSON" || k == "unknown_PUBLIC_KEY_JSON" {
-			text = strings.ReplaceAll(text, v, "\"${"+k+"}\"")
-		} else {
-			text = strings.ReplaceAll(text, v, "${"+k+"}")
-		}
+		text = strings.ReplaceAll(text, v, "${"+k+"}")
 	}
 
 	// replace any remaining timestamps


### PR DESCRIPTION
This reworks the replacement variables in acceptance tests and removes the special cases for JSON and XML. Given that only values are replaced we no longer need to render the whole JSON/XML structure.