### PR TITLE
Remove scheme from policy URL

### DIFF
--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
@@ -67,7 +68,10 @@ type PolicyUrl struct {
 
 // GetPolicies clones the repository for a given PolicyUrl
 func (p *PolicyUrl) GetPolicy(ctx context.Context, workDir string, showMsg bool) (string, error) {
+	// Trim scheme from repo url as this breaks go-getter.
 	sourceUrl := p.PolicyUrl()
+	sourceUrl = strings.TrimPrefix(sourceUrl, "https://")
+	sourceUrl = strings.TrimPrefix(sourceUrl, "http://")
 
 	dest := uniqueDestination(workDir, p.Subdir(), sourceUrl)
 

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -55,7 +55,7 @@ func TestGetPolicy(t *testing.T) {
 	}{
 		{
 			name:      "Gets policies",
-			sourceUrl: "https://example.com/user/foo.git",
+			sourceUrl: "example.com/user/foo.git",
 			dest:      "/tmp/ec-work-1234/policy/[0-9a-f]+",
 			err:       nil,
 		},


### PR DESCRIPTION
This commit strips the scheme (https:// or http://) from the repository URL for the policy to ensure that it doesn't break go-getter when attempting to download.

ref: EC-285