### PR TITLE
Lookup the latest digest of for a image tag

### DIFF
--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -17,3 +17,53 @@ task-bundles:
 [:stderr - 1]
 
 ---
+
+[:stdout - 2]
+/-/-/-/
+pipeline-bundles:
+  ${REGISTRY}/acceptance/bundle:
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+      effective_on: "${TIMESTAMP}"
+      tag: tag
+    - digest: sha256:21040e5abd0e077b7344574473468beff02cd6cc66dc464acb3c6b4be5bb82af
+      effective_on: "2006-01-02T15:04:05Z"
+      tag: tag
+task-bundles:
+  ${REGISTRY}/acceptance/bundle:
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+      effective_on: "${TIMESTAMP}"
+      tag: tag
+    - digest: sha256:21040e5abd0e077b7344574473468beff02cd6cc66dc464acb3c6b4be5bb82af
+      effective_on: "2006-01-02T15:04:05Z"
+      tag: tag
+
+---
+
+[:stderr - 2]
+
+---
+
+[Fresh tags:stdout - 1]
+/-/-/-/
+pipeline-bundles:
+  ${REGISTRY}/acceptance/bundle:
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+      effective_on: "${TIMESTAMP}"
+      tag: tag
+    - digest: sha256:21040e5abd0e077b7344574473468beff02cd6cc66dc464acb3c6b4be5bb82af
+      effective_on: "2006-01-02T15:04:05Z"
+      tag: tag
+task-bundles:
+  ${REGISTRY}/acceptance/bundle:
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+      effective_on: "${TIMESTAMP}"
+      tag: tag
+    - digest: sha256:21040e5abd0e077b7344574473468beff02cd6cc66dc464acb3c6b4be5bb82af
+      effective_on: "2006-01-02T15:04:05Z"
+      tag: tag
+
+---
+
+[Fresh tags:stderr - 1]
+
+---

--- a/features/track_bundle.feature
+++ b/features/track_bundle.feature
@@ -86,3 +86,28 @@ Feature: track bundles
           tag: tag
 
     """
+
+  Scenario: Fresh tags
+    Given a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1     |
+      | Pipeline | pipeline1 |
+      And a track bundle file named "${TMPDIR}/bundles.yaml" containing
+    """
+    ---
+    pipeline-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+          effective_on: 2006-01-02T15:04:05Z
+          tag: tag
+    task-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+          effective_on: 2006-01-02T15:04:05Z
+          tag: tag
+    """
+      And a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1-updated     |
+      | Pipeline | pipeline1-updated |
+    When ec command is run with "track bundle --input ${TMPDIR}/bundles.yaml --bundle ${REGISTRY}/acceptance/bundle:tag"
+    Then the exit status should be 0
+    Then the output should match the snapshot

--- a/internal/image/process_test.go
+++ b/internal/image/process_test.go
@@ -19,6 +19,7 @@
 package image
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -100,13 +101,14 @@ func TestParseAndResolveAll(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// func Head(ref name.Reference, options ...Option) (*v1.Descriptor, error) {
-			remoteHead = func(ref name.Reference, options ...remote.Option) (*v1.Descriptor, error) {
+			remoteHead := func(ref name.Reference, options ...remote.Option) (*v1.Descriptor, error) {
 				// Ensure it is only called when expected.
 				assert.NotEmpty(t, tt.headDigest)
 				return &v1.Descriptor{Digest: tt.headDigest}, nil
 			}
-			refs, err := ParseAndResolveAll(tt.urls, tt.opts...)
+			ctx := context.WithValue(context.Background(), RemoteHead, remoteHead)
+
+			refs, err := ParseAndResolveAll(ctx, tt.urls, tt.opts...)
 			if tt.err != "" {
 				assert.ErrorContains(t, err, tt.err)
 				return

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -50,7 +50,7 @@ func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Pol
 		return out, nil
 	}
 
-	if resolved, err := resolveAndSetImageUrl(comp.ContainerImage, a); err != nil {
+	if resolved, err := resolveAndSetImageUrl(ctx, comp.ContainerImage, a); err != nil {
 		return nil, err
 	} else {
 		out.ImageURL = resolved
@@ -127,10 +127,10 @@ func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Pol
 	return out, nil
 }
 
-func resolveAndSetImageUrl(url string, asi *application_snapshot_image.ApplicationSnapshotImage) (string, error) {
+func resolveAndSetImageUrl(ctx context.Context, url string, asi *application_snapshot_image.ApplicationSnapshotImage) (string, error) {
 	// Ensure image URL contains a digest to avoid ambiguity in the next
 	// validation steps
-	ref, err := ParseAndResolve(url)
+	ref, err := ParseAndResolve(ctx, url)
 	if err != nil {
 		log.Debugf("Failed to parse image url %s", url)
 		return "", err

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -271,7 +271,7 @@ var validAttestation = sign(&in_toto.Statement{
 func withImageConfig(ctx context.Context, url string) context.Context {
 	// Internally, ValidateImage strips off the tag from the image reference and
 	// leaves just the digest. Do the same here so mock matching works.
-	refWithTag, err := ParseAndResolve(url)
+	refWithTag, err := ParseAndResolve(ctx, url)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In `ec track bundle`, given a set of images to track either contained in `--input` or provided via `--bundle` parameter, if the `--freshen` flag is provided an additional lookup is done to fetch the latest digest of the image for the provided tag.

Ref. https://issues.redhat.com/browse/HACBS-2594