### PR TITLE
Use filesystem image cache

### DIFF
--- a/internal/fetchers/oci/client.go
+++ b/internal/fetchers/oci/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Red Hat, Inc.
+// Copyright The Enterprise Contract Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,19 +18,50 @@ package oci
 
 import (
 	"context"
+	"os"
+	"path"
+	"strconv"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	log "github.com/sirupsen/logrus"
 )
 
 type key string
 
 const clientKey key = "ec.fetcher.config.client"
 
+var imgCache cache.Cache
+
+func init() {
+	initCache()
+}
+
+func initCache() {
+	// if a value was set and it is parsed as false, turn the cache off
+	if v, err := strconv.ParseBool(os.Getenv("EC_CACHE")); err == nil && !v {
+		return
+	}
+
+	if userCache, err := os.UserCacheDir(); err != nil {
+		log.Debug("unable to find user cache directory")
+	} else {
+		imgCacheDir := path.Join(userCache, "ec", "images")
+		if err := os.MkdirAll(imgCacheDir, 0700); err != nil {
+			log.Debugf("unable to create temporary directory for image cache in %q: %v", imgCacheDir, err)
+		}
+		log.Debugf("using %q directory to store image cache", imgCacheDir)
+		imgCache = cache.NewFilesystemCache(imgCacheDir)
+	}
+}
+
 type client interface {
 	Image(name.Reference, ...remote.Option) (v1.Image, error)
 }
+
+var defaultClient = remoteClient{}
 
 func NewClient(ctx context.Context) client {
 	c, ok := ctx.Value(clientKey).(client)
@@ -38,7 +69,7 @@ func NewClient(ctx context.Context) client {
 		return c
 	}
 
-	return &remoteClient{}
+	return &defaultClient
 }
 
 func WithClient(ctx context.Context, c client) context.Context {
@@ -49,5 +80,14 @@ type remoteClient struct {
 }
 
 func (*remoteClient) Image(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
-	return remote.Image(ref, opts...)
+	img, err := remote.Image(ref, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if imgCache != nil {
+		img = cache.Image(img, imgCache)
+	}
+
+	return img, nil
 }

--- a/internal/fetchers/oci/client_test.go
+++ b/internal/fetchers/oci/client_test.go
@@ -1,0 +1,88 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheInit(t *testing.T) {
+	// by default the cache should be on
+	assert.NotNil(t, imgCache)
+
+	t.Setenv("EC_CACHE", "false")
+	imgCache = nil
+	initCache()
+	assert.Nil(t, imgCache)
+
+	t.Cleanup(func() {
+		t.Setenv("EC_CACHE", "true")
+		initCache()
+		assert.NotNil(t, imgCache)
+	})
+}
+
+func TestImage(t *testing.T) {
+	img, err := random.Image(4096, 2)
+	require.NoError(t, err)
+
+	l := &bytes.Buffer{}
+	registry := httptest.NewServer(registry.New(registry.Logger(log.New(l, "", 0))))
+	t.Cleanup(registry.Close)
+
+	u, err := url.Parse(registry.URL)
+	require.NoError(t, err)
+
+	ref, err := name.ParseReference(fmt.Sprintf("localhost:%s/repository/image:tag", u.Port()))
+	require.NoError(t, err)
+
+	require.NoError(t, remote.Put(ref, img))
+
+	fetchFully := func() {
+		img, err := defaultClient.Image(ref)
+		require.NoError(t, err)
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		for _, l := range layers {
+			r, err := l.Uncompressed()
+			require.NoError(t, err)
+			_, err = io.ReadAll(r)
+			require.NoError(t, err)
+		}
+	}
+
+	fetchFully()
+	fetchFully()
+	fetchFully()
+
+	blobDownloadCount := strings.Count(l.String(), "GET /v2/repository/image/blobs/sha256:")
+	assert.Equal(t, 5, blobDownloadCount) // three configs fetched each time and two layers fetched only once
+}


### PR DESCRIPTION
This makes sure that we cache remote image fetches by using a filesystem cache set to a path in the user cache directory. The cache is disabled if `EC_CACHE` environment variable is set to to `false` according to `strconv.ParseBool`.