### PR TITLE
Note how to exclude a violation in the description

### DIFF
--- a/acceptance/examples/reject.rego
+++ b/acceptance/examples/reject.rego
@@ -1,6 +1,10 @@
 # Simplest always-failing policy
 package main
 
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
 # METADATA
 # title: Reject rule
 # description: >-
@@ -12,11 +16,41 @@ package main
 #   solution: None
 #   collections:
 #   - A
-deny[result] {
+deny contains result if {
 	result := {
 		"code": "main.rejector",
 		"collections": ["A"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Fails always",
 	}
+}
+
+# METADATA
+# title: Reject with term rule
+# description: >-
+#   This rule xref:sith.adoc#commandments[will always]
+#   xref:attachment$failing_is_the_new_success.yml[fail]
+# custom:
+#   short_name: reject_with_term
+#   failure_msg: Fails always
+#   solution: None
+#   collections:
+#   - A
+deny contains result if {
+	some result in [
+		{
+			"code": "main.reject_with_term",
+			"term": "term1",
+			"collections": ["A"],
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Fails always (term1)",
+		},
+		{
+			"code": "main.reject_with_term",
+			"term": "term2",
+			"collections": ["A"],
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Fails always (term2)",
+		},
+	]
 }

--- a/features/__snapshots__/inspect_policy.snap
+++ b/features/__snapshots__/inspect_policy.snap
@@ -108,6 +108,11 @@ Reject rule
 This rule will always fail
 [A]
 --
+main.reject_with_term (deny)
+Reject with term rule
+This rule will always fail
+[A]
+--
 
 ---
 

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -81,7 +81,6 @@ components:
       description: The image signature matches available signing materials.
       title: Image signature check passed
     msg: Pass
-  warnings:
   - metadata:
       code: test.no_skipped_tests
       collections:
@@ -89,12 +88,8 @@ components:
       depends_on:
       - test.test_data_found
       description: Produce a warning if any tests have their result set to "SKIPPED".
-      solution: There is a test that was skipped. Make sure that each task with a
-        result named 'TEST_OUTPUT' was not skipped. You can find which test was skipped
-        by examining the 'result' key in the 'TEST_OUTPUT'.
-      term: skipped
       title: No tests were skipped
-    msg: Test "skipped" was skipped
+    msg: Pass
 ec-version: ${EC_VERSION}
 effective-time: "${TIMESTAMP}"
 key: |
@@ -144,7 +139,6 @@ components:
       description: The image signature matches available signing materials.
       title: Image signature check passed
     msg: Pass
-  warnings:
   - metadata:
       code: test.no_skipped_tests
       collections:
@@ -152,12 +146,8 @@ components:
       depends_on:
       - test.test_data_found
       description: Produce a warning if any tests have their result set to "SKIPPED".
-      solution: There is a test that was skipped. Make sure that each task with a
-        result named 'TEST_OUTPUT' was not skipped. You can find which test was skipped
-        by examining the 'result' key in the 'TEST_OUTPUT'.
-      term: skipped
       title: No tests were skipped
-    msg: Test "skipped" was skipped
+    msg: Pass
 ec-version: ${EC_VERSION}
 effective-time: "${TIMESTAMP}"
 key: |
@@ -372,13 +362,13 @@ TUF_MIRROR not set. Skipping TUF root initialization.
 
 [Strict with warnings:results - 1]
 {
-  "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":1,\"result\":\"WARNING\"}"
+  "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":4,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}"
 }
 ---
 
 [Non strict with warnings:results - 1]
 {
-  "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":1,\"result\":\"WARNING\"}"
+  "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":4,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}"
 }
 ---
 

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -76,7 +76,7 @@
 ---
 
 [JUnit and AppStudio output format:stdout - 1]
-<testsuites tests="5" failures="1"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="5" failures="1" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
+<testsuites tests="7" failures="3"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="7" failures="3" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.reject_with_term: Fails always (term1)" classname="main.reject_with_term: Fails always (term1)"><failure message="Fails always (term1)"><![CDATA[Fails always (term1)]]></failure></testcase><testcase name="main.reject_with_term: Fails always (term2)" classname="main.reject_with_term: Fails always (term2)"><failure message="Fails always (term2)"><![CDATA[Fails always (term2)]]></failure></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
 ---
 
 [JUnit and AppStudio output format:stderr - 1]
@@ -88,7 +88,7 @@ Error: success criteria not met
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
   "successes": 4,
-  "failures": 1,
+  "failures": 3,
   "warnings": 0,
   "result": "FAILURE"
 }
