### PR TITLE
Allow duplicate digests in bundles tracked with `ec track bundle`

### DIFF
--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -175,18 +175,19 @@ func filterRecords(records []bundleRecord, prune bool) []bundleRecord {
 	now := time.Now().UTC()
 
 	unique := make([]bundleRecord, 0, len(records))
-	keys := map[string]bool{}
-	for i := len(records) - 1; i >= 0; i-- {
+	last_index := len(records) - 1
+	for i := last_index; i >= 0; i-- {
 		r := records[i]
 		// NOTE: Newly added records will have a repository, but existing ones
 		// will not. This is expected because the output does not persist the
 		// repository for each record. Instead, the repository is the attribute
 		// which references the list of records.
-		key := r.Digest
-		if _, ok := keys[key]; ok {
-			continue
+		if i < last_index {
+			previous := records[i+1]
+			if previous.Digest == r.Digest {
+				continue
+			}
 		}
-		keys[key] = true
 		unique = append([]bundleRecord{r}, unique...)
 	}
 

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -264,6 +264,144 @@ func TestTrack(t *testing.T) {
 				      tag: "0.3"
 			`),
 		},
+		{
+			name: "prune entries with same digest if adjacent",
+			urls: []string{
+				"registry.com/mixed:1.0@" + sampleHashOne.String(),
+			},
+			prune: true,
+			input: []byte(hd.Doc(`
+				---
+				pipeline-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				task-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+			`)),
+			output: hd.Doc(`
+				---
+				pipeline-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashOne.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "1.0"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				task-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashOne.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "1.0"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+			`),
+		},
+		{
+			name: "don't prune entries with same digest if not adjacent",
+			urls: []string{
+				"registry.com/mixed:1.0@" + sampleHashOne.String(),
+			},
+			prune: true,
+			input: []byte(hd.Doc(`
+				---
+				pipeline-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				task-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+			`)),
+			output: hd.Doc(`
+				---
+				pipeline-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashOne.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "1.0"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				task-bundles:
+				  registry.com/mixed:
+				    - digest: ` + sampleHashOne.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "1.0"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+				    - digest: ` + sampleHashThree.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.3"
+				    - digest: ` + sampleHashTwo.String() + `
+				      effective_on: "` + expectedEffectiveOn + `"
+				      tag: "0.2"
+			`),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is a fairly simple patch that changes the logic for filtering out duplicate bundles. Now a bundle is only dropped if its digest is the same as _the previous_ bundle, instead of if its digest is the same as _any_ bundle.

Ref: https://issues.redhat.com/browse/HACBS-2394