### PR TITLE
Stop using deprecated SLSA provenence struct type

### DIFF
--- a/acceptance/attestation/attestation.go
+++ b/acceptance/attestation/attestation.go
@@ -42,7 +42,7 @@ const (
 
 // CreateStatementFor creates an empty statement that can be further customized
 // to add and subsequently signed by SignStatement.
-func CreateStatementFor(imageName string, image v1.Image) (*in_toto.ProvenanceStatement, error) {
+func CreateStatementFor(imageName string, image v1.Image) (*in_toto.ProvenanceStatementSLSA02, error) {
 	digest, err := image.Digest()
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func CreateStatementFor(imageName string, image v1.Image) (*in_toto.ProvenanceSt
 		return nil, err
 	}
 
-	if statement, ok := obj.(in_toto.ProvenanceStatement); ok {
+	if statement, ok := obj.(in_toto.ProvenanceStatementSLSA02); ok {
 		return &statement, nil
 	}
 
@@ -72,7 +72,7 @@ func CreateStatementFor(imageName string, image v1.Image) (*in_toto.ProvenanceSt
 
 // SignStatement signs the provided statement with the named key. The key needs
 // to be previously generated with the functionality from the crypto package.
-func SignStatement(ctx context.Context, keyName string, statement in_toto.ProvenanceStatement) ([]byte, error) {
+func SignStatement(ctx context.Context, keyName string, statement in_toto.ProvenanceStatementSLSA02) ([]byte, error) {
 	payload, err := json.Marshal(statement)
 	if err != nil {
 		return nil, err

--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -846,7 +846,7 @@ func RawImageSignaturesFrom(ctx context.Context) map[string]string {
 	return ret
 }
 
-func applyPatches(statement *in_toto.ProvenanceStatement, patches *godog.Table) (*in_toto.ProvenanceStatement, error) {
+func applyPatches(statement *in_toto.ProvenanceStatementSLSA02, patches *godog.Table) (*in_toto.ProvenanceStatementSLSA02, error) {
 	if statement == nil || patches == nil || len(patches.Rows) == 0 {
 		return statement, nil
 	}
@@ -869,7 +869,7 @@ func applyPatches(statement *in_toto.ProvenanceStatement, patches *godog.Table) 
 		}
 	}
 
-	var modified in_toto.ProvenanceStatement
+	var modified in_toto.ProvenanceStatementSLSA02
 	if err := json.Unmarshal(stmt, &modified); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The in_toto.ProvenanceStatementSLSA02 struct is identical to the deprecated in_toto.ProvenanceStatement struct. Let's stop using the older one.

https://github.com/in-toto/in-toto-golang/blob/8a5dc9e6d8637cf72c4b5103216ce3445e053a14/in_toto/attestations.go#L66