### PR TITLE
Print traces and debug messages from OPA

### DIFF
--- a/acceptance/examples/trace_debug.rego
+++ b/acceptance/examples/trace_debug.rego
@@ -1,0 +1,19 @@
+package main
+
+import future.keywords.contains
+import future.keywords.if
+
+# METADATA
+# title: Debug
+# description: This rule print to debug log
+# custom:
+#   short_name: debuggy
+#   failure_msg: Prints and succeeds
+deny contains result if {
+	print("here we are")
+	false
+	result := {
+		"code": "acceptance.debuggy",
+		"msg": "This should not happen",
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -47,7 +47,7 @@ func InitLogging(verbose, quiet, debug, trace bool) {
 	var v string
 	switch {
 	case trace:
-		level = log.DebugLevel
+		level = log.TraceLevel
 		setupDebugMode()
 		v = "9"
 	case debug:


### PR DESCRIPTION
When running at trace log level the execution trace and debug messages will be printed to the log (stderr by default), and when running at the debug log level the execution traces will be omited.

For example:
```
$ ec validate image --policy $POLICY --image $IMAGE --trace
...
ime="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | | | Redo true" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | | Redo __local2965__ = data.lib.tasks_from_pipelinerun" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | | Redo __local2708__ = [{\"annotations\": {\"custom\": {\"collections\": [\"redhat\"], \"depends_on\": [\"attestation_type.known_attestation_type\"], \"failure_msg\": \"Pipeline task '%s' uses an out of date task bundle '%s'\", \"short_name\": \"task_ref_bundles_current\", \"solution\": \"A task bundle used is not the most recent. The most recent task bundles are defined as in xref:acceptable_bundles.adoc#_task_bundles[acceptable bundles] list.\"}, \"description\": \"For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is the most recent xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle].\", \"scope\": \"rule\", \"title\": \"Task bundles are latest versions\"}, \"path\": [\"policy\", \"release\", \"attestation_task_bundle\", \"warn\"]}, {\"annotations\": {\"description\": \"To be able to reproduce and audit builds accurately it's important to know exactly what happened during the build. To do this Enterprise Contract requires that all tasks are defined in a set of known and trusted task bundles. This package includes rules to confirm that the tasks that built the image were defined in task bundles, and that the task bundles used are from the list of known and trusted bundles.\", \"scope\": \"package\", \"title\": \"Task bundle checks\"}, \"path\": [\"policy\", \"release\", \"attestation_task_bundle\"]}]" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | Unify set() = _" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | Exit data.policy.release.attestation_task_bundle.warn = _" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] Redo data.policy.release.attestation_task_bundle.warn = _" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=trace msg="[data.policy.release.attestation_task_bundle.warn] | Redo data.policy.release.attestation_task_bundle.warn = _" func=Run file=" conftest_evaluator.go:180"
time="2023-10-31T12:56:37+01:00" level=debug msg="[data.policy.release.attestation_task_bundle.warn] /tmp/ec-work-321015487/policy/9af95111f/bundles.rego:31: HELLO\n" func=Run file=" conftest_evaluator.go:187"
```

```
$ ec validate image --policy $POLICY --image $IMAGE --debug
...
time="2023-10-31T12:56:37+01:00" level=debug msg="[data.policy.release.attestation_task_bundle.warn] /tmp/ec-work-321015487/policy/9af95111f/bundles.rego:31: HELLO\n" func=Run file=" conftest_evaluator.go:187"
```