### PR TITLE
Make Rekor stubs more precise

### DIFF
--- a/acceptance/crypto/keys.go
+++ b/acceptance/crypto/keys.go
@@ -70,12 +70,6 @@ func GenerateKeyPairNamed(ctx context.Context, name string) (context.Context, er
 
 	state.Keys[name] = keyPair
 
-	if rekor, ok := ctx.Value(testenv.RekorImpl).(testenv.Rekor); ok {
-		if err := rekor.StubRekorEntryFor(ctx, keyPair.PublicBytes); err != nil {
-			return ctx, err
-		}
-	}
-
 	return ctx, nil
 }
 

--- a/acceptance/testenv/testenv.go
+++ b/acceptance/testenv/testenv.go
@@ -55,10 +55,6 @@ var version sync.Once
 var ecVersion = "undefined"
 var ecVersionErr error
 
-type Rekor interface {
-	StubRekorEntryFor(context.Context, []byte) error
-}
-
 // Persist persists the environment stored in context in a ".persisted" file as JSON
 func Persist(ctx context.Context) (bool, error) {
 	if !Persisted(ctx) {

--- a/acceptance/wiremock/wiremock.go
+++ b/acceptance/wiremock/wiremock.go
@@ -52,8 +52,8 @@ const (
 
 var Get = wiremock.Get
 var Post = wiremock.Post
-var Contains = wiremock.Contains
 var URLPathEqualTo = wiremock.URLPathEqualTo
+var MatchingJsonPath = wiremock.MatchingJsonPath
 
 type client struct {
 	*wiremock.Client


### PR DESCRIPTION
Previously, the Rekor stubs for the `/api/v1/log/entries/retrieve` API endpoint were matching any requests that included the public key.

This commit changes the stubs to only match the expected content. Queries for attestations and signature are different, so a different selector is used for each.