### PR TITLE
Increase number of returned assets in stats

### DIFF
--- a/hack/stats.sh
+++ b/hack/stats.sh
@@ -28,7 +28,7 @@ mkdir -p stats
     repository(owner: "enterprise-contract", name: "ec-cli") {
         release(tagName: "snapshot") {
         createdAt
-        releaseAssets(first: 10) {
+        releaseAssets(first: 50) {
             nodes {
             name
             downloadCount


### PR DESCRIPTION
We limit at 10 and we, currently, have 14 assets. This bumps to 50.