### PR TITLE
Multi-platform ec builds in TAP

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -163,6 +163,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "0"
+      - name: fetchTags
+        value: "true"
       runAfter:
       - init
       taskRef:

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -160,6 +160,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "0"
+      - name: fetchTags
+        value: "true"
       runAfter:
       - init
       taskRef:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 as downloads
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 AS downloads
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -30,21 +30,45 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21@sha256
 ARG TARGETOS
 ARG TARGETARCH
 
+# Adjust as required
+ARG BUILD_LIST="linux_amd64 linux_arm64 linux_ppc64le darwin_arm64"
+#ARG BUILD_LIST="linux_amd64 linux_arm64 linux_ppc64le darwin_arm64 darwin_amd64 windows_amd64"
+
 COPY . /build
 
 WORKDIR /build
 
 RUN go mod download
 
-# Derive the version from the branch name with the "release-" prefix removed if it's
-# present, e.g. in the branch "release-v0.1-alpha" the version will be "v0.1-alpha"
-RUN GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
-    EC_VERSION=${GIT_BRANCH#"release-"} && \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -trimpath \
-    -mod=readonly \
-    -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}-`git rev-parse --short HEAD`" \
-    -o "dist/ec_${TARGETOS}_${TARGETARCH}"
+# Derive the version from the branch name with the "release-" prefix removed
+# if it's present, e.g. in the branch "release-v0.1-alpha" the version will
+# be "v0.1-alpha"
+#
+# If the branch doesn't start with release- then assume it's not a release
+# branch and build just a single binary to save time and cpu cycles. If the
+# branch is a release branch then build all the binaries in ${BUILD_LIST}.
+#
+RUN \
+    EC_GIT_SHA=$( git rev-parse --short HEAD ); \
+    EC_GIT_BRANCH=$( git rev-parse --abbrev-ref HEAD ); \
+    EC_VERSION=${EC_GIT_BRANCH#"release-"}; \
+    EC_FULL_VERSION="${EC_VERSION}-${EC_GIT_SHA}"; \
+    if [ "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \
+      BUILDS="${TARGETOS}_${TARGETARCH}"; \
+    else \
+      BUILDS="${BUILD_LIST}"; \
+    fi; \
+    for os_arch in ${BUILDS}; do \
+      export GOOS="${os_arch%_*}"; \
+      export GOARCH="${os_arch#*_}"; \
+      BINFILE="ec_${GOOS}_${GOARCH}"; \
+      echo "Building ${BINFILE}"; \
+      go build \
+          -trimpath \
+          --mod=readonly \
+          -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_FULL_VERSION}" \
+          -o "dist/${BINFILE}"; \
+    done
 
 # Extract this so we can download the matching cosign version below
 RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt
@@ -60,6 +84,7 @@ WORKDIR /download
 
 COPY --from=build /build/cosign_version.txt /download/
 
+# Download the matching version of cosign
 RUN COSIGN_VERSION=$(cat /download/cosign_version.txt) && \
     curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} && \
     curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt && \
@@ -82,12 +107,17 @@ LABEL \
   io.openshift.tags="rhtas rhtap trusted-artifact-signer trusted-application-pipeline enterprise-contract ec opa cosign sigstore" \
   com.redhat.component="ec-cli"
 
+# Install cosign and other tools we want to use in the Tekton task
 RUN microdnf -y --nodocs install git-core jq && microdnf clean all
+COPY --from=download /download/cosign /usr/local/bin/cosign
 
-COPY --from=download /download/cosign /usr/local/bin/
+# Copy all the binaries so they're available to extract and download
+COPY --from=build /build/dist/ /usr/local/bin/
 
-COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec
+# Copy the one ec binary that can run in this container
+COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/local/bin/ec
 
-RUN git version && jq --version && cosign version && ec version
+# Show some version numbers for troubleshooting purposes
+RUN git version && jq --version && cosign version && ec version && ls -l /usr/local/bin
 
-ENTRYPOINT ["/usr/bin/ec"]
+ENTRYPOINT ["/usr/local/bin/ec"]

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -113,7 +113,7 @@ LABEL \
   com.redhat.component="ec-cli"
 
 # Install cosign and other tools we want to use in the Tekton task
-RUN microdnf -y --nodocs install git-core jq && microdnf clean all
+RUN microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
 COPY --from=download /download/cosign /usr/local/bin/cosign
 
 # Copy all the binaries so they're available to extract and download

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -16,7 +16,7 @@
 
 ## Downloads
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 as download
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 AS download
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -38,15 +38,15 @@ RUN sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_chec
 ## Build
 
 # This works fine but will produce an EC violation
-#FROM docker.io/library/golang:1.21 as build
+#FROM docker.io/library/golang:1.21 AS build
 
 # This currently has go version 1.20 but we need version 1.21
-#FROM registry.access.redhat.com/ubi9/go-toolset:latest as build
+#FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build
 
 # This image has go version 1.21 but requires an extra pull secret to access
 # See https://source.redhat.com/groups/public/teamnado/wiki/brew_registry for how to get your own pull secret
 # See our RHTAP pull secret at https://console.redhat.com/preview/application-pipeline/secrets
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21@sha256:4fe910174caaaae09ff75b6f1b1c2f4460fd9acfe38ec778a818a54de7f31afc as build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21@sha256:4fe910174caaaae09ff75b6f1b1c2f4460fd9acfe38ec778a818a54de7f31afc AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -14,27 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-## Downloads
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 AS download
-
-ARG TARGETOS
-ARG TARGETARCH
-
-# Todo: Need a way to derive this value, either directly in this Dockerfile
-# or somewhere else so it can be passed as a buildarg.
-# go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2 #=> v2.2.1
-ARG COSIGN_VERSION=v2.2.1
-
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /download/
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /download/
-
-WORKDIR /download
-
-RUN sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
-    mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
-    chmod +x cosign
-
 ## Build
 
 # This works fine but will produce an EC violation
@@ -66,6 +45,27 @@ RUN GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
     -mod=readonly \
     -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}-`git rev-parse --short HEAD`" \
     -o "dist/ec_${TARGETOS}_${TARGETARCH}"
