### PR TITLE
Produce readable note field in appstudio output

### DIFF
--- a/cmd/test/appstudio.go
+++ b/cmd/test/appstudio.go
@@ -51,6 +51,7 @@ func appstudioReport(results []output.CheckResult, namespaces []string) applicat
 	}
 
 	report.DeriveResult(false)
+	report.DeriveNote()
 	return report
 }
 

--- a/features/__snapshots__/conftest_test.snap
+++ b/features/__snapshots__/conftest_test.snap
@@ -19,7 +19,8 @@
   "successes": 1,
   "failures": 0,
   "warnings": 0,
-  "result": "SUCCESS"
+  "result": "SUCCESS",
+  "note": "All checks passed successfully"
 }
 ---
 
@@ -33,7 +34,8 @@
   "successes": 0,
   "failures": 0,
   "warnings": 0,
-  "result": "SKIPPED"
+  "result": "SKIPPED",
+  "note": "All checks were skipped"
 }
 ---
 
@@ -61,7 +63,8 @@
   "successes": 0,
   "failures": 0,
   "warnings": 1,
-  "result": "WARNING"
+  "result": "WARNING",
+  "note": "Warnings detected"
 }
 ---
 
@@ -143,7 +146,8 @@ FAIL - acceptance/examples/empty_input.json - main - Failure due to overripeness
   "successes": 0,
   "failures": 1,
   "warnings": 0,
-  "result": "FAILURE"
+  "result": "FAILURE",
+  "note": "Failures detected"
 }
 ---
 

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -276,6 +276,22 @@ func (r *TestReport) DeriveResult(hasFailures bool) {
 	}
 }
 
+// It's redundant and perhaps not very useful, but let's produce some kind of
+// a human readable note. We could perhaps make this more sophisticated in future,
+// e.g. by including an abbreviated list of failure or warning messages.
+func (r *TestReport) DeriveNote() {
+	switch {
+	case r.Result == "FAILURE":
+		r.Note = "Failures detected"
+	case r.Result == "WARNING":
+		r.Note = "Warnings detected"
+	case r.Result == "SKIPPED":
+		r.Note = "All checks were skipped"
+	case r.Result == "SUCCESS":
+		r.Note = "All checks passed successfully"
+	}
+}
+
 func OutputAppstudioReport(t TestReport) {
 	out, err := json.Marshal(t)
 	if err != nil {


### PR DESCRIPTION
The appstudio output format includes a note field, which prior to this patch was not populated at all unless there was an error. Let's put at least something in that field.

Notes:
- I did consider putting an abbreviated verison of the actual failure or warning messges into the note. I think it would be possible, but it's not simple so I decided not to do it here.
- There seems to be a usability issue with this. If we output only the appstudio summary, then the failure messages and descriptions are not visible anywhere. There are probabaly some ways to get around that, but let's not try to anticipate what the requirements are.