### PR TITLE
Add additional timestamp-based tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       head_sha: ${{ steps.head_sha.outputs.head_sha }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
 
     steps:
       - name: Git Info
@@ -42,6 +43,10 @@ jobs:
           GH_COBRA: 1
         run: |
           echo head_sha=$(gh api /repos/enterprise-contract/ec-cli/git/matching-refs/heads/main --jq '.[0].object.sha') >> "$GITHUB_OUTPUT"
+      - name: Timestamp
+        id: timestamp
+        run: |
+          echo timestamp=$(date '+%s') >> "$GITHUB_OUTPUT"
 
   release:
 
@@ -58,6 +63,7 @@ jobs:
       IMAGE_REPO: quay.io/hacbs-contract/ec-cli
       EC_IMAGE_REPO: quay.io/enterprise-contract/ec-cli
       TAG: ${{ github.sha }}
+      TAG_TIMESTAMP: ${{ github.sha }}-${{ needs.info.outputs.timestamp }}
 
     steps:
       # TODO: Enabling this seems to cause the host to run out of disk space.
@@ -112,7 +118,7 @@ jobs:
 
       # TODO: Remove this once all references to quay.io/hacbs-contract are removed
       - name: Create and push image
-        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG=snapshot
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
       # TODO: Remove this once all references to quay.io/hacbs-contract are removed
       - name: Create and push the tekton bundle
@@ -124,13 +130,13 @@ jobs:
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
 
       - name: Create and push image (quay.io/enterprise-contract/ec-cli)
-        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$EC_IMAGE_REPO ADD_IMAGE_TAG=snapshot
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$EC_IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
       - name: Create and push the tekton bundle (quay.io/enterprise-contract/ec-task-bundle)
         env:
           TASK_REPO: quay.io/enterprise-contract/ec-task-bundle
           TASK: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-definition/0.1/verify-definition.yaml"
-        run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG TASK=<( yq e ".spec.steps[].image? = \"$EC_IMAGE_REPO:$TAG\"" $TASK | yq 'select(. != null)')
+        run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP" TASK=<( yq e ".spec.steps[].image? = \"$EC_IMAGE_REPO:$TAG\"" $TASK | yq 'select(. != null)')
 
       - name: Download statistics
         env:

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,9 @@ dist-image-push: dist-image  $(subst image_,push_image_,$(ALL_SUPPORTED_IMG_OS_A
 	@for img in $(ALL_IMAGE_REFS); do TARGETOS=$$(echo $$img | sed -e 's/.*:[^-]\+-\([^-]\+\).*/\1/'); TARGETARCH=$${img/*-}; podman manifest add $(IMAGE_REPO):$(IMAGE_TAG) $(PODMAN_OPTS) $$img --os $${TARGETOS} --arch $${TARGETARCH}; done
 	@podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)
 ifdef ADD_IMAGE_TAG
-	@podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(ADD_IMAGE_TAG)
+	@for tag in $(ADD_IMAGE_TAG); do
+	  @podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$${tag}
+	done
 endif
 
 .PHONY: dev
@@ -266,6 +268,11 @@ task-bundle: ## Push the Tekton Task bundle an image repository
 task-bundle-snapshot: task-bundle ## Push task bundle and then tag with "snapshot"
 	@skopeo copy "docker://$(TASK_REPO):$(TASK_TAG)" "docker://$(TASK_REPO):snapshot" $(SKOPEO_ARGS)
 	echo Tagged $(TASK_REPO):$(TASK_TAG) with snapshot tag
+ifdef ADD_TASK_TAG
+	@for tag in $(ADD_TASK_TAG); do
+	  @skopeo copy "docker://$(TASK_REPO):$(TASK_TAG)" "docker://$(TASK_REPO):$${tag}"
+	done
+endif
 
 # Useful to compare the `ec test` command source with the `conftest test`
 # command source. They should be almost identical.


### PR DESCRIPTION
In addition to the `snapshot` and the `git-id` tags, this also tags the ec-cli and Tekton bundle images with a `git-id-timestmp` tag.

This should prevent quay.io from garbage collecting blobs that have had their tag moved.

Ref. https://issues.redhat.com/browse/HACBS-2567