@@ -513,6 +513,18 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
+          "msg": "Fails always (term1)",
+          "metadata": {
+            "code": "main.reject_with_term"
+          }
+        },
+        {
+          "msg": "Fails always (term2)",
+          "metadata": {
+            "code": "main.reject_with_term"
+          }
+        },
+        {
           "msg": "Fails always",
           "metadata": {
             "code": "main.rejector"
@@ -858,6 +870,18 @@ Error: success criteria not met
       "containerImage": "${REGISTRY}/acceptance/ec-multiple-sources@sha256:${REGISTRY_acceptance/ec-multiple-sources:latest_DIGEST}",
       "source": {},
       "violations": [
+        {
+          "msg": "Fails always (term1)",
+          "metadata": {
+            "code": "main.reject_with_term"
+          }
+        },
+        {
+          "msg": "Fails always (term2)",
+          "metadata": {
+            "code": "main.reject_with_term"
+          }
+        },
         {
           "msg": "Fails always",
           "metadata": {
@@ -1554,13 +1578,39 @@ Error: success criteria not met
       "source": {},
       "violations": [
         {
+          "msg": "Fails always (term1)",
+          "metadata": {
+            "code": "main.reject_with_term",
+            "collections": [
+              "A"
+            ],
+            "description": "This rule will always fail. To exclude this rule add \"main.reject_with_term:term1\" to the `exclude` section of the policy configuration.",
+            "solution": "None",
+            "term": "term1",
+            "title": "Reject with term rule"
+          }
+        },
+        {
+          "msg": "Fails always (term2)",
+          "metadata": {
+            "code": "main.reject_with_term",
+            "collections": [
+              "A"
+            ],
+            "description": "This rule will always fail. To exclude this rule add \"main.reject_with_term:term2\" to the `exclude` section of the policy configuration.",
+            "solution": "None",
+            "term": "term2",
+            "title": "Reject with term rule"
+          }
+        },
+        {
           "msg": "Fails always",
           "metadata": {
             "code": "main.rejector",
             "collections": [
               "A"
             ],
-            "description": "This rule will always fail",
+            "description": "This rule will always fail. To exclude this rule add \"main.rejector\" to the `exclude` section of the policy configuration.",
             "solution": "None",
             "title": "Reject rule"
           }

--- a/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
+++ b/internal/evaluator/__snapshots__/conftest_evaluator_test.snap
@@ -8,7 +8,9 @@
             {
                 Message:  "Pass",
                 Metadata: {
-                    "code": "a.success",
+                    "code":        "a.success",
+                    "description": "Success description.",
+                    "title":       "Success",
                 },
                 Outputs: nil,
             },
@@ -19,7 +21,9 @@
             {
                 Message:  "Warning!",
                 Metadata: {
-                    "code": "a.warning",
+                    "code":        "a.warning",
+                    "description": "Warning description.",
+                    "title":       "Warning",
                 },
                 Outputs: nil,
             },
@@ -28,7 +32,9 @@
             {
                 Message:  "Failure!",
                 Metadata: {
-                    "code": "a.failure",
+                    "code":        "a.failure",
+                    "description": "Failure description. To exclude this rule add \"a.failure\" to the `exclude` section of the policy configuration.",
+                    "title":       "Failure",
                 },
                 Outputs: nil,
             },

--- a/internal/evaluator/__testdir__/simple/a.rego
+++ b/internal/evaluator/__testdir__/simple/a.rego
@@ -2,6 +2,8 @@
 package a
 
 # METADATA
+# title: Failure
+# description: Failure description.
 # custom:
 #   short_name: failure
 deny[result] {
@@ -11,6 +13,8 @@ deny[result] {
 	}
 }
 # METADATA
+# title: Warning
+# description: Warning description.
 # custom:
 #   short_name: warning
 warn[result] {
@@ -20,6 +24,8 @@ warn[result] {
 	}
 }
 # METADATA
+# title: Success
+# description: Success description.
 # custom:
 #   short_name: success
 deny[result] {

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -103,8 +103,29 @@ func trim(results *[]Outcome) {
 		return trimmed
 	}
 
+	addNote := func(results []Result) []Result {
+		for i := range results {
+			var description, code string
+			var ok bool
+			if description, ok = results[i].Metadata[metadataDescription].(string); !ok {
+				continue
+			}
+
+			if code, ok = results[i].Metadata[metadataCode].(string); !ok {
+				continue
+			}
+
+			if term, ok := results[i].Metadata[metadataTerm]; ok {
+				code = fmt.Sprintf("%s:%s", code, term)
+			}
+			results[i].Metadata[metadataDescription] = fmt.Sprintf("%s. To exclude this rule add %q to the `exclude` section of the policy configuration.", strings.TrimSuffix(description, "."), code)
+		}
+
+		return results
+	}
+
 	for i, checks := range *results {
-		(*results)[i].Failures = trimOutput(checks.Failures)
+		(*results)[i].Failures = addNote(trimOutput(checks.Failures))
 		(*results)[i].Warnings = trimOutput(checks.Warnings)
 		(*results)[i].Skipped = trimOutput(checks.Skipped)
 		(*results)[i].Successes = trimOutput(checks.Successes)


### PR DESCRIPTION
This adds the text:

```
To exclude this rule add \"<code>[:term]\" to the `exclude` section of
the policy configuration
```

To the description field in the output when `--info` is provided to `validate image` command.

resolves: HACBS-2665