### PR TITLE
Set fetch depth to 0 for the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
       - name: Cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2


### PR DESCRIPTION
Given a set of versions it is difficult to compare them, for that reason we introduced the patch version having the number of commits on the release branch. The fetch depth set to 1 by default sets the patch version to `1`.

This sets the fetch depth to `0`, i.e. all commits, so that the command `git rev-list --count HEAD` returns the number of commits on the release branch instead of `1`.

Resolves: #1111