### PR TITLE
Improve Dockerfile for RHTAP builds

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -14,11 +14,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Note: There's more work to do before this image is usable for productized ec,
-# but it builds in RHTAP so it's a good starting point. To make this useful as
-# a Tekton step runnner, we need cosign, jq, and git, and possibly to build and
-# push it as a full multi-arch image, in which case we would do just one build
-# per container.
+## Downloads
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:c77792b8084ce5946c68f39024fa460ef7769c0eef3fce995e70299e21a7e166 as download
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG COSIGN_VERSION
+
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /opt/
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /opt/
+
+RUN cd /opt && \
+    sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
+    mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
+    chmod +x cosign
+
+## Build
 
 # This currently has 1.20, but we want 1.21
 #FROM registry.access.redhat.com/ubi9/go-toolset:latest as build
@@ -29,31 +42,34 @@
 # Temporary to make it work
 FROM docker.io/library/golang:1.21 as build
 
-COPY . /build
-WORKDIR /build
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG EC_VERSION
 
-# Download dependencies
-RUN go mod download
+COPY . /build
 
-# Build several binaries
-RUN for TARGETARCH in amd64 arm64 ppc64le; do \
- for TARGETOS in linux; do \
-  echo Building ${TARGETOS} ${TARGETARCH}; \
-  GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-   -trimpath \
-   -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}" \
-   -o dist/ec_${TARGETOS}_${TARGETARCH}; \
- done; \
-done
+RUN cd /build && go mod download
+
+RUN cd /build && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -trimpath \
+    -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}" \
+    -o "dist/ec_${TARGETOS}_${TARGETARCH}"
+
+## Final image
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:c77792b8084ce5946c68f39024fa460ef7769c0eef3fce995e70299e21a7e166
 
-# Copy all the binaries into the final image
-COPY --from=build "/build/dist" /dist
+ARG TARGETOS
+ARG TARGETARCH
 
-# Make an assumption about the most likely os and arch
-RUN ln -s /dist/ec_linux_amd64 /usr/bin/ec
+RUN microdnf -y --nodocs install git-core jq && microdnf clean all
+
+COPY --from=download /opt/cosign /usr/local/bin/
+
+COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec
+
+RUN git version && jq --version && cosign version && ec version
 
 ENTRYPOINT ["/usr/bin/ec"]

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -21,7 +21,10 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:c77792b8084ce5946c68
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG COSIGN_VERSION
+# Todo: Need a way to derive this value, either directly in this Dockerfile
+# or somewhere else so it can be passed as a buildarg.
+# go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2 #=> v2.2.1
+ARG COSIGN_VERSION=v2.2.1
 
 ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /opt/
 ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /opt/
@@ -45,7 +48,8 @@ FROM docker.io/library/golang:1.21 as build
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG EC_VERSION
+# Todo: Figure what version to use and how to provide it
+ARG EC_VERSION=v0.1-alpha
 
 COPY . /build
 
@@ -54,7 +58,7 @@ RUN cd /build && go mod download
 RUN cd /build && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -trimpath \
-    -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}" \
+    -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}-`git rev-parse --short HEAD`" \
     -o "dist/ec_${TARGETOS}_${TARGETARCH}"
 
 ## Final image

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,13 @@ $(ALL_SUPPORTED_OS_ARCH): ## Build binaries for specific platform/architecture, 
 .PHONY: dist
 dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating systems and architectures
 
-# Experimental. Should work with an RHTAP style buildah task
+# Dockerfile.dist is used by the RHTAP build pipeline where it's built using
+# buildah not podman. This is for testing that build locally.
+# Todo: Don't hard code the platform here. Should probably do multi-arch builds similar
+# to dist-image. Also why not use buildah here for consistency with the RHTAP build.
 .PHONY: dist-container
 dist-container: clean
-	podman build . --file Dockerfile.dist --tag dist-container --build-arg EC_VERSION=$(VERSION)
+	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 --build-arg EC_VERSION=$(VERSION) --build-arg COSIGN_VERSION=$(COSIGN_VERSION)
 
 # For local debugging of the above
 dist-container-run:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating sys
 # to dist-image. Also why not use buildah here for consistency with the RHTAP build.
 .PHONY: dist-container
 dist-container: clean
-	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 --build-arg EC_VERSION=$(VERSION) --build-arg COSIGN_VERSION=$(COSIGN_VERSION)
+	#podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 --build-arg EC_VERSION=$(VERSION) --build-arg COSIGN_VERSION=$(COSIGN_VERSION)
+	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64
 
 # For local debugging of the above
 dist-container-run:


### PR DESCRIPTION
Make the new Docker file used by the RHTAP downstream build produce an image more similar to the existing upstream step runner image.

It's not tested yet, but this image should now be useable as the step runner image for our Tekton tasks, as well as provide a place for the OpenShift cli downloader to access a binary cli for download.

It now also just builds one binary specific for the container image, rather than cross-compiling multiple binaries and making them available in a single image.

See also the patch
https://github.com/redhat-appstudio/infra-deployments/pull/2883 which demonstrates how we're likely to provide access to the cli downloads.

Ref: https://issues.redhat.com/browse/EC-290