### PR TITLE
Set git-clone task refspec param to fetch branches

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -169,6 +169,8 @@ spec:
         value: "0"
       - name: fetchTags
         value: "true"
+      - name: refspec
+        value: '{{target_branch}}'
       runAfter:
       - init
       taskRef:

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -166,6 +166,8 @@ spec:
         value: "0"
       - name: fetchTags
         value: "true"
+      - name: refspec
+        value: '{{target_branch}}'
       runAfter:
       - init
       taskRef:


### PR DESCRIPTION
Because we want to use the branch names to extract a version name when building we need to have the branch refs available.

Ref: [EC-343](https://issues.redhat.com/browse/EC-343)