### PR TITLE
Bring back the release branch prefix

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,11 +21,11 @@ name: Checks
   pull_request:
     branches:
       - main
-      - redhat-*
+      - release-*
   push:
     branches:
       - main
-      - redhat-*
+      - release-*
   workflow_dispatch:
 
 permissions:

--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -32,7 +32,7 @@ if [[ $RELEASE_NAME == "" ]]; then
 fi
 
 # Use release name as-is for the branch name
-BRANCH_NAME="${RELEASE_NAME}"
+BRANCH_NAME="release-${RELEASE_NAME}"
 
 # RHTAP disallows . chars in names so remove those
 RHTAP_APPLICATION_SUFFIX="${RELEASE_NAME/./}"
@@ -50,7 +50,7 @@ echo RHTAP cli component name: $RHTAP_CLI_COMPONENT_NAME
 RHTAP_APPS_URL=https://console.redhat.com/preview/application-pipeline/workspaces/rhtap-contract/applications
 
 # Explain what needs to be done next
-# (We could make this more automated this in future.)
+# (We could make this more automated in future.)
 cat <<EOT
 
 Next steps:


### PR DESCRIPTION
It makes it easier to the GitHub CI if there's a branch name prefix.

Decide to make it "release-" instead of "redhat-" this time around.