### PR TITLE
Add build tag to vsa tests

### DIFF
--- a/internal/applicationsnapshot/vsa_test.go
+++ b/internal/applicationsnapshot/vsa_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package applicationsnapshot
 
 import (


### PR DESCRIPTION
Without it, the integration and generative tests throw certain errors as the tests incorrectly execute there as well.