### PR TITLE
Add --ignore-rekor flag

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -52,6 +52,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		imageRef                    string
 		info                        bool
 		input                       string // Deprecated: images replaced this
+		ignoreRekor                 bool
 		output                      []string
 		outputFile                  string
 		policy                      policy.Policy
@@ -241,9 +242,10 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 					Subject:       data.certificateIdentity,
 					SubjectRegExp: data.certificateIdentityRegExp,
 				},
-				PolicyRef: data.policyConfiguration,
-				PublicKey: data.publicKey,
-				RekorURL:  data.rekorURL,
+				IgnoreRekor: data.ignoreRekor,
+				PolicyRef:   data.policyConfiguration,
+				PublicKey:   data.publicKey,
+				RekorURL:    data.rekorURL,
 			}); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
@@ -362,6 +364,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 
 	cmd.Flags().StringVarP(&data.rekorURL, "rekor-url", "r", data.rekorURL,
 		"Rekor URL. Overrides rekorURL from EnterpriseContractPolicy")
+
+	cmd.Flags().BoolVar(&data.ignoreRekor, "ignore-rekor", data.ignoreRekor,
+		"Skip Rekor transparency log checks during validation.")
 
 	cmd.Flags().StringVar(&data.certificateIdentity, "certificate-identity", data.certificateIdentity,
 		"EXPERIMENTAL. URL of the certificate identity for keyless verification")

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -297,6 +297,8 @@ func Test_ValidateImageCommand(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
+	utils.SetTestRekorPublicKey(t)
+
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.JSONEq(t, fmt.Sprintf(`{
@@ -351,6 +353,8 @@ func Test_ValidateImageCommandKeyless(t *testing.T) {
 	})
 
 	t.Setenv("EC_EXPERIMENTAL", "1")
+
+	utils.SetTestRekorPublicKey(t)
 	utils.SetTestFulcioRoots(t)
 	utils.SetTestCTLogPublicKey(t)
 
@@ -430,6 +434,8 @@ configuration:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
+	utils.SetTestRekorPublicKey(t)
+
 	err = cmd.Execute()
 	assert.NoError(t, err)
 }
@@ -506,6 +512,8 @@ configuration:
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
+	utils.SetTestRekorPublicKey(t)
+
 	err = cmd.Execute()
 	assert.NoError(t, err)
 }
@@ -569,6 +577,8 @@ func Test_ValidateImageCommandEmptyPolicyFile(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
+
+	utils.SetTestRekorPublicKey(t)
 
 	err = cmd.Execute()
 	assert.EqualError(t, err, "1 error occurred:\n\t* file /policy.yaml is empty\n\n")
@@ -650,6 +660,8 @@ func Test_ValidateErrorCommand(t *testing.T) {
 			cmd.SilenceErrors = true
 			cmd.SilenceUsage = true
 
+			utils.SetTestRekorPublicKey(t)
+
 			err := cmd.Execute()
 			assert.EqualError(t, err, c.expected)
 			assert.Empty(t, out.String())
@@ -693,6 +705,8 @@ func Test_FailureImageAccessibility(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
+
+	utils.SetTestRekorPublicKey(t)
 
 	err := cmd.Execute()
 	assert.NoError(t, err)
@@ -755,6 +769,8 @@ func Test_FailureOutput(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
+
+	utils.SetTestRekorPublicKey(t)
 
 	err := cmd.Execute()
 	assert.NoError(t, err)
@@ -824,6 +840,8 @@ func Test_WarningOutput(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
+
+	utils.SetTestRekorPublicKey(t)
 
 	err := cmd.Execute()
 	assert.NoError(t, err)

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -478,6 +478,7 @@ Error: success criteria not met
         }
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -651,6 +652,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -822,6 +824,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -959,8 +962,7 @@ Error: success criteria not met
           "git::https://${GITHOST}/git/unexpected-keyless-cert.git"
         ]
       }
-    ],
-    "rekorUrl": "http://this.is.ignored"
+    ]
   },
   "ec-version": "${EC_VERSION}",
   "effective-time": "${TIMESTAMP}"
@@ -1094,6 +1096,7 @@ Error: success criteria not met
         "filtering.always_pass"
       ]
     },
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1184,6 +1187,7 @@ Error: 1 error occurred:
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1261,6 +1265,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1390,8 +1395,7 @@ Error: success criteria not met
           "git::https://${GITHOST}/git/happy-day-policy.git"
         ]
       }
-    ],
-    "rekorUrl": "http://this.is.ignored"
+    ]
   },
   "ec-version": "${EC_VERSION}",
   "effective-time": "${TIMESTAMP}"
@@ -1438,6 +1442,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1616,6 +1621,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1774,6 +1780,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -1952,6 +1959,7 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:29: rego_type_error: undefi
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -2209,6 +2217,7 @@ Error: success criteria not met
         ]
       }
     ],
+    "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
@@ -2303,5 +2312,102 @@ Error: success criteria not met
 ---
 
 [policy input output:stderr - 1]
+
+---
+
+[ignore rekor:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/ignore-rekor@sha256:${REGISTRY_acceptance/ignore-rekor:latest_DIGEST}",
+      "source": {},
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/ignore-rekor}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/ignore-rekor}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/ignore-rekor.git"
+        ]
+      }
+    ],
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[ignore rekor:stderr - 1]
+
+---
+
+[rekor entries required:stdout - 1]
+{
+  "success": false,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/rekor-by-default@sha256:${REGISTRY_acceptance/rekor-by-default:latest_DIGEST}",
+      "source": {},
+      "violations": [
+        {
+          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created.",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created.",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        }
+      ],
+      "success": false
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/rekor-by-default.git"
+        ]
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[rekor entries required:stderr - 1]
+Error: success criteria not met
 
 ---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -96,9 +96,7 @@ Feature: evaluate enterprise contract
     }
     """
     Given the environment variable is set "EC_EXPERIMENTAL=1"
-    # TODO: The Rekor value is ignored here, but it cannot be an empty value because that causes
-    # the ec-cli to ignore the tlog altogether.
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day-keyless --policy acceptance/ec-policy --rekor-url http://this.is.ignored --certificate-oidc-issuer ${CERT_ISSUER} --certificate-identity ${CERT_IDENTITY} --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day-keyless --policy acceptance/ec-policy --certificate-oidc-issuer ${CERT_ISSUER} --certificate-identity ${CERT_IDENTITY} --strict --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
 
@@ -145,9 +143,7 @@ Feature: evaluate enterprise contract
     }
     """
     Given the environment variable is set "EC_EXPERIMENTAL=1"
-    # TODO: The Rekor value is ignored here, but it cannot be an empty value because that causes
-    # the ec-cli to ignore the tlog altogether.
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/unexpected-keyless-cert --policy acceptance/ec-policy --rekor-url http://this.is.ignored --certificate-oidc-issuer https://spam.cluster.local --certificate-identity https://kubernetes.io/namespaces/bacon/serviceaccounts/eggs --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/unexpected-keyless-cert --policy acceptance/ec-policy --certificate-oidc-issuer https://spam.cluster.local --certificate-identity https://kubernetes.io/namespaces/bacon/serviceaccounts/eggs --strict --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -326,11 +322,13 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/ec-happy-day"
     Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
     Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key, patched with
       | [{"op": "add", "path": "/predicate/metadata", "value": {}}, {"op": "add", "path": "/predicate/metadata/buildFinishedOn", "value": "2100-01-01T00:00:00Z"}] |
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
     Given a git repository named "future-deny-policy" with
       | main.rego | examples/future_deny.rego |
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy {"sources":[{"policy":["git::https://${GITHOST}/git/future-deny-policy.git"]}]} --public-key ${known_PUBLIC_KEY} --effective-time attestation --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy {"sources":[{"policy":["git::https://${GITHOST}/git/future-deny-policy.git"]}]} --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --effective-time attestation --strict --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -338,7 +336,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid image signature of "acceptance/image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/image"
     Given a valid attestation of "acceptance/image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/image"
     Given a git repository named "happy-day-policy" with
       | happy_day.rego | examples/happy_day.rego      |
       | reject.rego    | examples/reject.rego         |
@@ -354,7 +354,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --info --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --info --strict --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -391,7 +391,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/ec-happy-day"
     Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
     Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
     Given a git repository named "happy-day-policy" with
       | filtering.rego | examples/filtering.rego |
     Given policy configuration named "ec-policy" with specification
@@ -410,7 +412,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
 
@@ -418,7 +420,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/ec-happy-day"
     Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
     Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
     Given a git repository named "happy-day-policy" with
       | main.rego | examples/happy_day.rego |
     Given policy configuration named "ec-policy" with specification
@@ -433,7 +437,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --json-input {"components":[{"name":"Happy","containerImage":"${REGISTRY}/acceptance/ec-happy-day"}]} --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
+    When ec command is run with "validate image --json-input {"components":[{"name":"Happy","containerImage":"${REGISTRY}/acceptance/ec-happy-day"}]} --policy acceptance/ec-policy  --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
 
@@ -441,7 +445,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/ec-happy-day"
     Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
     Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
     Given a git repository named "happy-day-policy" with
       | main.rego | examples/happy_day.rego |
     Given an Snapshot named "happy" with specification
@@ -467,7 +473,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --snapshot acceptance/happy --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
+    When ec command is run with "validate image --snapshot acceptance/happy --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
 
@@ -475,7 +481,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid image signature of "acceptance/image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/image"
     Given a valid attestation of "acceptance/image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/image"
     Given a git repository named "my-policy" with
       | happy_day.rego | examples/happy_day.rego      |
       | reject.rego    | examples/reject.rego         |
@@ -491,7 +499,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --output junit --strict  --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --output junit --strict  --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -499,7 +507,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/my-image"
     Given a valid image signature of "acceptance/my-image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/my-image"
     Given a valid attestation of "acceptance/my-image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/my-image"
     Given a OCI policy bundle named "acceptance/happy-day-policy:tag" with
       | main.rego | examples/happy_day.rego |
     Given a OCI policy bundle named "acceptance/allow-all:latest" with
@@ -517,7 +527,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/my-image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/my-image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
 
@@ -550,7 +560,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid image signature of "acceptance/image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/image"
     Given a valid attestation of "acceptance/image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/image"
     Given a git repository named "my-policy1" with
       | rule_data.rego | examples/rule_data.rego |
     Given a git repository named "my-policy2" with
@@ -578,7 +590,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --output=json --output data=${TMPDIR}/custom-rule-data.yaml --effective-time 2014-05-31 --strict --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --output=json --output data=${TMPDIR}/custom-rule-data.yaml --effective-time 2014-05-31 --strict --show-successes"
     Then the exit status should be 0
     And the output should match the snapshot
     And the "${TMPDIR}/custom-rule-data.yaml" file should match the snapshot
@@ -587,8 +599,10 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid image signature of "acceptance/image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/image"
     Given an image named "acceptance/bad-actor" with signature from "acceptance/image"
     Given a valid attestation of "acceptance/bad-actor" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/bad-actor"
     Given a git repository named "mismatched-image-digest" with
       | main.rego | examples/happy_day.rego |
     Given policy configuration named "mismatched-image-digest" with specification
@@ -603,7 +617,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/bad-actor --policy acceptance/mismatched-image-digest --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/bad-actor --policy acceptance/mismatched-image-digest --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -611,8 +625,10 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid attestation of "acceptance/image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/image"
     Given an image named "acceptance/bad-actor" with attestation from "acceptance/image"
     Given a valid image signature of "acceptance/bad-actor" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/bad-actor"
     Given a git repository named "mismatched-image-digest" with
       | main.rego | examples/happy_day.rego |
     Given policy configuration named "mismatched-image-digest" with specification
@@ -627,7 +643,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/bad-actor --policy acceptance/mismatched-image-digest --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/bad-actor --policy acceptance/mismatched-image-digest --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict  --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -661,7 +677,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
     Given an image named "acceptance/image"
     Given a valid image signature of "acceptance/image" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/image"
     Given a valid attestation of "acceptance/image" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/image"
     Given a git repository named "with-dependencies" with
       | main.rego | examples/rules_with_dependencies.rego |
     Given policy configuration named "ec-policy" with specification
@@ -676,7 +694,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    And ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict --show-successes"
+    And ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --strict --show-successes"
     Then the exit status should be 1
     Then the output should match the snapshot
 
@@ -720,7 +738,9 @@ Feature: evaluate enterprise contract
     Given a key pair named "known"
       And an image named "acceptance/image"
       And a valid image signature of "acceptance/image" image signed by the "known" key
+      Given a valid Rekor entry for image signature of "acceptance/image"
       And a valid attestation of "acceptance/image" signed by the "known" key
+      Given a valid Rekor entry for attestation of "acceptance/image"
       And a git repository named "my-policy" with
       | happy.rego  | examples/happy_day.rego   |
       And policy configuration named "ec-policy" with specification
@@ -735,7 +755,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --output=json --output attestation=${TMPDIR}/attestation.jsonl --strict"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --output=json --output attestation=${TMPDIR}/attestation.jsonl --strict"
     Then the exit status should be 0
     And the output should match the snapshot
     And the "${TMPDIR}/attestation.jsonl" file should match the snapshot
@@ -757,3 +777,32 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: ignore rekor
+    Given a key pair named "known"
+    Given an image named "acceptance/ignore-rekor"
+    Given a valid image signature of "acceptance/ignore-rekor" image signed by the "known" key
+    Given a valid attestation of "acceptance/ignore-rekor" signed by the "known" key
+    Given a git repository named "ignore-rekor" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {"sources": [{"policy": ["git::https://${GITHOST}/git/ignore-rekor.git"]}]}
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ignore-rekor --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --ignore-rekor --strict"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: rekor entries required
+    Given a key pair named "known"
+    Given an image named "acceptance/rekor-by-default"
+    Given a valid image signature of "acceptance/rekor-by-default" image signed by the "known" key
+    Given a valid attestation of "acceptance/rekor-by-default" signed by the "known" key
+    Given a git repository named "rekor-by-default" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {"sources": [{"policy": ["git::https://${GITHOST}/git/rekor-by-default.git"]}]}
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/rekor-by-default --rekor-url ${REKOR} --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --strict"
+    Then the exit status should be 1
+    Then the output should match the snapshot

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -765,6 +765,8 @@ func testComponentsFor(snapshot app.SnapshotSpec) []Component {
 }
 
 func createTestPolicy(t *testing.T, ctx context.Context) policy.Policy {
+	utils.SetTestRekorPublicKey(t)
+
 	p, err := policy.NewPolicy(ctx, policy.Options{
 		PublicKey:     utils.TestPublicKey,
 		EffectiveTime: policy.Now,

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -456,6 +456,7 @@ func TestPublicKeyPEM(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
+			utils.SetTestRekorPublicKey(t)
 			utils.SetTestFulcioRoots(t)
 			utils.SetTestCTLogPublicKey(t)
 
@@ -537,6 +538,7 @@ func TestIdentity(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
+			utils.SetTestRekorPublicKey(t)
 			utils.SetTestFulcioRoots(t)
 			utils.SetTestCTLogPublicKey(t)
 

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -63,6 +63,14 @@ spec:
       description: Rekor host for transparency log lookups
       default: ""
 
+    - name: IGNORE_REKOR
+      type: string
+      description: >-
+        Skip Rekor transparency log checks during validation. NOTE: The default value will change to
+        "false" in the near future as that is a more secure default value. It is currently "true" to
+        retain temporary backwards compatibility.
+      default: "true"
+
     - name: TUF_MIRROR
       type: string
       description: TUF mirror URL. Provide a value when NOT using public sigstore deployment.
@@ -150,6 +158,7 @@ spec:
         - "$(params.PUBLIC_KEY)"
         - "--rekor-url"
         - "$(params.REKOR_HOST)"
+        - "--ignore-rekor=$(params.IGNORE_REKOR)"
         # NOTE: The syntax below is required to negate boolean parameters
         - "--info=$(params.INFO)"
         - "--strict=false"


### PR DESCRIPTION
Prior to this change, the flag --rekor-url had two purposes. To provide the URL for the Rekor service, and to determine whether or not Rekor should be used in the verification at all. This was problematic.

Depending on the item being verified, cosign may not use the provided Rekor URL during verification. Instead, it may switch to offline verification. This uses the Rekor public keys fetched from TUF. This led to the odd usage of having to provide a dummy value as the Rekor URL to trigger Rekor verification.

This commit introduces a new flag, `--ignore-rekor`, to explicitly skip Rekor during verification. The default value is `false` as that is the most secure option.

This has implications with backwards compatibility. Someone that wants to ignore Rekor when running `ec validate image` must now use the new flag.

This commit also adds a new parameter to the
`verify-enterprise-contract` task, aptly named `IGNORE_REKOR`. Contrary to the CLI flag, this parameter defaults to `true`. This is done for a temporary amount of time to allow users of the Task to start using the new parameter if needed. (Tekton does not allow passing parmeters that don't exist to a Task.) After a certain amount of time, the default value will be updated to `false` for security reasons.

https://issues.redhat.com/browse/HACBS-2165