### PR TITLE
Refactor fetchers

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
-	"github.com/enterprise-contract/ec-cli/internal/fetcher/image_config"
+	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/config"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/policy/source"
 	"github.com/enterprise-contract/ec-cli/internal/signature"
@@ -178,7 +178,7 @@ func (a *ApplicationSnapshotImage) FetchImageConfig(ctx context.Context) error {
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
 	}
 	var err error
-	a.configJSON, err = image_config.FetchImageConfig(ctx, a.reference, opts...)
+	a.configJSON, err = config.FetchImageConfig(ctx, a.reference, opts...)
 	return err
 }
 
@@ -190,11 +190,11 @@ func (a *ApplicationSnapshotImage) FetchParentImageConfig(ctx context.Context) e
 	}
 
 	var err error
-	a.parentRef, err = image_config.FetchParentImage(ctx, a.reference, opts...)
+	a.parentRef, err = config.FetchParentImage(ctx, a.reference, opts...)
 	if err != nil {
 		return err
 	}
-	a.parentConfigJSON, err = image_config.FetchImageConfig(ctx, a.parentRef, opts...)
+	a.parentConfigJSON, err = config.FetchImageConfig(ctx, a.parentRef, opts...)
 	return err
 }
 

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -49,7 +49,7 @@ import (
 
 	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
-	"github.com/enterprise-contract/ec-cli/internal/fetcher/image_config"
+	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/fake"
 	"github.com/enterprise-contract/ec-cli/internal/mocks"
 	"github.com/enterprise-contract/ec-cli/internal/signature"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
@@ -701,7 +701,7 @@ func TestValidateImageSignatureWithCertificates(t *testing.T) {
 func TestFetchImageConfig(t *testing.T) {
 	url := utils.WithDigest("registry.local/test-image")
 	ctx := context.Background()
-	ctx = image_config.WithTestImageConfig(ctx, url)
+	ctx = fake.WithTestImageConfig(ctx, url)
 
 	ref, err := name.ParseReference(url)
 	require.NoError(t, err)
@@ -716,7 +716,7 @@ func TestFetchImageConfig(t *testing.T) {
 func TestFetchParentImageConfig(t *testing.T) {
 	url := utils.WithDigest("registry.local/test-image")
 	ctx := context.Background()
-	ctx = image_config.WithTestImageConfig(ctx, url)
+	ctx = fake.WithTestImageConfig(ctx, url)
 
 	ref, err := name.ParseReference(url)
 	require.NoError(t, err)

--- a/internal/fetchers/oci/client.go
+++ b/internal/fetchers/oci/client.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package image_config
+package oci
 
 import (
 	"context"

--- a/internal/fetchers/oci/constants.go
+++ b/internal/fetchers/oci/constants.go
@@ -14,4 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package fetcher
+package oci
+
+const (
+	// These annotations are defined here:
+	// https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+	BaseImageNameAnnotation   = "org.opencontainers.image.base.name"
+	BaseImageDigestAnnotation = "org.opencontainers.image.base.digest"
+)

--- a/internal/fetchers/oci/fake/client.go
+++ b/internal/fetchers/oci/fake/client.go
@@ -18,7 +18,7 @@
 
 // The contents of this file are meant to assist in writing unit tests. It requires the "unit" build
 // tag which is not included when building the ec binary.
-package image_config
+package fake
 
 import (
 	"context"
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
@@ -44,7 +45,7 @@ func WithTestImageConfig(ctx context.Context, url string) context.Context {
 	if err != nil {
 		panic(err)
 	}
-	parentImage := &mockImage{}
+	parentImage := &FakeImage{}
 	parentImage.On("ConfigFile").Return(&v1.ConfigFile{
 		Config: v1.Config{
 			Labels: map[string]string{"io.k8s.display-name": "Base Image"},
@@ -52,9 +53,9 @@ func WithTestImageConfig(ctx context.Context, url string) context.Context {
 	}, nil)
 
 	// Setup child image mock
-	image := &mockImage{}
+	image := &FakeImage{}
 	image.On("Manifest").Return(&v1.Manifest{
-		Annotations: map[string]string{BaseImageNameAnnotation: parentURL},
+		Annotations: map[string]string{oci.BaseImageNameAnnotation: parentURL},
 	}, nil)
 	image.On("ConfigFile").Return(&v1.ConfigFile{
 		Config: v1.Config{
@@ -69,77 +70,77 @@ func WithTestImageConfig(ctx context.Context, url string) context.Context {
 	})
 
 	// Setup client
-	client := &mockClient{}
+	client := &FakeClient{}
 	client.On("Image", ref, opts).Return(image, nil)
 	client.On("Image", parentRef, opts).Return(parentImage, nil)
 
-	return WithClient(ctx, client)
+	return oci.WithClient(ctx, client)
 }
 
-type mockClient struct {
+type FakeClient struct {
 	mock.Mock
 }
 
-func (m *mockClient) Image(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
+func (m *FakeClient) Image(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
 	args := m.Called(ref, opts)
 	return args.Get(0).(v1.Image), args.Error(1)
 }
 
-type mockImage struct {
+type FakeImage struct {
 	mock.Mock
 }
 
-func (m *mockImage) Layers() ([]v1.Layer, error) {
+func (m *FakeImage) Layers() ([]v1.Layer, error) {
 	args := m.Called()
 	return args.Get(0).([]v1.Layer), args.Error(1)
 }
 
-func (m *mockImage) MediaType() (types.MediaType, error) {
+func (m *FakeImage) MediaType() (types.MediaType, error) {
 	args := m.Called()
 	return args.Get(0).(types.MediaType), args.Error(1)
 }
 
-func (m *mockImage) Size() (int64, error) {
+func (m *FakeImage) Size() (int64, error) {
 	args := m.Called()
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *mockImage) ConfigName() (v1.Hash, error) {
+func (m *FakeImage) ConfigName() (v1.Hash, error) {
 	args := m.Called()
 	return args.Get(0).(v1.Hash), args.Error(1)
 }
 
-func (m *mockImage) ConfigFile() (*v1.ConfigFile, error) {
+func (m *FakeImage) ConfigFile() (*v1.ConfigFile, error) {
 	args := m.Called()
 	return args.Get(0).(*v1.ConfigFile), args.Error(1)
 }
 
-func (m *mockImage) RawConfigFile() ([]byte, error) {
+func (m *FakeImage) RawConfigFile() ([]byte, error) {
 	args := m.Called()
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (m *mockImage) Digest() (v1.Hash, error) {
+func (m *FakeImage) Digest() (v1.Hash, error) {
 	args := m.Called()
 	return args.Get(0).(v1.Hash), args.Error(1)
 }
 
-func (m *mockImage) Manifest() (*v1.Manifest, error) {
+func (m *FakeImage) Manifest() (*v1.Manifest, error) {
 	args := m.Called()
 	return args.Get(0).(*v1.Manifest), args.Error(1)
 }
 
-func (m *mockImage) RawManifest() ([]byte, error) {
+func (m *FakeImage) RawManifest() ([]byte, error) {
 	args := m.Called()
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (m *mockImage) LayerByDigest(v1.Hash) (v1.Layer, error) {
+func (m *FakeImage) LayerByDigest(v1.Hash) (v1.Layer, error) {
 	args := m.Called()
 	return args.Get(0).(v1.Layer), args.Error(1)
 }
 
-func (m *mockImage) LayerByDiffID(v1.Hash) (v1.Layer, error) {
+func (m *FakeImage) LayerByDiffID(v1.Hash) (v1.Layer, error) {
 	args := m.Called()
 	return args.Get(0).(v1.Layer), args.Error(1)
 }

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -43,7 +43,7 @@ import (
 
 	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
-	"github.com/enterprise-contract/ec-cli/internal/fetcher/image_config"
+	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/fake"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
@@ -277,5 +277,5 @@ func withImageConfig(ctx context.Context, url string) context.Context {
 	refWithTag.Tag = ""
 	resolved := refWithTag.String()
 
-	return image_config.WithTestImageConfig(ctx, resolved)
+	return fake.WithTestImageConfig(ctx, resolved)
 }


### PR DESCRIPTION
Moves `internal/fetcher/image_config` to `internal/fetchers/oci/[config|fake]`.

This allows evolution of fetchers and implementation of different OCI related fetchers.