### PR TITLE
Tweak the licence preamble

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release-antora-extension.yaml
+++ b/.github/workflows/release-antora-extension.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ALL_SUPPORTED_IMG_OS_ARCH:=$(filter-out $(UNSUPPORTED_OS_ARCH_IMG),$(subst dist/
 _SHELL := bash
 SHELL=$(if $@,$(info ❱ [1m$@[0m))$(_SHELL)
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-COPY:="Red Hat, Inc."
+COPY:=The Enterprise Contract Contributors
 COSIGN_VERSION=$(shell go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2)
 
 ##@ Information
@@ -127,9 +127,9 @@ LINT_TO_GITHUB_ANNOTATIONS='map(map(.)[])[][] as $$d | $$d.posn | split(":") as 
 .PHONY: lint
 lint: tekton-lint ## Run linter
 # addlicense doesn't give us a nice explanation so we prefix it with one
-	@go run -modfile tools/go.mod github.com/google/addlicense -c $(COPY) -s -check $(LICENSE_IGNORE) . | sed 's/^/Missing license header in: /g'
+	@go run -modfile tools/go.mod github.com/google/addlicense -c '$(COPY)' -y '' -s -check $(LICENSE_IGNORE) . | sed 's/^/Missing license header in: /g'
 # piping to sed above looses the exit code, luckily addlicense is fast so we invoke it for the second time to exit 1 in case of issues
-	@go run -modfile tools/go.mod github.com/google/addlicense -c $(COPY) -s -check $(LICENSE_IGNORE) . >/dev/null 2>&1
+	@go run -modfile tools/go.mod github.com/google/addlicense -c '$(COPY)' -y '' -s -check $(LICENSE_IGNORE) . >/dev/null 2>&1
 	@go run -modfile tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --sort-results $(if $(GITHUB_ACTIONS), --out-format=github-actions --timeout=10m0s)
 	@(cd acceptance && go run -modfile ../tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --path-prefix acceptance --sort-results $(if $(GITHUB_ACTIONS), --out-format=github-actions --timeout=10m0s))
 # We don't fail on the internal (error handling) linter, we just report the
@@ -139,7 +139,7 @@ lint: tekton-lint ## Run linter
 
 .PHONY: lint-fix
 lint-fix: ## Fix linting issues automagically
-	@go run -modfile tools/go.mod github.com/google/addlicense -c $(COPY) -s $(LICENSE_IGNORE) .
+	@go run -modfile tools/go.mod github.com/google/addlicense -c '$(COPY)' -y '' -s $(LICENSE_IGNORE) .
 	@go run -modfile tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --fix
 	@(cd acceptance && go run -modfile ../tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --path-prefix acceptance --fix)
 # We don't apply the fixes from the internal (error handling) linter.

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/attestation/attestation.go
+++ b/acceptance/attestation/attestation.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/cli/cli_test.go
+++ b/acceptance/cli/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/conftest/conftest.go
+++ b/acceptance/conftest/conftest.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/crypto/keys.go
+++ b/acceptance/crypto/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/git/git.go
+++ b/acceptance/git/git.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/kind/image.go
+++ b/acceptance/kubernetes/kind/image.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/kind/kind.go
+++ b/acceptance/kubernetes/kind/kind.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/kind/kubernetes.go
+++ b/acceptance/kubernetes/kind/kubernetes.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/kubernetes.go
+++ b/acceptance/kubernetes/kubernetes.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/kubernetes_test.go
+++ b/acceptance/kubernetes/kubernetes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/stub/stub.go
+++ b/acceptance/kubernetes/stub/stub.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kubernetes/types/types.go
+++ b/acceptance/kubernetes/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/kustomize/kustomize.go
+++ b/acceptance/kustomize/kustomize.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/log/log.go
+++ b/acceptance/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/pipeline/pipeline_definition.go
+++ b/acceptance/pipeline/pipeline_definition.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/registry/registry.go
+++ b/acceptance/registry/registry.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/rekor/rekor.go
+++ b/acceptance/rekor/rekor.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/tekton/bundles.go
+++ b/acceptance/tekton/bundles.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/testenv/testenv.go
+++ b/acceptance/testenv/testenv.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/testenv/testenv_test.go
+++ b/acceptance/testenv/testenv_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/acceptance/wiremock/wiremock.go
+++ b/acceptance/wiremock/wiremock.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/fetch/fetch_k8s_resource.go
+++ b/cmd/fetch/fetch_k8s_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/fetch/fetch_policy.go
+++ b/cmd/fetch/fetch_policy.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/inspect/inspect_policy.go
+++ b/cmd/inspect/inspect_policy.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/inspect/inspect_policy_data.go
+++ b/cmd/inspect/inspect_policy_data.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/track/track.go
+++ b/cmd/track/track.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/track/track_bundle.go
+++ b/cmd/track/track_bundle.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/track/track_bundle_test.go
+++ b/cmd/track/track_bundle_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validate/definition.go
+++ b/cmd/validate/definition.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/chains/chains.sh
+++ b/hack/chains/chains.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/chains/chains.yaml
+++ b/hack/chains/chains.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/chains/kustomization.yaml
+++ b/hack/chains/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/chains/secrets.yaml
+++ b/hack/chains/secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/development/kustomization.yaml
+++ b/hack/development/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ecc/ecc.sh
+++ b/hack/ecc/ecc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ecc/ecc.yaml
+++ b/hack/ecc/ecc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ecc/kustomization.yaml
+++ b/hack/ecc/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ecc/permissions.yaml
+++ b/hack/ecc/permissions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/pipeline-demo.sh
+++ b/hack/pipeline-demo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/registry/kustomization.yaml
+++ b/hack/registry/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/registry/namespace.yaml
+++ b/hack/registry/namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/registry/registry.sh
+++ b/hack/registry/registry.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/registry/registry.yaml
+++ b/hack/registry/registry.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/setup-dev-environment.sh
+++ b/hack/setup-dev-environment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/setup-test-environment.sh
+++ b/hack/setup-test-environment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/tekton/kustomization.yaml
+++ b/hack/tekton/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/tekton/tekton.sh
+++ b/hack/tekton/tekton.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/tekton/tekton.yaml
+++ b/hack/tekton/tekton.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/test/kustomization.yaml
+++ b/hack/test/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/work/kustomization.yaml
+++ b/hack/work/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/work/permissions.yaml
+++ b/hack/work/permissions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/work/secrets.yaml
+++ b/hack/work/secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/work/work.sh
+++ b/hack/work/work.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 

--- a/hack/work/work.yaml
+++ b/hack/work/work.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/definition/validate.go
+++ b/internal/definition/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/documentation/documentation.go
+++ b/internal/documentation/documentation.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluation_target/application_snapshot_image/client.go
+++ b/internal/evaluation_target/application_snapshot_image/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluation_target/definition/definition.go
+++ b/internal/evaluation_target/definition/definition.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/format/target.go
+++ b/internal/format/target.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/format/target_test.go
+++ b/internal/format/target_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/authorization.go
+++ b/internal/image/authorization.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/authorization_test.go
+++ b/internal/image/authorization_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/process.go
+++ b/internal/image/process.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/process_test.go
+++ b/internal/image/process_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/kubernetes/names.go
+++ b/internal/kubernetes/names.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/kubernetes/names_test.go
+++ b/internal/kubernetes/names_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/ec.go
+++ b/internal/lint/ec.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/ec_test.go
+++ b/internal/lint/ec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/error.go
+++ b/internal/lint/error.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/error_test.go
+++ b/internal/lint/error_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/current/existing.go
+++ b/internal/lint/testdata/current/existing.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/01_add_new.go
+++ b/internal/lint/testdata/returns/01_add_new.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/01_add_new.go.golden
+++ b/internal/lint/testdata/returns/01_add_new.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/02_simple.go
+++ b/internal/lint/testdata/returns/02_simple.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/02_simple.go.golden
+++ b/internal/lint/testdata/returns/02_simple.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/03_has_import.go
+++ b/internal/lint/testdata/returns/03_has_import.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/03_has_import.go.golden
+++ b/internal/lint/testdata/returns/03_has_import.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/04_nothing.go
+++ b/internal/lint/testdata/returns/04_nothing.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/05_vars.go
+++ b/internal/lint/testdata/returns/05_vars.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/05_vars.go.golden
+++ b/internal/lint/testdata/returns/05_vars.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/06_no_imports.go
+++ b/internal/lint/testdata/returns/06_no_imports.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/06_no_imports.go.golden
+++ b/internal/lint/testdata/returns/06_no_imports.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/07_a_test.go
+++ b/internal/lint/testdata/returns/07_a_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/08_errorf.go
+++ b/internal/lint/testdata/returns/08_errorf.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/08_errorf.go.golden
+++ b/internal/lint/testdata/returns/08_errorf.go.golden
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lint/testdata/returns/no_import_error.go
+++ b/internal/lint/testdata/returns/no_import_error.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/inspect.go
+++ b/internal/opa/inspect.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/inspect_test.go
+++ b/internal/opa/inspect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/output.go
+++ b/internal/opa/output.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/source/git_config.go
+++ b/internal/policy/source/git_config.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/source/git_config_test.go
+++ b/internal/policy/source/git_config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/signature/certificate.go
+++ b/internal/signature/certificate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/signature/certificate_test.go
+++ b/internal/signature/certificate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/signature/signature.go
+++ b/internal/signature/signature.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/test_data/pipeline_definitions/pipeline.yaml
+++ b/internal/test_data/pipeline_definitions/pipeline.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/internal/tracker/bundle_info.go
+++ b/internal/tracker/bundle_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/client.go
+++ b/internal/tracker/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/oci.go
+++ b/internal/tracker/oci.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/oci_test.go
+++ b/internal/tracker/oci_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/tracker_gen_test.go
+++ b/internal/tracker/tracker_gen_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/utils/testing_sigstore.go
+++ b/internal/utils/testing_sigstore.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/schema/keywords_array.go
+++ b/pkg/schema/keywords_array.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/schema/keywords_array_test.go
+++ b/pkg/schema/keywords_array_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/schema/slsa_provenance_v0.2_test.go
+++ b/pkg/schema/slsa_provenance_v0.2_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reference-antora-extension/index.js
+++ b/reference-antora-extension/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Red Hat, Inc.
+ * Copyright The Enterprise Contract Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tasks/artifacthub-repo.yml
+++ b/tasks/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tasks/verify-definition/0.1/tests/verify-definition-taskrun.yaml
+++ b/tasks/verify-definition/0.1/tests/verify-definition-taskrun.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tasks/verify-definition/0.1/verify-definition.yaml
+++ b/tasks/verify-definition/0.1/verify-definition.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tasks/verify-enterprise-contract/0.1/tests/ecp-policy.yaml
+++ b/tasks/verify-enterprise-contract/0.1/tests/ecp-policy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tasks/verify-enterprise-contract/0.1/tests/verify-enterprise-contract-taskrun.yaml
+++ b/tasks/verify-enterprise-contract/0.1/tests/verify-enterprise-contract-taskrun.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright The Enterprise Contract Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tekton-task-antora-extension/index.js
+++ b/tekton-task-antora-extension/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Red Hat, Inc.
+ * Copyright The Enterprise Contract Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The guidance at [1] suggests removing the year entirely so let's do that. Also let's changed the copyright holder to "The Enterprise Contract Contributors" which we decided on over "The Enterprise Contract Authors" or just "Red Hat". (The guide recommends against "Red Hat, Inc".)

Adjust the Makefile options to use that format for new files, and modify the existing preambles with some handy sed -i commands, something like this:

    git grep -l ... | xargs -n 1 sed -i 's/.../.../'

[1] https://source.redhat.com/departments/legal/redhatintellectualproperty/intellectual_property_and_ip_litigation_wiki/copyright_notices_in_source_code