### PR TITLE
Remove extraneous policy input

### DIFF
--- a/docs/modules/ROOT/pages/policy_input.adoc
+++ b/docs/modules/ROOT/pages/policy_input.adoc
@@ -61,16 +61,6 @@ attributes. `.statement` represents a SLSA Provenance v0.2 statement. See
 https://slsa.dev/provenance/v0.2#schema[schema] for details. `.signatures` contains information
 about the signatures associated with the statement.
 
-NOTE: The information from `.attestations[].statement` is accessible directly via `.attestations[]`.
-However, this limits the amount of information that can be provided for each attestation. As a
-result, `.attestations[].extra` was introduced as a workaround to hold additional information such
-as signatures. This created potential collisions with attributes from the statement. For this
-reason, the old format is now marked as deprecated and it will be removed soon.
-
-An additional attribute, `.extra`, is
-added to provide additional information about the statements. Currently, this means the signatures
-associated with the statement.
-
 `.image` is an object representing the image being validated.
 
 `.image.config` holds the OCI config for the image. It may contain various attributes, such as

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -2321,33 +2321,6 @@ Error: success criteria not met
 {
   "attestations": [
     {
-      "_type": "https://in-toto.io/Statement/v0.1",
-      "predicateType": "https://slsa.dev/provenance/v0.2",
-      "subject": [
-        {
-          "name": "acceptance/policy-input-output",
-          "digest": {
-            "sha256": "${REGISTRY_acceptance/policy-input-output:latest_DIGEST}"
-          }
-        }
-      ],
-      "predicate": {
-        "builder": {
-          "id": "https://tekton.dev/chains/v2"
-        },
-        "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-        "invocation": {
-          "configSource": {}
-        }
-      },
-      "extra": {
-        "signatures": [
-          {
-            "keyid": "",
-            "sig": "${ATTESTATION_SIGNATURE_acceptance/policy-input-output}"
-          }
-        ]
-      },
       "statement": {
         "_type": "https://in-toto.io/Statement/v0.1",
         "predicateType": "https://slsa.dev/provenance/v0.2",
@@ -2512,33 +2485,6 @@ Error: success criteria not met
 {
   "attestations": [
     {
-      "_type": "https://in-toto.io/Statement/v0.1",
-      "predicateType": "https://slsa.dev/provenance/v0.2",
-      "subject": [
-        {
-          "name": "acceptance/image",
-          "digest": {
-            "sha256": "${REGISTRY_acceptance/image:latest_DIGEST}"
-          }
-        }
-      ],
-      "predicate": {
-        "builder": {
-          "id": "https://tekton.dev/chains/v2"
-        },
-        "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-        "invocation": {
-          "configSource": {}
-        }
-      },
-      "extra": {
-        "signatures": [
-          {
-            "keyid": "",
-            "sig": "${ATTESTATION_SIGNATURE_acceptance/image}"
-          }
-        ]
-      },
       "statement": {
         "_type": "https://in-toto.io/Statement/v0.1",
         "predicateType": "https://slsa.dev/provenance/v0.2",
@@ -2940,33 +2886,6 @@ Error: success criteria not met
 {
   "attestations": [
     {
-      "_type": "https://in-toto.io/Statement/v0.1",
-      "predicateType": "https://slsa.dev/provenance/v0.2",
-      "subject": [
-        {
-          "name": "acceptance/image",
-          "digest": {
-            "sha256": "${REGISTRY_acceptance/image:latest_DIGEST}"
-          }
-        }
-      ],
-      "predicate": {
-        "builder": {
-          "id": "https://tekton.dev/chains/v2"
-        },
-        "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-        "invocation": {
-          "configSource": {}
-        }
-      },
-      "extra": {
-        "signatures": [
-          {
-            "keyid": "",
-            "sig": "${ATTESTATION_SIGNATURE_acceptance/image}"
-          }
-        ]
-      },
       "statement": {
         "_type": "https://in-toto.io/Statement/v0.1",
         "predicateType": "https://slsa.dev/provenance/v0.2",

--- a/internal/evaluation_target/application_snapshot_image/__snapshots__/application_snapshot_image_test.snap
+++ b/internal/evaluation_target/application_snapshot_image/__snapshots__/application_snapshot_image_test.snap
@@ -15,18 +15,6 @@
 {
  "attestations": [
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {},
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "statement": {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicate": {
@@ -40,8 +28,7 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   }
  ],
  "image": {
@@ -55,18 +42,6 @@
 {
  "attestations": [
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {},
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "statement": {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicate": {
@@ -80,22 +55,9 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   },
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {},
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "statement": {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicate": {
@@ -109,8 +71,7 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   }
  ],
  "image": {
@@ -124,18 +85,6 @@
 {
  "attestations": [
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {},
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "statement": {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicate": {
@@ -149,8 +98,7 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   }
  ],
  "image": {
@@ -211,35 +159,6 @@
 {
  "attestations": [
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {
-    "signatures": [
-     {
-      "certificate": "certificate",
-      "chain": [
-       "a",
-       "b",
-       "c"
-      ],
-      "keyid": "keyId",
-      "metadata": {
-       "k1": "v1",
-       "k2": "v2"
-      },
-      "sig": "signature"
-     }
-    ]
-   },
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "signatures": [
     {
      "certificate": "certificate",
@@ -269,8 +188,7 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   }
  ],
  "image": {
@@ -284,18 +202,6 @@
 {
  "attestations": [
   {
-   "_type": "https://in-toto.io/Statement/v0.1",
-   "extra": {},
-   "predicate": {
-    "buildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-    "builder": {
-     "id": ""
-    },
-    "invocation": {
-     "configSource": {}
-    }
-   },
-   "predicateType": "https://slsa.dev/provenance/v0.2",
    "statement": {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicate": {
@@ -309,39 +215,13 @@
     },
     "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": null
-   },
-   "subject": null
+   }
   }
  ],
  "image": {
   "ref": "registry.io/repository/image:tag",
   "source": {}
  }
-}
----
-
-[TestAttestationDataJSONMarshal - 1]
-{
- "extra": {
-  "signatures": [
-   {
-    "certificate": "certificate",
-    "chain": [
-     "c1",
-     "c2",
-     "c3"
-    ],
-    "keyid": "key-id",
-    "metadata": {
-     "m1": "v1",
-     "m2": "v2"
-    },
-    "sig": "signature"
-   }
-  ]
- },
- "json": "here",
- "statement": null
 }
 ---
 

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -334,13 +334,7 @@ func (a *ApplicationSnapshotImage) Signatures() []signature.EntitySignature {
 }
 
 type attestationData struct {
-	json.RawMessage                             // Deprecated
-	Extra           attestationExtraData        `json:"extra"` // Deprecated
-	Statement       json.RawMessage             `json:"statement"`
-	Signatures      []signature.EntitySignature `json:"signatures,omitempty"`
-}
-
-type attestationExtraData struct {
+	Statement  json.RawMessage             `json:"statement"`
 	Signatures []signature.EntitySignature `json:"signatures,omitempty"`
 }
 
@@ -352,27 +346,8 @@ type attestationExtraData struct {
 // a standard process for Marshaling the JSON can be used, thus removing the need for this method.
 func (a attestationData) MarshalJSON() ([]byte, error) {
 	buffy := bytes.Buffer{}
-	raw, err := a.RawMessage.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
 
-	if _, err = buffy.Write(raw[0 : len(raw)-1]); err != nil {
-		return nil, err
-	}
-
-	if _, err = buffy.WriteString(`,"extra":`); err != nil {
-		return nil, fmt.Errorf("write extra key: %w", err)
-	}
-	extra, err := json.Marshal(a.Extra)
-	if err != nil {
-		return nil, fmt.Errorf("marshal json extra: %w", err)
-	}
-	if _, err := buffy.Write(extra); err != nil {
-		return nil, fmt.Errorf("write extra value: %w", err)
-	}
-
-	_, err = buffy.WriteString(`, "statement":`)
+	_, err := buffy.WriteString(`{"statement":`)
 	if err != nil {
 		return nil, fmt.Errorf("write statement key: %w", err)
 	}
@@ -426,8 +401,6 @@ func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context) (string, 
 	var attestations []attestationData
 	for _, a := range a.attestations {
 		attestations = append(attestations, attestationData{
-			RawMessage: a.Statement(),                                    // Deprecated, remove soon
-			Extra:      attestationExtraData{Signatures: a.Signatures()}, // Deprecated, remove soon
 			Statement:  a.Statement(),
 			Signatures: a.Signatures(),
 		})

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -754,28 +754,6 @@ func TestFetchParentImageConfig(t *testing.T) {
 	require.Equal(t, string(a.parentConfigJSON), `{"Labels":{"io.k8s.display-name":"Base Image"}}`)
 }
 
-func TestAttestationDataJSONMarshal(t *testing.T) {
-	data := attestationData{
-		RawMessage: []byte(`{"json": "here"}`),
-		Extra: attestationExtraData{
-			Signatures: []signature.EntitySignature{
-				{
-					KeyID:       "key-id",
-					Signature:   "signature",
-					Certificate: "certificate",
-					Chain:       []string{"c1", "c2", "c3"},
-					Metadata: map[string]string{
-						"m1": "v1",
-						"m2": "v2",
-					},
-				},
-			},
-		},
-	}
-
-	snaps.MatchJSON(t, data)
-}
-
 func TestFetchImageFiles(t *testing.T) {
 	ref := name.MustParseReference("registry.io/repository/image:tag")
 	a := ApplicationSnapshotImage{reference: ref}


### PR DESCRIPTION
This PR rips out all the extraneous, duplicate policy fields that are no longer necessary with the transition to `statement.predicate` complete on the `ec-policies` side.

Resolves #1140.