### PR TITLE
Add CI triggers for redhat-* branches

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,9 +21,11 @@ name: Checks
   pull_request:
     branches:
       - main
+      - redhat-*
   push:
     branches:
       - main
+      - redhat-*
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,9 +21,11 @@ name: Lint
   pull_request:
     branches:
       - main
+      - redhat-*
   push:
     branches:
       - main
+      - redhat-*
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
We want to make sure any changes made in the downstream release branches also pass the test suites.

I wasn't sure about CodeQL, so I didn't add it in this commit, but perhaps it should be added too.