### PR TITLE
Fix random order of var replacement in snapshots

### DIFF
--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -294,16 +294,12 @@ func setupRegistry(ctx context.Context, vars map[string]string, environment []st
 
 	vars["REGISTRY"] = registryURL
 
-	hashes, err := registry.AllHashes(ctx)
+	digests, err := registry.AllDigests(ctx)
 	if err != nil {
 		return environment, vars, err
 	}
 
-	for repositoryAndTag, hash := range hashes {
-		_, digest, found := strings.Cut(hash, ":")
-		if !found {
-			return environment, vars, fmt.Errorf("hash %q does not contain digest", hash)
-		}
+	for repositoryAndTag, digest := range digests {
 		vars[fmt.Sprintf("REGISTRY_%s_DIGEST", repositoryAndTag)] = digest
 	}
 
@@ -687,6 +683,11 @@ func logExecution(ctx context.Context) {
 	outputSegment("Command", s.Cmd)
 	outputSegment("State", fmt.Sprintf("Exit code: %d\nPid: %d", s.ProcessState.ExitCode(), s.ProcessState.Pid()))
 	outputSegment("Environment", strings.Join(s.Env, "\n"))
+	var varsStr []string
+	for k, v := range s.vars {
+		varsStr = append(varsStr, fmt.Sprintf("%s=%s", k, v))
+	}
+	outputSegment("Variables", strings.Join(varsStr, "\n"))
 	if s.stdout.Len() == 0 {
 		outputSegment("Stdout", c.Italic("* No standard output"))
 	} else {

--- a/acceptance/kubernetes/kubernetes.go
+++ b/acceptance/kubernetes/kubernetes.go
@@ -270,13 +270,13 @@ func taskLogsShouldMatchTheSnapshot(ctx context.Context, stepName string) error 
 		vars[fmt.Sprintf("____%s_PUBLIC_KEY", name)] = indent(key, 4)
 	}
 
-	hashes, err := registry.AllHashes(ctx)
+	digests, err := registry.AllDigests(ctx)
 	if err != nil {
 		return err
 	}
 
-	for repositoryAndTag, hash := range hashes {
-		vars[fmt.Sprintf("REGISTRY_%s_HASH", repositoryAndTag)] = hash
+	for repositoryAndTag, digest := range digests {
+		vars[fmt.Sprintf("REGISTRY_%s_DIGEST", repositoryAndTag)] = digest
 	}
 
 	maps.Copy(vars, image.RawAttestationSignaturesFrom(ctx))

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -58,7 +58,7 @@ components:
     - keyid: ""
       sig: ${ATTESTATION_SIGNATURE_acceptance/non-strict-with-warnings}
     type: https://in-toto.io/Statement/v0.1
-  containerImage: ${REGISTRY}/acceptance/non-strict-with-warnings@${REGISTRY_acceptance/non-strict-with-warnings:latest_HASH}
+  containerImage: ${REGISTRY}/acceptance/non-strict-with-warnings@sha256:${REGISTRY_acceptance/non-strict-with-warnings:latest_DIGEST}
   name: ""
   signatures:
   - keyid: ""
@@ -121,7 +121,7 @@ components:
     - keyid: ""
       sig: ${ATTESTATION_SIGNATURE_acceptance/strict-with-warnings}
     type: https://in-toto.io/Statement/v0.1
-  containerImage: ${REGISTRY}/acceptance/strict-with-warnings@${REGISTRY_acceptance/strict-with-warnings:latest_HASH}
+  containerImage: ${REGISTRY}/acceptance/strict-with-warnings@sha256:${REGISTRY_acceptance/strict-with-warnings:latest_DIGEST}
   name: ""
   signatures:
   - keyid: ""
@@ -406,7 +406,7 @@ components:
     - keyid: ""
       sig: ${ATTESTATION_SIGNATURE_acceptance/okayish}
     type: https://in-toto.io/Statement/v0.1
-  containerImage: ${REGISTRY}/acceptance/okayish@${REGISTRY_acceptance/okayish:latest_HASH}
+  containerImage: ${REGISTRY}/acceptance/okayish@sha256:${REGISTRY_acceptance/okayish:latest_DIGEST}
   name: ""
   signatures:
   - keyid: ""
@@ -446,7 +446,27 @@ success: true
 ---
 
 [Outputs are there:attestations - 1]
-{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"acceptance/okayish","digest":${REGISTRY_acceptance/okayish:latest_JSON_HASH}}],"predicate":{"builder":{"id":"https://tekton.dev/chains/v2"},"buildType":"https://tekton.dev/attestations/chains/pipelinerun@v2","invocation":{"configSource":{}}}}
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v0.2",
+  "subject": [
+    {
+      "name": "acceptance/okayish",
+      "digest": {
+        "sha256": "${REGISTRY_acceptance/okayish:latest_DIGEST}"
+      }
+    }
+  ],
+  "predicate": {
+    "builder": {
+      "id": "https://tekton.dev/chains/v2"
+    },
+    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+    "invocation": {
+      "configSource": {}
+    }
+  }
+}
 ---
 
 [Outputs are there:summary - 1]


### PR DESCRIPTION
Prior to this change, some variables were mapping to overlappling values:

```
REGISTRY_acceptance/image/parent:latest_JSON_DIGEST👉"c88bcb8e9c4827b15e33db83849b678220f1a88fc654090a0c9ac08038b73721"}
REGISTRY_acceptance/image/parent:latest_DIGEST👉c88bcb8e9c4827b15e33db83849b678220f1a88fc654090a0c9ac08038b73721
```

This caused two problems. First, the value of the variables ending in JSON_DIGEST causes the underlying JSON to break due to the closing `}` at the end. It also includes quotes which could potentially cause other issues. Second, because values overlap, and the order in which variable replacement happens in unpredictable, re-running the acceptance tests may result in a different variable being used. This resulted in random snapshot mismatches in CI.

With this change, we do away with the `JSON_DIGEST` variables altogether and instead rely on just the `DIGEST` variables.

For the `validate_image` acceptance tests, the variables are also now logged when a failure occurs. This makes issues like this much easier to debug.