### PR TITLE
Add .pre-commit-config.yaml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+repos:
+  - repo: https://github.com/enterprise-contract/hooks
+    rev: v0.0.2
+    hooks:
+      - id: check-commit-message 


### PR DESCRIPTION
This commit adds a .pre-commit-config.yaml file which is used to implement commit hook scripts. At this time the only hook specified is a commit-msg hook that calls a script which validates that the commit message contains a reference to an issue or ticket identifier.

ref: HACBS-2653