+
+## Downloads
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 AS download
+
+ARG TARGETOS
+ARG TARGETARCH
+
+# Todo: Need a way to derive this value, either directly in this Dockerfile
+# or somewhere else so it can be passed as a buildarg.
+# go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2 #=> v2.2.1
+ARG COSIGN_VERSION=v2.2.1
+
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /download/
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /download/
+
+WORKDIR /download
+
+RUN sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
+    mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
+    chmod +x cosign
 
 ## Final image
 

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -26,11 +26,12 @@ ARG TARGETARCH
 # go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2 #=> v2.2.1
 ARG COSIGN_VERSION=v2.2.1
 
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /opt/
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /opt/
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /download/
+ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /download/
 
-RUN cd /opt && \
-    sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
+WORKDIR /download
+
+RUN sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
     mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
     chmod +x cosign
 
@@ -52,12 +53,13 @@ ARG TARGETARCH
 
 COPY . /build
 
-RUN cd /build && go mod download
+WORKDIR /build
+
+RUN go mod download
 
 # Derive the "version" from the branch name, e.g. in the branch
 # "redhat-v0.1-alpha" the version will be "v0.1-alpha"
-RUN cd /build && \
-    GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
+RUN GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
     EC_VERSION=${GIT_BRANCH#"redhat-"} && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -trimpath \
@@ -82,7 +84,7 @@ LABEL \
 
 RUN microdnf -y --nodocs install git-core jq && microdnf clean all
 
-COPY --from=download /opt/cosign /usr/local/bin/
+COPY --from=download /download/cosign /usr/local/bin/
 
 COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec
 

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -46,6 +46,9 @@ RUN GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
     -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_VERSION}-`git rev-parse --short HEAD`" \
     -o "dist/ec_${TARGETOS}_${TARGETARCH}"
 
