### PR TITLE
Fix `reference-docs` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ BUILD_IMG_ARCH:=$(shell podman version -f {{.Server.OsArch}} | awk -F/ '{print $
 build-for-test: dist/ec_$(BUILD_IMG_ARCH)
 
 .PHONY: reference-docs
-reference-docs: ## Generate reference documentation input YAML files
+reference-docs: generate ## Generate reference documentation input YAML files
 	@mkdir -p dist
 	@rm -rf dist/cli-reference
 # Make sure docs for experimental commands are generated.


### PR DESCRIPTION
With the change in #910 we introduced code generation that removed the application-api go files, this is now missing when the `reference-docs` target is used.
This fixes the issue by making the `generate` target a dependency of the `reference-docs`, so that the required go files are generated.