### PR TITLE
Implement custom rego functions for PURL handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -227,6 +227,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/package-url/packageurl-go v0.1.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/peterh/liner v1.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1026,6 +1026,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.3.0 h1:XtuXmOLIXLjiU2XduuWREDT0LOKtSgos/g7i7RYyoZQ=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
+github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
+github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=

--- a/internal/evaluator/rego_test.go
+++ b/internal/evaluator/rego_test.go
@@ -106,9 +106,87 @@ func TestOCIBlob(t *testing.T) {
 	}
 }
 
+func TestPURLIsValid(t *testing.T) {
+	cases := []struct {
+		name     string
+		uri      *ast.Term
+		expected bool
+	}{
+		{
+			name:     "success",
+			uri:      ast.StringTerm("pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25"),
+			expected: true,
+		},
+		{
+			name:     "unexpected uri type",
+			uri:      ast.IntNumberTerm(42),
+			expected: false,
+		},
+		{
+			name:     "malformed PURL string",
+			uri:      ast.StringTerm("pkg::rpm//fedora/curl7.50.3-1.fc25?arch=i386&distro=fedora-"),
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			isValid, err := purlIsValid(bctx, c.uri)
+			require.NoError(t, err)
+			require.NotNil(t, isValid)
+			require.Equal(t, isValid, ast.BooleanTerm(c.expected))
+		})
+	}
+}
+
+func TestPURLParse(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  *ast.Term
+		err  bool
+	}{
+		{
+			name: "success",
+			uri:  ast.StringTerm("pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25"),
+		},
+		{
+			name: "unexpected uri type",
+			uri:  ast.IntNumberTerm(42),
+			err:  true,
+		},
+		{
+			name: "malformed PURL string",
+			uri:  ast.StringTerm("pkg::rpm//fedora/curl7.50.3-1.fc25?arch=i386&distro=fedora-"),
+			err:  true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			instance, err := purlParse(bctx, c.uri)
+			require.NoError(t, err)
+			if c.err {
+				require.Nil(t, instance)
+			} else {
+				require.NotNil(t, instance)
+				data := instance.Get(ast.StringTerm("type")).Value
+				require.Equal(t, ast.String("rpm"), data)
+			}
+		})
+	}
+}
+
 func TestFunctionsRegistered(t *testing.T) {
 	names := []string{
 		ociBlobName,
+		purlIsValidName,
+		purlParseName,
 	}
 	for _, name := range names {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds two basic custom Rego functions to handle PURLs: `ec.purl.is_valid` and `ec.purl.parse`. 

Marking as WIP due to lacking tests.

Resolves #1053.