+# Extract this so we can download the matching cosign version below
+RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt
+
 ## Downloads
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c84666a3dccb88e193a116da3cebabaf9bcdc33609b61172 AS download
@@ -53,17 +56,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:a340f4b9fb261a75c846
 ARG TARGETOS
 ARG TARGETARCH
 
-# Todo: Need a way to derive this value, either directly in this Dockerfile
-# or somewhere else so it can be passed as a buildarg.
-# go list -f '{{.Version}}' -m github.com/sigstore/cosign/v2 #=> v2.2.1
-ARG COSIGN_VERSION=v2.2.1
-
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /download/
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /download/
-
 WORKDIR /download
 
-RUN sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
+COPY --from=build /build/cosign_version.txt /download/
+
+RUN COSIGN_VERSION=$(cat /download/cosign_version.txt) && \
+    curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} && \
+    curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt && \
+    sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
     mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
     chmod +x cosign
 

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -48,11 +48,16 @@ RUN go mod download
 # branch and build just a single binary to save time and cpu cycles. If the
 # branch is a release branch then build all the binaries in ${BUILD_LIST}.
 #
+# For EC_BUILD_NUM, I'd like to try this:
+#   $( git rev-list --count $( git merge-base --fork-point main )..HEAD )
+# but I don't think the main branch ref will be known.
+#
 RUN \
     EC_GIT_SHA=$( git rev-parse --short HEAD ); \
     EC_GIT_BRANCH=$( git rev-parse --abbrev-ref HEAD ); \
     EC_VERSION=${EC_GIT_BRANCH#"release-"}; \
-    EC_FULL_VERSION="${EC_VERSION}-${EC_GIT_SHA}"; \
+    EC_BUILD_NUM=$( git rev-list --count $( git describe --tags --abbrev=0 )..HEAD ); \
+    EC_FULL_VERSION="${EC_VERSION}-${EC_BUILD_NUM}-${EC_GIT_SHA}"; \
     if [ "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \
       BUILDS="${TARGETOS}_${TARGETARCH}"; \
     else \

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -57,10 +57,10 @@ WORKDIR /build
 
 RUN go mod download
 
-# Derive the "version" from the branch name, e.g. in the branch
-# "redhat-v0.1-alpha" the version will be "v0.1-alpha"
+# Derive the version from the branch name with the "release-" prefix removed if it's
+# present, e.g. in the branch "release-v0.1-alpha" the version will be "v0.1-alpha"
 RUN GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
-    EC_VERSION=${GIT_BRANCH#"redhat-"} && \
+    EC_VERSION=${GIT_BRANCH#"release-"} && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -trimpath \
     -mod=readonly \

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -117,6 +117,8 @@ RUN microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
 COPY --from=download /download/cosign /usr/local/bin/cosign
 
 # Copy all the binaries so they're available to extract and download
+# (Beware if you're testing this locally it will copy everything from
+# your dist directory, not just the freshly built binaries.)
 COPY --from=build /build/dist/ /usr/local/bin/
 
 # Copy the one ec binary that can run in this container

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating sys
 # to dist-image. Also why not use buildah here for consistency with the RHTAP build.
 .PHONY: dist-container
 dist-container: clean
-	#podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 --build-arg EC_VERSION=$(VERSION) --build-arg COSIGN_VERSION=$(COSIGN_VERSION)
-	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64
+	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 # --no-cache
 
 # For local debugging of the above
 dist-container-run:


### PR DESCRIPTION
There are a few additional tweaks and fixes here, but the main changes are:

* Derive the cosign version from the go.mod file instead of hard coding it
* Bring back the building of multiple binaries (but skip it for main branch builds)
* Add a new build number to the version that should increase when new builds are done

See commit messages for more detail.

Ref: [EC-325](https://issues.redhat.com/browse/EC-325)