### PR TITLE
Refactor and fix top level flag handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,6 @@ package cmd
 import (
 	"context"
 	"os"
-	"time"
-
-	"github.com/spf13/cobra"
 
 	"github.com/enterprise-contract/ec-cli/cmd/fetch"
 	"github.com/enterprise-contract/ec-cli/cmd/initialize"
@@ -31,31 +28,11 @@ import (
 	"github.com/enterprise-contract/ec-cli/cmd/track"
 	"github.com/enterprise-contract/ec-cli/cmd/validate"
 	"github.com/enterprise-contract/ec-cli/cmd/version"
-	"github.com/enterprise-contract/ec-cli/internal/kubernetes"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
 // RootCmd represents the base command when called without any subcommands
-var RootCmd = root.NewRootCmd(quiet, verbose, debug, trace, globalTimeout)
-
-var quiet bool = false
-var verbose bool = false
-var debug bool = false
-var trace bool = false
-var globalTimeout = 5 * time.Minute
-
-func init() {
-	setFlags(RootCmd)
-}
-
-func setFlags(rootCmd *cobra.Command) {
-	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", quiet, "less verbose output")
-	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", verbose, "more verbose output")
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", debug, "same as verbose but also show function names and line numbers")
-	rootCmd.PersistentFlags().BoolVar(&trace, "trace", trace, "enable trace logging")
-	rootCmd.PersistentFlags().DurationVar(&globalTimeout, "timeout", globalTimeout, "max overall execution duration")
-	kubernetes.AddKubeconfigFlag(rootCmd)
-}
+var RootCmd = root.NewRootCmd()
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.

--- a/cmd/root/root_cmd.go
+++ b/cmd/root/root_cmd.go
@@ -23,12 +23,19 @@ import (
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"github.com/enterprise-contract/ec-cli/internal/kubernetes"
 	"github.com/enterprise-contract/ec-cli/internal/logging"
 )
 
 var cancel context.CancelFunc
 
-func NewRootCmd(verbose bool, quiet bool, debug bool, trace bool, globalTimeout time.Duration) *cobra.Command {
+var quiet bool = false
+var verbose bool = false
+var debug bool = false
+var trace bool = false
+var globalTimeout = 5 * time.Minute
+
+func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "ec",
 		Short: "Enterprise Contract CLI",
@@ -57,5 +64,16 @@ func NewRootCmd(verbose bool, quiet bool, debug bool, trace bool, globalTimeout 
 		},
 	}
 
+	setFlags(rootCmd)
+
 	return rootCmd
+}
+
+func setFlags(rootCmd *cobra.Command) {
+	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", quiet, "less verbose output")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", verbose, "more verbose output")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", debug, "same as verbose but also show function names and line numbers")
+	rootCmd.PersistentFlags().BoolVar(&trace, "trace", trace, "enable trace logging")
+	rootCmd.PersistentFlags().DurationVar(&globalTimeout, "timeout", globalTimeout, "max overall execution duration")
+	kubernetes.AddKubeconfigFlag(rootCmd)
 }


### PR DESCRIPTION
The vars designed to hold the global flag values were being used to create the command before the associated flag values were read. This patch moves the vars and does the flag parsing to a place where the vars will be in the right scope. I believe this bug was introduced in PR #1021.

Resolves: https://issues.redhat.com/browse/HACBS-2688