### PR TITLE
Refactor tests to utilize full Cobra command backend

### DIFF
--- a/cmd/initialize/init_policies_test.go
+++ b/cmd/initialize/init_policies_test.go
@@ -24,8 +24,10 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/enterprise-contract/ec-cli/cmd/root"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
@@ -33,12 +35,15 @@ func TestInitializeNoError(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ctx := utils.WithFS(context.Background(), fs)
 
-	cmd := initPoliciesCmd()
+	initPoliciesCmd := initPoliciesCmd()
+	cmd := setUpCobra(initPoliciesCmd)
 	cmd.SetContext(ctx)
 	buffy := new(bytes.Buffer)
 	cmd.SetOut(buffy)
 
 	cmd.SetArgs([]string{
+		"init",
+		"policies",
 		"--dest-dir",
 		"sample",
 	})
@@ -51,12 +56,15 @@ func TestInitializeSamplePolicy(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ctx := utils.WithFS(context.Background(), fs)
 
-	cmd := initPoliciesCmd()
+	initPoliciesCmd := initPoliciesCmd()
+	cmd := setUpCobra(initPoliciesCmd)
 	cmd.SetContext(ctx)
 	buffy := new(bytes.Buffer)
 	cmd.SetOut(buffy)
 
 	cmd.SetArgs([]string{
+		"init",
+		"policies",
 		"--dest-dir",
 		"sample",
 	})
@@ -74,12 +82,26 @@ func TestInitializeStdOut(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ctx := utils.WithFS(context.Background(), fs)
 
-	cmd := initPoliciesCmd()
+	initPoliciesCmd := initPoliciesCmd()
+	cmd := setUpCobra(initPoliciesCmd)
 	cmd.SetContext(ctx)
 	buffy := bytes.Buffer{}
 	cmd.SetOut(&buffy)
 
+	cmd.SetArgs([]string{
+		"init",
+		"policies",
+	})
+
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Contains(t, buffy.String(), "Simplest never-failing policy")
+}
+
+func setUpCobra(command *cobra.Command) *cobra.Command {
+	initCmd := NewInitCmd()
+	initCmd.AddCommand(command)
+	cmd := root.NewRootCmd()
+	cmd.AddCommand(initCmd)
+	return cmd
 }

--- a/cmd/track/track_bundle_test.go
+++ b/cmd/track/track_bundle_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/enterprise-contract/ec-cli/cmd/root"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
@@ -212,9 +213,14 @@ func Test_TrackBundleCommand(t *testing.T) {
 				assert.NotEmpty(t, invocation) // in tests this will be the cmd.test in temp directory, counting on os.Args to be correct when ec-cli is invoked
 				return nil
 			}
-			cmd := trackBundleCmd(track, pullImage, pushImage)
+			completeArgs := append([]string{"track", "bundle"}, c.args...)
+			trackBundleCmd := trackBundleCmd(track, pullImage, pushImage)
+			trackCmd := NewTrackCmd()
+			trackCmd.AddCommand(trackBundleCmd)
+			cmd := root.NewRootCmd()
+			cmd.AddCommand(trackCmd)
 			cmd.SetContext(ctx)
-			cmd.SetArgs(c.args)
+			cmd.SetArgs(completeArgs)
 			var out bytes.Buffer
 			cmd.SetOut(&out)
 			err := cmd.Execute()

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -39,12 +39,15 @@ func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 		return &output2.Output{PolicyCheck: []evaluator.Outcome{{FileName: fpath}}}, nil
 	}
 
-	cmd := validateDefinitionCmd(validate)
+	validateDefinitionCmd := validateDefinitionCmd(validate)
+	cmd := setUpCobra(validateDefinitionCmd)
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
 	cmd.SetArgs([]string{
+		"validate",
+		"definition",
 		"--file",
 		"/path/file1.yaml",
 		"--file",
@@ -85,12 +88,15 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 		return &output2.Output{}, nil
 	}
 
-	cmd := validateDefinitionCmd(validate)
+	validateDefinitionCmd := validateDefinitionCmd(validate)
+	cmd := setUpCobra(validateDefinitionCmd)
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
 	cmd.SetArgs([]string{
+		"validate",
+		"definition",
 		"--file",
 		"/path/file1.yaml",
 		"--policy",
@@ -158,12 +164,15 @@ func TestDefinitionFileOutputFormats(t *testing.T) {
 				return &output2.Output{PolicyCheck: []evaluator.Outcome{{FileName: fpath}}}, nil
 			}
 
-			cmd := validateDefinitionCmd(validate)
+			validateDefinitionCmd := validateDefinitionCmd(validate)
+			cmd := setUpCobra(validateDefinitionCmd)
 
 			var out bytes.Buffer
 			cmd.SetOut(&out)
 
 			cmd.SetArgs(append([]string{
+				"validate",
+				"definition",
 				"--file",
 				"/path/file1.yaml",
 			}, c.output...))
@@ -188,13 +197,16 @@ func TestValidateDefinitionFileCommandErrors(t *testing.T) {
 		return nil, errors.New(fpath)
 	}
 
-	cmd := validateDefinitionCmd(validate)
+	validateDefinitionCmd := validateDefinitionCmd(validate)
+	cmd := setUpCobra(validateDefinitionCmd)
 
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SilenceUsage = true
 
 	cmd.SetArgs([]string{
+		"validate",
+		"definition",
 		"--file",
 		"/path/file1.yaml",
 		"--file",
@@ -245,8 +257,9 @@ func TestStrictOutput(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			cmd := validateDefinitionCmd(validate)
-			cmd.SetArgs(c.args)
+			validateDefinitionCmd := validateDefinitionCmd(validate)
+			cmd := setUpCobra(validateDefinitionCmd)
+			cmd.SetArgs(append([]string{"validate", "definition"}, c.args...))
 			err := cmd.Execute()
 			assert.Equal(t, c.expectedError, err)
 		})


### PR DESCRIPTION
This PR refactors `ec-cli`'s tests to utilize the modular Cobra command hierarchy introduced in #1010. Resolves #1011.