### PR TITLE
Experimental image build using Chainguard

### DIFF
--- a/Dockerfile.chainguard
+++ b/Dockerfile.chainguard
@@ -1,0 +1,11 @@
+FROM cgr.dev/chainguard/go AS builder
+ARG VERSION
+COPY . /app
+RUN cd /app && go build \
+  -trimpath \
+  -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${VERSION}" \
+  -o dist/ec
+
+FROM cgr.dev/chainguard/glibc-dynamic
+COPY --from=builder /app/dist/ec /usr/bin/
+ENTRYPOINT ["/usr/bin/ec"]

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,12 @@ ifdef ADD_IMAGE_TAG
 	@podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(ADD_IMAGE_TAG)
 endif
 
+# Proof of concept. Currently not pushed anywhere or used for anything.
+# I'm being lazy and ignoring the additional tags and non-default os/arch options.
+.PHONY: build-image-small
+build-image-small: ## Build a small image using Chainguard base images. Experimental.
+	@podman build -f Dockerfile.chainguard -t $(IMAGE_REPO):snapshot-cg --build-arg VERSION=$(VERSION)
+
 .PHONY: dev
 dev: REGISTRY_PORT=5000
 dev: IMAGE_REPO=localhost:$(REGISTRY_PORT)/ec


### PR DESCRIPTION
Based on [these docs](https://edu.chainguard.dev/chainguard/chainguard-images/reference/go/getting-started-go/#example-2--multistage-docker-build-for-go-chainguard-image).

Not sure if we want or need it, but I'll push a draft PR.

Size comparison:
- `snapshot       331 MB`
- `snapshot-cg    89.1 MB`

Notes:
- We include git-core and jq in the current image build, so the size comparison is not really fair.
- The idea of doing a multi-stage build with a build container may have some value, even if we don't end up using these base images.
- Currently the go modules are downloaded every time, which makes the build a bit slower.