### PR TITLE
Bubble up missing sig error

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -601,7 +601,7 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
-          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created.",
+          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created. Error: no matching signatures: invalid or missing digest in claim: sha256:${REGISTRY_acceptance/image:latest_DIGEST}",
           "metadata": {
             "code": "builtin.image.signature_check"
           }
@@ -984,13 +984,13 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
-          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created.",
+          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created. Error: no matching attestations: accepted signatures do not match threshold, Found: 0, Expected 1",
           "metadata": {
             "code": "builtin.attestation.signature_check"
           }
         },
         {
-          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created.",
+          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created. Error: no matching signatures: searching log query: \u0026{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface",
           "metadata": {
             "code": "builtin.image.signature_check"
           }
@@ -1416,7 +1416,7 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
-          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created.",
+          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created. Error: no matching attestations: no matching subject digest found",
           "metadata": {
             "code": "builtin.attestation.signature_check"
           }
@@ -2402,13 +2402,13 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
-          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created.",
+          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created. Error: no matching attestations: searching log query: \u0026{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface",
           "metadata": {
             "code": "builtin.attestation.signature_check"
           }
         },
         {
-          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created.",
+          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created. Error: no matching signatures: searching log query: \u0026{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface",
           "metadata": {
             "code": "builtin.image.signature_check"
           }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -33,11 +33,11 @@ import (
 
 const missingSignatureMessage = "No image signatures found matching the given public key. " +
 	"Verify the correct public key was provided, " +
-	"and a signature was created."
+	"and a signature was created. Error: %s"
 
 const missingAttestationMessage = "No image attestations found matching the given public key. " +
 	"Verify the correct public key was provided, " +
-	"and one or more attestations were created."
+	"and one or more attestations were created. Error: %s"
 
 // VerificationStatus represents the status of a verification check.
 type VerificationStatus struct {
@@ -341,9 +341,9 @@ func wrapCosignErrorMessage(err error, checkType string, p policy.Policy) string
 	if p == nil || !p.Keyless() {
 		switch err.(type) {
 		case *cosign.ErrNoMatchingSignatures:
-			return missingSignatureMessage
+			return fmt.Sprintf(missingSignatureMessage, err)
 		case *cosign.ErrNoMatchingAttestations:
-			return missingAttestationMessage
+			return fmt.Sprintf(missingAttestationMessage, err)
 		}
 	}
 	return fmt.Sprintf("Image %s check failed: %s", checkType, err)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"unsafe"
@@ -865,7 +866,7 @@ func TestSetImageSignatureCheckFromError(t *testing.T) {
 			expectedPassed: false,
 			err:            &noMatchingSignatures,
 			expectedResult: &evaluator.Result{
-				Message: missingSignatureMessage,
+				Message: fmt.Sprintf(missingSignatureMessage, &noMatchingSignatures),
 				Metadata: map[string]interface{}{
 					"code": "builtin.image.signature_check",
 				},
@@ -957,7 +958,7 @@ func TestSetAttestationSignatureCheckFromError(t *testing.T) {
 			expectedPassed: false,
 			err:            &noMatchingAttestations,
 			expectedResult: &evaluator.Result{
-				Message: missingAttestationMessage,
+				Message: fmt.Sprintf(missingAttestationMessage, &noMatchingAttestations),
 				Metadata: map[string]interface{}{
 					"code": "builtin.attestation.signature_check",
 				},


### PR DESCRIPTION
With this change, the cosign errors continue to be wrapped but the original error is also included at the end. This is important in debugging validation failures which may be due to different underlying issues.