### PR TITLE
Update snapshots to reflect removed collections

### DIFF
--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -213,8 +213,6 @@ components:
       code: slsa_provenance_available.attestation_predicate_type_accepted
       collections:
       - minimal
-      - slsa1
-      - slsa2
       - slsa3
       - redhat
       depends_on:
@@ -306,8 +304,6 @@ components:
       code: slsa_provenance_available.attestation_predicate_type_accepted
       collections:
       - minimal
-      - slsa1
-      - slsa2
       - slsa3
       - redhat
       depends_on:


### PR DESCRIPTION
The slsa1 and slsa2 collection have been removed from ec-policies. This commit updates the snapshots in the acceptance tests to no longer expecte them.