### PR TITLE
Add git resolver keys for v-e-c Task in infra CM

### DIFF
--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -46,12 +46,17 @@ diff \
     <(skopeo inspect --raw "docker://quay.io/hacbs-contract/ec-task-bundle@${TASK_BUNDLE_DIGEST}")
 TASK_BUNDLE_REF="quay.io/hacbs-contract/ec-task-bundle:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
 echo "Resolved bundle is ${TASK_BUNDLE_REF}"
+echo "Resolved revision is ${REVISION}"
 
 echo 'Updating infra-deployments...'
-REF="${TASK_BUNDLE_REF}" yq e -i \
+REF="${TASK_BUNDLE_REF}" REV="${REVISION}" yq e -i \
     '.configMapGenerator[] |=
-        select(.name == "ec-defaults").literals[] |=
-            select(. == "verify_ec_task_bundle=*") = "verify_ec_task_bundle=" + env(REF)' \
+        select(.name == "ec-defaults").literals[] = {
+            "verify_ec_task_bundle": env(REF),
+            "verify_ec_task_git_url": "https://github.com/enterprise-contract/ec-cli.git",
+            "verify_ec_task_git_revision": env(REV),
+            "verify_ec_task_git_pathInRepo": "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml"
+        }' \
     components/enterprise-contract/kustomization.yaml
 
 echo 'infra-deployments updated successfully'


### PR DESCRIPTION
Modifies the pull request generating script to set additional Tekton git resolver keys: `verify_ec_task_git_url`, `verify_ec_task_git_revision` and `verify_ec_task_git_pathInRepo` that can be used to reference the `verify-enterprise-contract` task.

Since the only key in the `ec-defaults` ConfigMap was the existing `verify_ec_task_bundle` this opts to replace the whole `literals` key instead of trying to update it in-place.

Ref. https://issues.redhat.com/browse/HACBS-2489