### PR TITLE
Use golang 1.21.2 consistently

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.1
+golang 1.21.2

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,8 +1,6 @@
 module github.com/enterprise-contract/ec-cli/acceptance
 
-go 1.21.0
-
-toolchain go1.21.1
+go 1.21.2
 
 require (
 	cuelang.org/go v0.6.0

--- a/application/generator/go.mod
+++ b/application/generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/application/generator
 
-go 1.21
+go 1.21.2
 
 require (
 	github.com/redhat-appstudio/application-api v0.0.0-20230802141542-0caa1d32ccf6

--- a/application/go.mod
+++ b/application/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/application
 
-go 1.21
+go 1.21.2
 
 require (
 	k8s.io/api v0.28.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/enterprise-contract/ec-cli
 
-go 1.21.0
-
-toolchain go1.21.1
+go 1.21.2
 
 require (
 	cuelang.org/go v0.6.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/tools
 
-go 1.21
+go 1.21.2
 
 require (
 	github.com/daixiang0/gci v0.11.2


### PR DESCRIPTION
Makes sure all `go.mod` files use the same golang/go toolbox version and upgrades to the latest 1.21.2.