### PR TITLE
Allow policy as ECP or as ECP.Spec

### DIFF
--- a/cmd/validate/__snapshots__/image_test.snap
+++ b/cmd/validate/__snapshots__/image_test.snap
@@ -1,0 +1,76 @@
+
+[Test_ValidateImageCommandYAMLPolicyFile/spec - 1]
+{
+ "components": [
+  {
+   "containerImage": "registry/image:tag",
+   "name": "Unnamed",
+   "source": {},
+   "success": true
+  }
+ ],
+ "ec-version": "development",
+ "effective-time": "1970-01-01T00:00:00Z",
+ "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
+ "policy": {
+  "configuration": {
+   "exclude": [
+    "not_useful",
+    "test:conftest-clair"
+   ],
+   "include": [
+    "always_checked",
+    "@salsa_one_collection"
+   ]
+  },
+  "description": "My custom enterprise contract policy configuration",
+  "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
+  "sources": [
+   {
+    "policy": [
+     "quay.io/hacbs-contract/ec-release-policy:latest"
+    ]
+   }
+  ]
+ },
+ "success": true
+}
+---
+
+[Test_ValidateImageCommandYAMLPolicyFile/ecp - 1]
+{
+ "components": [
+  {
+   "containerImage": "registry/image:tag",
+   "name": "Unnamed",
+   "source": {},
+   "success": true
+  }
+ ],
+ "ec-version": "development",
+ "effective-time": "1970-01-01T00:00:00Z",
+ "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
+ "policy": {
+  "configuration": {
+   "exclude": [
+    "not_useful",
+    "test:conftest-clair"
+   ],
+   "include": [
+    "always_checked",
+    "@salsa_one_collection"
+   ]
+  },
+  "description": "My custom enterprise contract policy configuration",
+  "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
+  "sources": [
+   {
+    "policy": [
+     "quay.io/hacbs-contract/ec-release-policy:latest"
+    ]
+   }
+  ]
+ },
+ "success": true
+}
+---

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -230,9 +230,15 @@ func (p *policy) loadPolicy(ctx context.Context, policyRef string) error {
 
 	if strings.Contains(policyRef, ":") { // Should detect JSON or YAML objects 🤞
 		log.Debug("Read EnterpriseContractPolicy as YAML")
-		if err := yaml.Unmarshal([]byte(policyRef), &p.EnterpriseContractPolicySpec); err != nil {
-			log.Debugf("Problem parsing EnterpriseContractPolicySpec from %q", policyRef)
-			return fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+		ecp := ecc.EnterpriseContractPolicy{}
+		if err := yaml.Unmarshal([]byte(policyRef), &ecp); err == nil && ecp.APIVersion != "" {
+			p.EnterpriseContractPolicySpec = ecp.Spec
+		} else {
+			log.Debugf("Problem parsing EnterpriseContractPolicy from %q", policyRef)
+			if err := yaml.Unmarshal([]byte(policyRef), &p.EnterpriseContractPolicySpec); err != nil {
+				log.Debugf("Problem parsing EnterpriseContractPolicySpec from %q", policyRef)
+				return fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+			}
 		}
 	} else {
 		log.Debug("Read EnterpriseContractPolicy as k8s resource")


### PR DESCRIPTION
Allows providing policy in the format of EnterpriseContractPolicy custom resource in addition to the EnterpriseContractPolicySpec currently supported.

resolves: gh-1040