### PR TITLE
Enable manual runs for "checks" and "lint" workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,6 +24,7 @@ name: Checks
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,7 @@ name: Lint
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This can be helpful for manually running tests before submitting a pull request to this repo.