### PR TITLE
Isolate dependency on conftest

### DIFF
--- a/cmd/test/appstudio.go
+++ b/cmd/test/appstudio.go
@@ -1,0 +1,60 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// -------------------------------------------------------------------------------
+// This file is almost to identical to the conftest version of this command.
+// Use `make conftest-test-cmd-diff` to show a comparison.
+// Note also that the way that flags are handled here is not consistent with how
+// it's done elsewhere. This intentional in order to be consistent with Conftest.
+// -------------------------------------------------------------------------------
+package test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/open-policy-agent/conftest/output"
+
+	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
+)
+
+func appstudioReport(results []output.CheckResult, namespaces []string) applicationsnapshot.TestReport {
+	// This is may need revising in future. It does not handle multiple namespaces
+	// accurately. We could consider using a string delimited list of namespaces
+	// but I'm being cautious about breaking consumers of this data. The
+	// testReport.Namespace field might need to be converted to a list of strings
+	// in future but we need to coordinate that change carefully.
+	// Also, we might prefer to extract the namespaces from results rather than
+	// use whatever the user provided on the command line.
+	useNamespace := ""
+	if len(namespaces) > 0 {
+		// The first namespace only
+		useNamespace = namespaces[0]
+	}
+	report := applicationsnapshot.TestReport{
+		Timestamp: fmt.Sprint(time.Now().UTC().Unix()),
+		Namespace: useNamespace,
+	}
+
+	for _, result := range results {
+		report.Successes += result.Successes
+		report.Failures += len(result.Failures)
+		report.Warnings += len(result.Warnings)
+	}
+
+	report.DeriveResult(false)
+	return report
+}

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/open-policy-agent/conftest/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
 )
 
 const testDesc = `
@@ -164,7 +162,7 @@ func newTestCommand() *cobra.Command {
 			if !runner.Quiet || exitCode != 0 {
 				if runner.Output == OutputAppstudio {
 					// The appstudio format is unknown to Conftest so we handle it ourselves
-					report := applicationsnapshot.AppstudioReportFromCheckResults(results, runner.Namespace)
+					report := appstudioReport(results, runner.Namespace)
 					reportOutput, err := json.Marshal(report)
 					if err != nil {
 						return fmt.Errorf("output results: %w", err)

--- a/cmd/validate/definition.go
+++ b/cmd/validate/definition.go
@@ -22,10 +22,10 @@ import (
 
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/hashicorp/go-multierror"
-	coutput "github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/cobra"
 
 	"github.com/enterprise-contract/ec-cli/internal/definition"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/policy/source"
@@ -100,7 +100,7 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 					showSuccesses, _ := cmd.Flags().GetBool("show-successes")
 					if !showSuccesses {
 						for i := range out.PolicyCheck {
-							out.PolicyCheck[i].Successes = make([]coutput.Result, 0)
+							out.PolicyCheck[i].Successes = []evaluator.Result{}
 						}
 
 					}

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
@@ -37,7 +36,7 @@ import (
 
 func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 	validate := func(_ context.Context, fpath string, _ []source.PolicySource, _ []string) (*output2.Output, error) {
-		return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
+		return &output2.Output{PolicyCheck: []evaluator.Outcome{{FileName: fpath}}}, nil
 	}
 
 	cmd := validateDefinitionCmd(validate)
@@ -156,7 +155,7 @@ func TestDefinitionFileOutputFormats(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			validate := func(_ context.Context, fpath string, sources []source.PolicySource, _ []string) (*output2.Output, error) {
-				return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
+				return &output2.Output{PolicyCheck: []evaluator.Outcome{{FileName: fpath}}}, nil
 			}
 
 			cmd := validateDefinitionCmd(validate)
@@ -209,15 +208,15 @@ func TestValidateDefinitionFileCommandErrors(t *testing.T) {
 
 func TestStrictOutput(t *testing.T) {
 	validate := func(_ context.Context, fpath string, _ []source.PolicySource, _ []string) (*output2.Output, error) {
-		failureResult := output.CheckResult{
+		failureResult := evaluator.Outcome{
 			FileName: fpath,
-			Failures: []output.Result{
+			Failures: []evaluator.Result{
 				{
 					Message: "failure",
 				},
 			},
 		}
-		return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: failureResult}}}, nil
+		return &output2.Output{PolicyCheck: []evaluator.Outcome{failureResult}}, nil
 	}
 
 	cases := []struct {

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	hd "github.com/MakeNowJust/heredoc"
-	conftestOutput "github.com/open-policy-agent/conftest/output"
 	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/spf13/afero"
@@ -257,14 +256,11 @@ func Test_ValidateImageCommand(t *testing.T) {
 			AttestationSyntaxCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: evaluator.CheckResults{
+			PolicyCheck: []evaluator.Outcome{
 				{
-					CheckResult: conftestOutput.CheckResult{
-						FileName:  "test.json",
-						Namespace: "test.main",
-						Successes: 1,
-					},
-					Successes: []conftestOutput.Result{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: []evaluator.Result{
 						{
 							Message: "Pass",
 							Metadata: map[string]interface{}{
@@ -377,14 +373,11 @@ func Test_ValidateImageCommandYAMLPolicyFile(t *testing.T) {
 			AttestationSyntaxCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: evaluator.CheckResults{
+			PolicyCheck: []evaluator.Outcome{
 				{
-					CheckResult: conftestOutput.CheckResult{
-						FileName:  "test.json",
-						Namespace: "test.main",
-						Successes: 1,
-					},
-					Successes: []conftestOutput.Result{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: []evaluator.Result{
 						{
 							Message: "Pass",
 							Metadata: map[string]interface{}{
@@ -455,14 +448,11 @@ func Test_ValidateImageCommandJSONPolicyFile(t *testing.T) {
 			AttestationSyntaxCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: evaluator.CheckResults{
+			PolicyCheck: []evaluator.Outcome{
 				{
-					CheckResult: conftestOutput.CheckResult{
-						FileName:  "test.json",
-						Namespace: "test.main",
-						Successes: 1,
-					},
-					Successes: []conftestOutput.Result{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: []evaluator.Result{
 						{
 							Message: "Pass",
 							Metadata: map[string]interface{}{
@@ -533,14 +523,11 @@ func Test_ValidateImageCommandEmptyPolicyFile(t *testing.T) {
 			AttestationSyntaxCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: evaluator.CheckResults{
+			PolicyCheck: []evaluator.Outcome{
 				{
-					CheckResult: conftestOutput.CheckResult{
-						FileName:  "test.json",
-						Namespace: "test.main",
-						Successes: 1,
-					},
-					Successes: []conftestOutput.Result{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: []evaluator.Result{
 						{
 							Message: "Pass",
 							Metadata: map[string]interface{}{
@@ -674,15 +661,15 @@ func Test_FailureImageAccessibility(t *testing.T) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
-				Result: &conftestOutput.Result{Message: "skipped due to inaccessible image ref"},
+				Result: &evaluator.Result{Message: "skipped due to inaccessible image ref"},
 			},
 			ImageAccessibleCheck: output.VerificationStatus{
 				Passed: false,
-				Result: &conftestOutput.Result{Message: "image ref not accessible. HEAD registry/image:tag: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)"},
+				Result: &evaluator.Result{Message: "image ref not accessible. HEAD registry/image:tag: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)"},
 			},
 			AttestationSignatureCheck: output.VerificationStatus{
 				Passed: false,
-				Result: &conftestOutput.Result{Message: "skipped due to inaccessible image ref"},
+				Result: &evaluator.Result{Message: "skipped due to inaccessible image ref"},
 			},
 			ImageURL: url,
 		}, nil
@@ -739,14 +726,14 @@ func Test_FailureOutput(t *testing.T) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
-				Result: &conftestOutput.Result{Message: "failed image signature check"},
+				Result: &evaluator.Result{Message: "failed image signature check"},
 			},
 			ImageAccessibleCheck: output.VerificationStatus{
 				Passed: true,
 			},
 			AttestationSignatureCheck: output.VerificationStatus{
 				Passed: false,
-				Result: &conftestOutput.Result{Message: "failed attestation signature check"},
+				Result: &evaluator.Result{Message: "failed attestation signature check"},
 			},
 			ImageURL: url,
 		}, nil
@@ -809,13 +796,11 @@ func Test_WarningOutput(t *testing.T) {
 			AttestationSignatureCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: evaluator.CheckResults{
+			PolicyCheck: []evaluator.Outcome{
 				{
-					CheckResult: conftestOutput.CheckResult{
-						Warnings: []conftestOutput.Result{
-							{Message: "warning for policy check 1"},
-							{Message: "warning for policy check 2"},
-						},
+					Warnings: []evaluator.Result{
+						{Message: "warning for policy check 1"},
+						{Message: "warning for policy check 2"},
 					},
 				},
 			},

--- a/internal/applicationsnapshot/junit.go
+++ b/internal/applicationsnapshot/junit.go
@@ -23,19 +23,20 @@ import (
 
 	"cuelang.org/go/pkg/time"
 	"github.com/jstemmer/go-junit-report/v2/junit"
-	conftestOutput "github.com/open-policy-agent/conftest/output"
 	"golang.org/x/exp/maps"
+
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 )
 
 // mapResults maps an slice of Conftest results to a slice of arbitrary types
 // given a mapper function
-func mapResults(suite *junit.Testsuite, results []conftestOutput.Result, m func(conftestOutput.Result) junit.Testcase) {
+func mapResults(suite *junit.Testsuite, results []evaluator.Result, m func(evaluator.Result) junit.Testcase) {
 	for _, r := range results {
 		suite.AddTestcase(m(r))
 	}
 }
 
-func asTestCase(r conftestOutput.Result) junit.Testcase {
+func asTestCase(r evaluator.Result) junit.Testcase {
 	meta := maps.Clone(r.Metadata)
 	delete(meta, "code")
 
@@ -112,7 +113,7 @@ func (r *Report) toJUnit() junit.Testsuites {
 
 		mapResults(&suite, component.Successes, asTestCase)
 
-		mapResults(&suite, component.Violations, func(r conftestOutput.Result) junit.Testcase {
+		mapResults(&suite, component.Violations, func(r evaluator.Result) junit.Testcase {
 			c := asTestCase(r)
 			c.Failure = &junit.Result{
 				Message: r.Message,
@@ -122,7 +123,7 @@ func (r *Report) toJUnit() junit.Testsuites {
 			return c
 		})
 
-		mapResults(&suite, component.Warnings, func(r conftestOutput.Result) junit.Testcase {
+		mapResults(&suite, component.Warnings, func(r evaluator.Result) junit.Testcase {
 			c := asTestCase(r)
 			c.Skipped = &junit.Result{
 				Message: r.Message,

--- a/internal/applicationsnapshot/junit_test.go
+++ b/internal/applicationsnapshot/junit_test.go
@@ -20,16 +20,16 @@ import (
 	"testing"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
-	"github.com/open-policy-agent/conftest/output"
 	"github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/signature"
 )
 
 func TestMapResults(t *testing.T) {
 	s := junit.Testsuite{}
-	mapResults(&s, []output.Result{{Message: "0"}, {Message: "1"}, {Message: "2"}}, func(r output.Result) junit.Testcase {
+	mapResults(&s, []evaluator.Result{{Message: "0"}, {Message: "1"}, {Message: "2"}}, func(r evaluator.Result) junit.Testcase {
 		return junit.Testcase{
 			Name: r.Message,
 		}
@@ -49,7 +49,7 @@ func TestMapResults(t *testing.T) {
 func TestAsTestCase(t *testing.T) {
 	cases := []struct {
 		name     string
-		result   output.Result
+		result   evaluator.Result
 		expected junit.Testcase
 	}{
 		{
@@ -58,22 +58,22 @@ func TestAsTestCase(t *testing.T) {
 		},
 		{
 			name:     "trivial",
-			result:   output.Result{Message: "msg"},
+			result:   evaluator.Result{Message: "msg"},
 			expected: junit.Testcase{Name: "msg", Classname: "msg"},
 		},
 		{
 			name:     "with code",
-			result:   output.Result{Message: "msg", Metadata: map[string]interface{}{"code": "a.b.c"}},
+			result:   evaluator.Result{Message: "msg", Metadata: map[string]interface{}{"code": "a.b.c"}},
 			expected: junit.Testcase{Name: "a.b.c: msg", Classname: "a.b.c: msg"},
 		},
 		{
 			name:     "with metadata",
-			result:   output.Result{Message: "msg", Metadata: map[string]interface{}{"x": "1", "y": "2", "z": "3"}},
+			result:   evaluator.Result{Message: "msg", Metadata: map[string]interface{}{"x": "1", "y": "2", "z": "3"}},
 			expected: junit.Testcase{Name: "msg [x=1, y=2, z=3]", Classname: "msg [x=1, y=2, z=3]"},
 		},
 		{
 			name:     "with code and metadata",
-			result:   output.Result{Message: "msg", Metadata: map[string]interface{}{"code": "a.b.c", "x": "1", "y": "2", "z": "3"}},
+			result:   evaluator.Result{Message: "msg", Metadata: map[string]interface{}{"code": "a.b.c", "x": "1", "y": "2", "z": "3"}},
 			expected: junit.Testcase{Name: "a.b.c: msg [x=1, y=2, z=3]", Classname: "a.b.c: msg [x=1, y=2, z=3]"},
 		},
 	}
@@ -120,7 +120,7 @@ func TestToJunit(t *testing.T) {
 								},
 							},
 						},
-						Violations: []output.Result{
+						Violations: []evaluator.Result{
 							{
 								Message: "violation",
 								Metadata: map[string]interface{}{
@@ -128,7 +128,7 @@ func TestToJunit(t *testing.T) {
 								},
 							},
 						},
-						Warnings: []output.Result{
+						Warnings: []evaluator.Result{
 							{
 								Message: "warning",
 								Metadata: map[string]interface{}{
@@ -136,7 +136,7 @@ func TestToJunit(t *testing.T) {
 								},
 							},
 						},
-						Successes: []output.Result{
+						Successes: []evaluator.Result{
 							{
 								Message: "success",
 								Metadata: map[string]interface{}{

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -27,12 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/conftest/output"
 	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
@@ -162,7 +162,7 @@ func Test_ReportSummary(t *testing.T) {
 		{
 			name: "testing one violation and warning",
 			input: Component{
-				Violations: []output.Result{
+				Violations: []evaluator.Result{
 					{
 						Message: "short report",
 						Metadata: map[string]interface{}{
@@ -170,7 +170,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Warnings: []output.Result{
+				Warnings: []evaluator.Result{
 					{
 						Message: "short report",
 						Metadata: map[string]interface{}{
@@ -204,12 +204,12 @@ func Test_ReportSummary(t *testing.T) {
 		{
 			name: "testing no metadata",
 			input: Component{
-				Violations: []output.Result{
+				Violations: []evaluator.Result{
 					{
 						Message: "short report",
 					},
 				},
-				Warnings: []output.Result{
+				Warnings: []evaluator.Result{
 					{
 						Message: "short report",
 					},
@@ -236,7 +236,7 @@ func Test_ReportSummary(t *testing.T) {
 		{
 			name: "testing multiple violations and warnings",
 			input: Component{
-				Violations: []output.Result{
+				Violations: []evaluator.Result{
 					{
 						Message: "short report",
 						Metadata: map[string]interface{}{
@@ -250,7 +250,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Warnings: []output.Result{
+				Warnings: []evaluator.Result{
 					{
 						Message: "short report",
 						Metadata: map[string]interface{}{
@@ -290,7 +290,7 @@ func Test_ReportSummary(t *testing.T) {
 		{
 			name: "with successes",
 			input: Component{
-				Violations: []output.Result{
+				Violations: []evaluator.Result{
 					{
 						Message: "violation",
 						Metadata: map[string]interface{}{
@@ -298,7 +298,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Warnings: []output.Result{
+				Warnings: []evaluator.Result{
 					{
 						Message: "warning",
 						Metadata: map[string]interface{}{
@@ -306,7 +306,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Successes: []output.Result{
+				Successes: []evaluator.Result{
 					{
 						Message: "success",
 						Metadata: map[string]interface{}{
@@ -337,7 +337,7 @@ func Test_ReportSummary(t *testing.T) {
 			name:     "with snapshot",
 			snapshot: "snappy",
 			input: Component{
-				Violations: []output.Result{
+				Violations: []evaluator.Result{
 					{
 						Message: "violation",
 						Metadata: map[string]interface{}{
@@ -345,7 +345,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Warnings: []output.Result{
+				Warnings: []evaluator.Result{
 					{
 						Message: "warning",
 						Metadata: map[string]interface{}{
@@ -353,7 +353,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				Successes: []output.Result{
+				Successes: []evaluator.Result{
 					{
 						Message: "success",
 						Metadata: map[string]interface{}{
@@ -429,7 +429,7 @@ func Test_ReportAppstudio(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: true, Warnings: []output.Result{{Message: "this is a warning"}}},
+				{Success: true, Warnings: []evaluator.Result{{Message: "this is a warning"}}},
 			},
 			success: true,
 		},
@@ -446,7 +446,7 @@ func Test_ReportAppstudio(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
+				{Success: false, Violations: []evaluator.Result{{Message: "this is a violation"}}},
 			},
 			success: false,
 		},
@@ -477,8 +477,8 @@ func Test_ReportAppstudio(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
-				{Success: false, Warnings: []output.Result{{Message: "this is a warning"}}},
+				{Success: false, Violations: []evaluator.Result{{Message: "this is a violation"}}},
+				{Success: false, Warnings: []evaluator.Result{{Message: "this is a warning"}}},
 			},
 			success: false,
 		},
@@ -577,7 +577,7 @@ func Test_ReportHACBS(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: true, Warnings: []output.Result{{Message: "this is a warning"}}},
+				{Success: true, Warnings: []evaluator.Result{{Message: "this is a warning"}}},
 			},
 			success: true,
 		},
@@ -594,7 +594,7 @@ func Test_ReportHACBS(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
+				{Success: false, Violations: []evaluator.Result{{Message: "this is a violation"}}},
 			},
 			success: false,
 		},
@@ -625,8 +625,8 @@ func Test_ReportHACBS(t *testing.T) {
 			}`,
 			components: []Component{
 				{Success: true},
-				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
-				{Success: false, Warnings: []output.Result{{Message: "this is a warning"}}},
+				{Success: false, Violations: []evaluator.Result{{Message: "this is a violation"}}},
+				{Success: false, Warnings: []evaluator.Result{{Message: "this is a warning"}}},
 			},
 			success: false,
 		},
