### PR TITLE
Use Chains secret from OpenShift Pipelines

### DIFF
--- a/configs/default/policy.yaml
+++ b/configs/default/policy.yaml
@@ -6,7 +6,7 @@ description: >
   Use the policy rules from the "minimal" collection. This and other collections are defined in
   https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
 
-publicKey: "k8s://tekton-chains/public-key"
+publicKey: "k8s://openshift-pipelines/public-key"
 
 sources:
   - name: Default

--- a/configs/everything/policy.yaml
+++ b/configs/everything/policy.yaml
@@ -6,7 +6,7 @@ description: >
   Identical to the default configuration, but use every rule instead of just the rules
   in the minimal collection.
 
-publicKey: "k8s://tekton-chains/public-key"
+publicKey: "k8s://openshift-pipelines/public-key"
 
 sources:
   - name: Everything

--- a/configs/slsa3/policy.yaml
+++ b/configs/slsa3/policy.yaml
@@ -7,7 +7,7 @@ description: >
   two and three of the SLSA v0.1 specification. The minimal and slsa collections are defined in
   https://enterprisecontract.dev/docs/ec-policies/release_policy.html#_available_rule_collections
 
-publicKey: "k8s://tekton-chains/public-key"
+publicKey: "k8s://openshift-pipelines/public-key"
 
 sources:
   - name: Default

--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -121,4 +121,4 @@ echo "${IMAGES}" > "${HACK_DIR}/images.txt"
 cat <<< "$(jq --rawfile images <(echo "$IMAGES") '.components |= [$images | capture("(?<containerImage>.*\/(?<name>.*)@.*)";"g")]' "${HACK_DIR}/application_snapshot.json")" > "${HACK_DIR}/application_snapshot.json"
 
 # update cosign public key
-kubectl get secret -n tekton-chains signing-secrets -o jsonpath='{.data.cosign\.pub}'|base64 -d > "${HACK_DIR}/work/cosign.pub"
+kubectl get secret -n openshift-pipelines signing-secrets -o jsonpath='{.data.cosign\.pub}'|base64 -d > "${HACK_DIR}/work/cosign.pub"

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -33,10 +33,7 @@ components:
 # The key defined here should work, but if it doesn't then you can get a fresh one from the cluster:
 #  - Visit https://oauth-openshift.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/oauth/token/request
 #  - Authenticate and get a token, then use the oc login to authenticate
-#  - kubectl get -n tekton-chains secret public-key -o json | jq -r '.data."cosign.pub" | @base64d'
-#
-# The key might also be available here but currently it's out of date:
-#   https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/pipeline-service/public/tekton-chains-signing-secret.pub
+#  - kubectl get -n openshift-pipelines secret public-key -o json | jq -r '.data."cosign.pub" | @base64d'
 #
 PUBLIC_KEY=${PUBLIC_KEY:-"-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA


### PR DESCRIPTION
Update the existing demo configs and hacking scripts to use the RHTAP public-key secret from the openshift-pipelines namespace.