### PR TITLE
Implement acceptance tests for ec init policies

### DIFF
--- a/cmd/initialize/init_policies.go
+++ b/cmd/initialize/init_policies.go
@@ -57,7 +57,7 @@ func initPoliciesCmd() *cobra.Command {
 			ctx := cmd.Context()
 			samplePolicy := hd.Doc(`
 				# Simplest never-failing policy
-				package policy.release.my_package
+				package main
 
 				# METADATA
 				# title: Allow rule

--- a/features/__snapshots__/initialize.snap
+++ b/features/__snapshots__/initialize.snap
@@ -1,0 +1,29 @@
+
+[success:stdout - 1]
+[
+  {
+    "filename": "acceptance/examples/empty_input.json",
+    "namespace": "main",
+    "successes": 1
+  }
+]
+---
+
+[success:stderr - 1]
+
+---
+[appstudio success:stdout - 1]
+{
+  "timestamp": "${TIMESTAMP}",
+  "namespace": "main",
+  "successes": 1,
+  "failures": 0,
+  "warnings": 0,
+  "result": "SUCCESS",
+  "note": "All checks passed successfully"
+}
+---
+
+[appstudio success:stderr - 1]
+
+---

--- a/features/initialize.feature
+++ b/features/initialize.feature
@@ -1,0 +1,17 @@
+Feature: init policies command
+  The ec init policies command should work as expected
+
+  Background:
+    Given the environment variable is set "EC_EXPERIMENTAL=1"
+
+  Scenario: success
+    When ec command is run with "init policies --dest-dir=${TMPDIR}"
+    When ec command is run with "test --policy ${TMPDIR} acceptance/examples/empty_input.json -o json"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: appstudio success
+    When ec command is run with "init policies --dest-dir=${TMPDIR}"
+    When ec command is run with "test --policy ${TMPDIR} acceptance/examples/empty_input.json -o appstudio"
+    Then the exit status should be 0
+    Then the output should match the snapshot


### PR DESCRIPTION
This PR implements two basic acceptance tests for `ec init policies`.

Resolves: #947 