### PR TITLE
Relax the SLSA Provenance schema validation

### DIFF
--- a/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
+++ b/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
@@ -269,21 +269,11 @@
 
 [TestPredicateInvocationConfigSourceUri/case_1 - 1]
 []jsonschema.KeyError{
-    {
-        PropertyPath: "/predicate/invocation/configSource/uri",
-        InvalidValue: "",
-        Message:      "invalid uri: uri missing scheme prefix",
-    },
 }
 ---
 
 [TestPredicateInvocationConfigSourceUri/case_2 - 1]
 []jsonschema.KeyError{
-    {
-        PropertyPath: "/predicate/invocation/configSource/uri",
-        InvalidValue: "not_uri",
-        Message:      "invalid uri: uri missing scheme prefix",
-    },
 }
 ---
 

--- a/pkg/schema/slsa_provenance_v0.2.json
+++ b/pkg/schema/slsa_provenance_v0.2.json
@@ -94,8 +94,7 @@
               "type": "object",
               "properties": {
                 "uri": {
-                  "type": "string",
-                  "format": "uri"
+                  "type": "string"
                 },
                 "digest": {
                   "$ref": "#/$defs/DigestSet"

--- a/pkg/schema/slsa_provenance_v0.2_test.go
+++ b/pkg/schema/slsa_provenance_v0.2_test.go
@@ -125,6 +125,7 @@ func TestPredicateBuilderType(t *testing.T) {
 func TestPredicateInvocationConfigSourceUri(t *testing.T) {
 	check(t,
 		`{"predicate": {"invocation": {"configSource": {"uri": null}}}}`, // is optional, so `null` is allowed
+		// Values without a scheme are currently allowed due to https://github.com/tektoncd/chains/issues/934.
 		`{"predicate": {"invocation": {"configSource": {"uri": ""}}}}`,
 		`{"predicate": {"invocation": {"configSource": {"uri": "not_uri"}}}}`,
 		`{"predicate": {"invocation": {"configSource": {"uri": "scheme:authority"}}}}`,


### PR DESCRIPTION
Chains is not populating the `invocation.configSource.uri` attribute correctly, due to https://github.com/tektoncd/chains/issues/934

This change relaxes the schema validation until the issue in Chains is fixed and widely adopted.

Ref: RHTAPBUGS-857