### PR TITLE
Don't license-lint helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ci: test lint-fix acceptance ## Run the usual required CI tasks
 
 ##@ Linters
 
-LICENSE_IGNORE=-ignore 'dist/cli-reference/*.yaml' -ignore 'acceptance/examples/*.yaml' -ignore 'configs/*/*.yaml' -ignore 'node_modules/**'
+LICENSE_IGNORE=-ignore 'dist/cli-reference/*.yaml' -ignore 'acceptance/examples/*.yaml' -ignore 'configs/*/*.yaml' -ignore 'node_modules/**' -ignore 'hack/**/charts/**'
 LINT_TO_GITHUB_ANNOTATIONS='map(map(.)[])[][] as $$d | $$d.posn | split(":") as $$posn | "::warning file=\($$posn[0]),line=\($$posn[1]),col=\($$posn[2])::\($$d.message)"'
 .PHONY: lint
 lint: generate tekton-lint go-mod-lint ## Run linter


### PR DESCRIPTION
Running `make lint-fix` adds a comment to the top of the files of expanded Helm charts, this could corrupt them by commenting out the first line (usually `apiVersion`).