### PR TITLE
Remove HTML-escaping of description

### DIFF
--- a/docs/template/reference.hbs
+++ b/docs/template/reference.hbs
@@ -5,7 +5,7 @@
 {{#if description}}
 == Synopsis
 
-{{ description}}
+{{{ description}}}
 
 {{#if usage}}
 [source,shell]


### PR DESCRIPTION
The description text must not be HTML escaped, otherwise it could break Asciidoc syntax.