@@ -725,17 +725,17 @@ func testComponentsFor(snapshot app.SnapshotSpec) []Component {
 	components := []Component{
 		{
 			SnapshotComponent: snapshot.Components[0],
-			Violations: []output.Result{
+			Violations: []evaluator.Result{
 				{
 					Message: "violation1",
 				},
 			},
-			Warnings: []output.Result{
+			Warnings: []evaluator.Result{
 				{
 					Message: "warning1",
 				},
 			},
-			Successes: []output.Result{
+			Successes: []evaluator.Result{
 				{
 					Message: "success1",
 				},
@@ -744,7 +744,7 @@ func testComponentsFor(snapshot app.SnapshotSpec) []Component {
 		},
 		{
 			SnapshotComponent: snapshot.Components[1],
-			Violations: []output.Result{
+			Violations: []evaluator.Result{
 				{
 					Message: "violation2",
 				},
@@ -753,7 +753,7 @@ func testComponentsFor(snapshot app.SnapshotSpec) []Component {
 		},
 		{
 			SnapshotComponent: snapshot.Components[2],
-			Successes: []output.Result{
+			Successes: []evaluator.Result{
 				{
 					Message: "success3",
 				},

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -20,19 +20,19 @@ import (
 	"encoding/json"
 	"fmt"
 
-	cOutput "github.com/open-policy-agent/conftest/output"
 	"sigs.k8s.io/yaml"
 
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/version"
 )
 
 type ReportItem struct {
-	Filename   string           `json:"filename"`
-	Violations []cOutput.Result `json:"violations"`
-	Warnings   []cOutput.Result `json:"warnings"`
-	Successes  []cOutput.Result `json:"successes"`
+	Filename   string             `json:"filename"`
+	Violations []evaluator.Result `json:"violations"`
+	Warnings   []evaluator.Result `json:"warnings"`
+	Successes  []evaluator.Result `json:"successes"`
 }
 
 type ReportFormat string
@@ -65,9 +65,9 @@ func (r *Report) Add(o output.Output) {
 	for _, check := range o.PolicyCheck {
 		if _, ok := itemsByFile[check.FileName]; !ok {
 			itemsByFile[check.FileName] = ReportItem{
-				Violations: []cOutput.Result{},
-				Warnings:   []cOutput.Result{},
-				Successes:  []cOutput.Result{},
+				Violations: []evaluator.Result{},
+				Warnings:   []evaluator.Result{},
+				Successes:  []evaluator.Result{},
 			}
 		}
 		item := itemsByFile[check.FileName]

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -19,7 +19,6 @@ package definition
 import (
 	"testing"
 
-	conftest "github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
@@ -38,7 +37,9 @@ func TestReport(t *testing.T) {
 		{
 			name: "success",
 			output: []output.Output{
-				{PolicyCheck: evaluator.CheckResults{{CheckResult: conftest.CheckResult{FileName: "/path/to/pipeline.json"}}}},
+				{PolicyCheck: []evaluator.Outcome{
+					evaluator.Outcome{FileName: "/path/to/pipeline.json"},
+				}},
 			},
 			expect: `{"definitions": [{
 				"filename": "/path/to/pipeline.json",
@@ -54,14 +55,12 @@ func TestReport(t *testing.T) {
 			name: "warnings",
 			output: []output.Output{
 				{
-					PolicyCheck: evaluator.CheckResults{
-						{
-							CheckResult: conftest.CheckResult{
-								FileName: "/path/to/pipeline.json",
-								Warnings: []conftest.Result{
-									{Message: "running low in spam"},
-									{Message: "not all like spam"},
-								},
+					PolicyCheck: []evaluator.Outcome{
+						evaluator.Outcome{
+							FileName: "/path/to/pipeline.json",
+							Warnings: []evaluator.Result{
+								{Message: "running low in spam"},
+								{Message: "not all like spam"},
 							},
 						},
 					},
@@ -81,14 +80,12 @@ func TestReport(t *testing.T) {
 			name: "violations",
 			output: []output.Output{
 				{
-					PolicyCheck: evaluator.CheckResults{
-						{
-							CheckResult: conftest.CheckResult{
-								FileName: "/path/to/pipeline.json",
-								Failures: []conftest.Result{
-									{Message: "out of spam!"},
-									{Message: "spam 💔"},
-								},
+					PolicyCheck: []evaluator.Outcome{
+						evaluator.Outcome{
+							FileName: "/path/to/pipeline.json",
+							Failures: []evaluator.Result{
+								{Message: "out of spam!"},
+								{Message: "spam 💔"},
 							},
 						},
 					},
@@ -108,12 +105,10 @@ func TestReport(t *testing.T) {
 			name: "successes",
 			output: []output.Output{
 				{
-					PolicyCheck: evaluator.CheckResults{
-						{
-							CheckResult: conftest.CheckResult{
-								FileName: "/path/to/pipeline.json",
-							},
-							Successes: []conftest.Result{
+					PolicyCheck: []evaluator.Outcome{
+						evaluator.Outcome{
+							FileName: "/path/to/pipeline.json",
+							Successes: []evaluator.Result{
 								{Message: "Nice"},
 								{Message: "Day"},
 							},

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -36,8 +36,8 @@ import (
 type mockEvaluator struct{}
 type badMockEvaluator struct{}
 
-func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, evaluator.Data, error) {
-	return evaluator.CheckResults{}, nil, nil
+func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+	return []evaluator.Outcome{}, nil, nil
 }
 
 func (e mockEvaluator) Destroy() {
@@ -47,7 +47,7 @@ func (e mockEvaluator) CapabilitiesPath() string {
 	return ""
 }
 
-func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, evaluator.Data, error) {
+func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
 	return nil, nil, errors.New("Evaluator error")
 }
 
@@ -87,7 +87,7 @@ func Test_ValidatePipeline(t *testing.T) {
 			name:    "validation succeeds",
 			fpath:   validFile,
 			err:     nil,
-			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{
@@ -115,14 +115,14 @@ func Test_ValidatePipeline(t *testing.T) {
 			name:    "validation succeeds with json input",
 			fpath:   "{\"json\": 1}",
 			err:     nil,
-			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{
 			name:    "validation succeeds with yaml input",
 			fpath:   "kind: task",
 			err:     nil,
-			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{

--- a/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
+++ b/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
@@ -1,76 +1,9 @@
 
 [TestConftestEvaluatorEvaluate - 1]
-evaluator.CheckResults{
+[]evaluator.Outcome{
     {
-        CheckResult: output.CheckResult{
-            FileName:  "$TMPDIR/inputs/data.json",
-            Namespace: "a",
-            Successes: 1,
-            Skipped:   {
-            },
-            Warnings: {
-                {
-                    Message:  "Warning!",
-                    Metadata: {
-                        "code": "a.warning",
-                    },
-                    Outputs: nil,
-                },
-            },
-            Failures: {
-                {
-                    Message:  "Failure!",
-                    Metadata: {
-                        "code": "a.failure",
-                    },
-                    Outputs: nil,
-                },
-            },
-            Exceptions: {
-            },
-            Queries: {
-                {
-                    Query:   "data.a.exception[_][_] == \"\"",
-                    Results: nil,
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.a.deny",
-                    Results: {
-                        {
-                            Message:  "Failure!",
-                            Metadata: {
-                                "code": "a.failure",
-                            },
-                            Outputs: nil,
-                        },
-                    },
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.a.exception[_][_] == \"\"",
-                    Results: nil,
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.a.warn",
-                    Results: {
-                        {
-                            Message:  "Warning!",
-                            Metadata: {
-                                "code": "a.warning",
-                            },
-                            Outputs: nil,
-                        },
-                    },
-                    Traces:  nil,
-                    Outputs: {},
-                },
-            },
-        },
+        FileName:  "$TMPDIR/inputs/data.json",
+        Namespace: "a",
         Successes: {
             {
                 Message:  "Pass",
@@ -80,77 +13,32 @@ evaluator.CheckResults{
                 Outputs: nil,
             },
         },
-    },
-    {
-        CheckResult: output.CheckResult{
-            FileName:  "$TMPDIR/inputs/data.json",
-            Namespace: "b",
-            Successes: 1,
-            Skipped:   {
-            },
-            Warnings: {
-                {
-                    Message:  "Warning!",
-                    Metadata: {
-                        "code": "b.warning",
-                    },
-                    Outputs: nil,
+        Skipped: {
+        },
+        Warnings: {
+            {
+                Message:  "Warning!",
+                Metadata: {
+                    "code": "a.warning",
                 },
-            },
-            Failures: {
-                {
-                    Message:  "Failure!",
-                    Metadata: {
-                        "code": "b.failure",
-                    },
-                    Outputs: nil,
-                },
-            },
-            Exceptions: {
-            },
-            Queries: {
-                {
-                    Query:   "data.b.exception[_][_] == \"\"",
-                    Results: nil,
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.b.deny",
-                    Results: {
-                        {
-                            Message:  "Failure!",
-                            Metadata: {
-                                "code": "b.failure",
-                            },
-                            Outputs: nil,
-                        },
-                    },
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.b.exception[_][_] == \"\"",
-                    Results: nil,
-                    Traces:  nil,
-                    Outputs: {},
-                },
-                {
-                    Query:   "data.b.warn",
-                    Results: {
-                        {
-                            Message:  "Warning!",
-                            Metadata: {
-                                "code": "b.warning",
-                            },
-                            Outputs: nil,
-                        },
-                    },
-                    Traces:  nil,
-                    Outputs: {},
-                },
+                Outputs: nil,
             },
         },
+        Failures: {
+            {
+                Message:  "Failure!",
+                Metadata: {
+                    "code": "a.failure",
+                },
+                Outputs: nil,
+            },
+        },
+        Exceptions: {
+        },
+    },
+    {
+        FileName:  "$TMPDIR/inputs/data.json",
+        Namespace: "b",
         Successes: {
             {
                 Message:  "Pass",
@@ -159,6 +47,28 @@ evaluator.CheckResults{
                 },
                 Outputs: nil,
             },
+        },
+        Skipped: {
+        },
+        Warnings: {
+            {
+                Message:  "Warning!",
+                Metadata: {
+                    "code": "b.warning",
+                },
+                Outputs: nil,
+            },
+        },
+        Failures: {
+            {
+                Message:  "Failure!",
+                Metadata: {
+                    "code": "b.failure",
+                },
+                Outputs: nil,
+            },
+        },
+        Exceptions: {
         },
     },
 }

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -21,12 +21,29 @@ import (
 )
 
 type Evaluator interface {
-	// TODO refactor not to expose Conftest type here
-	Evaluate(ctx context.Context, inputs []string) (CheckResults, Data, error)
+	Evaluate(ctx context.Context, inputs []string) ([]Outcome, Data, error)
 
 	// Destroy performs any cleanup needed
 	Destroy()
 
 	// CapabilitiesPath returns the path to the file where capabilities are defined
 	CapabilitiesPath() string
+}
+
+type Data map[string]any
+
+type Outcome struct {
+	FileName   string   `json:"filename"`
+	Namespace  string   `json:"namespace"`
+	Successes  []Result `json:"successes,omitempty"`
+	Skipped    []Result `json:"skipped,omitempty"`
+	Warnings   []Result `json:"warnings,omitempty"`
+	Failures   []Result `json:"failures,omitempty"`
+	Exceptions []Result `json:"exceptions,omitempty"`
+}
+
+type Result struct {
+	Message  string                 `json:"msg"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Outputs  []string               `json:"outputs,omitempty"`
 }

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"time"
 
-	conftestOutput "github.com/open-policy-agent/conftest/output"
 	"github.com/qri-io/jsonpointer"
 	log "github.com/sirupsen/logrus"
 
@@ -86,14 +85,11 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 	log.Debugf("Found %d attestations", attCount)
 	if attCount == 0 {
 		// This is very much a corner case.
-		out.SetPolicyCheck(evaluator.CheckResults{
+		out.SetPolicyCheck([]evaluator.Outcome{
 			{
-				CheckResult: conftestOutput.CheckResult{
-					Failures: []conftestOutput.Result{{
-						Message: "No attestations contain a subject that match the given image.",
-					},
-					},
-				},
+				Failures: []evaluator.Result{{
+					Message: "No attestations contain a subject that match the given image.",
+				}},
 			},
 		})
 		return out, nil
@@ -105,7 +101,7 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 		return nil, err
 	}
 
-	var allResults evaluator.CheckResults
+	var allResults []evaluator.Outcome
 	for _, e := range a.Evaluators {
 		// Todo maybe: Handle each one concurrently
 		results, data, err := e.Evaluate(ctx, []string{inputPath})

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
-	conftestOutput "github.com/open-policy-agent/conftest/output"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
@@ -43,6 +42,7 @@ import (
 
 	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/fake"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
@@ -60,8 +60,8 @@ func TestValidateImage(t *testing.T) {
 		name               string
 		client             *mockASIClient
 		url                string
-		expectedViolations []conftestOutput.Result
-		expectedWarnings   []conftestOutput.Result
+		expectedViolations []evaluator.Result
+		expectedWarnings   []evaluator.Result
 		expectedImageURL   string
 	}{
 		{
@@ -72,20 +72,20 @@ func TestValidateImage(t *testing.T) {
 				attestations: []oci.Signature{validAttestation},
 			},
 			url:                imageRef,
-			expectedViolations: []conftestOutput.Result{},
-			expectedWarnings:   []conftestOutput.Result{},
+			expectedViolations: []evaluator.Result{},
+			expectedWarnings:   []evaluator.Result{},
 			expectedImageURL:   imageRegistry + "@sha256:" + imageDigest,
 		},
 		{
 			name:   "unaccessible image",
 			client: &mockASIClient{},
 			url:    imageRef,
-			expectedViolations: []conftestOutput.Result{
+			expectedViolations: []evaluator.Result{
 				{Message: "Image URL is not accessible: no response received", Metadata: map[string]interface{}{
 					"code": "builtin.image.accessible",
 				}},
 			},
-			expectedWarnings: []conftestOutput.Result{},
+			expectedWarnings: []evaluator.Result{},
 			expectedImageURL: imageRef,
 		},
 		{
@@ -95,12 +95,12 @@ func TestValidateImage(t *testing.T) {
 				attestations: []oci.Signature{validAttestation},
 			},
 			url: imageRef,
-			expectedViolations: []conftestOutput.Result{
+			expectedViolations: []evaluator.Result{
 				{Message: "Image signature check failed: no image signatures client error", Metadata: map[string]interface{}{
 					"code": "builtin.image.signature_check",
 				}},
 			},
-			expectedWarnings: []conftestOutput.Result{},
+			expectedWarnings: []evaluator.Result{},
 			expectedImageURL: imageRegistry + "@sha256:" + imageDigest,
 		},
 		{
@@ -110,12 +110,12 @@ func TestValidateImage(t *testing.T) {
 				signatures: []oci.Signature{validSignature},
 			},
 			url: imageRef,
-			expectedViolations: []conftestOutput.Result{
+			expectedViolations: []evaluator.Result{
 				{Message: "Image attestation check failed: no image attestations client error", Metadata: map[string]interface{}{
 					"code": "builtin.attestation.signature_check",
 				}},
 			},
-			expectedWarnings: []conftestOutput.Result{},
+			expectedWarnings: []evaluator.Result{},
 			expectedImageURL: imageRegistry + "@sha256:" + imageDigest,
 		},
 	}


### PR DESCRIPTION
This commit improves the Evaluator interface to use its own types instead of the ones defined by conftest.

Conftest is now only used on the places that leverage it, such as `cmd/test`, `internal/downloader`, and `conftest_evaluator`.