### PR TITLE
Upload statistics to website

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,8 @@ jobs:
 
     permissions:
       contents: write  # for Git to git push & cache write
+      pages: write     # Needed for GitHub Pages deployment
+      id-token: write  # Needed for GitHub Pages deployment
     name: Release
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_dispatch }}
@@ -96,6 +98,22 @@ jobs:
         env:
           TASK: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-definition/0.1/verify-definition.yaml"
         run: make task-bundle-snapshot TASK_TAG=$TAG TASK=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASK | yq 'select(. != null)')
+
+      - name: Download statistics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: hack/stats.sh
+
+      - name: Configure statistics pages
+        uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
+
+      - name: Upload statistics
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
+        with:
+          path: stats
+
+      - name: Deploy statistics
+        uses: actions/deploy-pages@12ab2b16cf43a7a061fe99da74b6f8f11fb77f5b # v2.0.3
 
       - name: Delete snapshot release and tag
         run: |

--- a/hack/stats.sh
+++ b/hack/stats.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o posix
+
+mkdir -p stats
+# shellcheck disable=SC2016
+{
+    curl --silent --fail https://enterprisecontract.dev/ec-cli/stats.json || echo -n ''
+    gh api graphql --field query='{
+    repository(owner: "enterprise-contract", name: "ec-cli") {
+        release(tagName: "snapshot") {
+        createdAt
+        releaseAssets(first: 10) {
+            nodes {
+            name
+            downloadCount
+            }
+        }
+        }
+    }
+    }' --jq '.data.repository.release as $r |
+    {
+    "created": $r.createdAt,
+    "updated" : now | todate,
+    "data": [
+        $r.releaseAssets.nodes[] as $n |
+        $n.name | ltrimstr("ec_") | split("[_.]"; "") as $parts |
+        $n | {
+        "os": $parts[0],
+        "architecture": $parts[1],
+        "hash": ($parts[2] != null),
+        "downloads": .downloadCount
+        }
+    ]
+    }'
+} > stats/stats.json


### PR DESCRIPTION
This will publish a JSONL file to

    https://enterprisecontract.dev/ec-cli/stats.json

Which we can use to monitor the download statistics which are currently lost each time we perform a release.