### PR TITLE
wip: Introduce the concept of a validation intent

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -62,6 +62,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		spec                        *app.SnapshotSpec
 		strict                      bool
 		images                      string
+		intent                      string
 	}{
 		strict: true,
 	}
@@ -207,6 +208,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				PolicyRef:   data.policyConfiguration,
 				PublicKey:   data.publicKey,
 				RekorURL:    data.rekorURL,
+				Intent:      data.intent,
 			}); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
@@ -384,6 +386,10 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		Include additional information on the failures. For instance for policy
 		violations, include the title and the description of the failed policy
 		rule.`))
+
+	cmd.Flags().StringVar(&data.intent, "intent", data.intent, hd.Doc(`
+		Specify the intent of validating an image.
+	`))
 
 	if len(data.input) > 0 || len(data.filePath) > 0 || len(data.images) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -57,6 +57,7 @@ type Report struct {
 	EcVersion     string                           `json:"ec-version"`
 	Data          any                              `json:"-"`
 	EffectiveTime time.Time                        `json:"effective-time"`
+	Intent        string                           `json:"intent"`
 	PolicyInput   [][]byte                         `json:"-"`
 }
 
@@ -141,6 +142,7 @@ func NewReport(snapshot string, components []Component, policy policy.Policy, da
 		Data:          data,
 		PolicyInput:   policyInput,
 		EffectiveTime: policy.EffectiveTime().UTC(),
+		Intent:        policy.Intent(),
 	}, nil
 }
 

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -632,7 +632,8 @@ func createConfigJSON(ctx context.Context, dataDir string, p policy.Policy) erro
 	}
 
 	pc := &struct {
-		WhenNs int64 `json:"when_ns"`
+		WhenNs int64  `json:"when_ns"`
+		Intent string `json:"intent"`
 	}{}
 
 	// Now that the future deny logic is handled in the ec-cli and not in rego,
@@ -640,6 +641,8 @@ func createConfigJSON(ctx context.Context, dataDir string, p policy.Policy) erro
 	// acceptable bundles list. Always set it, even when we are using the current
 	// time, so that a consistent current time is used everywhere.
 	pc.WhenNs = p.EffectiveTime().UnixNano()
+
+	pc.Intent = p.Intent()
 
 	// Add the policy config we just prepared
 	config["config"] = map[string]interface{}{

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -57,6 +57,7 @@ type Policy interface {
 	AttestationTime(time.Time)
 	Identity() cosign.Identity
 	Keyless() bool
+	Intent() string
 }
 
 type policy struct {
@@ -67,6 +68,7 @@ type policy struct {
 	attestationTime *time.Time
 	identity        cosign.Identity
 	ignoreRekor     bool
+	intent          string
 }
 
 // PublicKeyPEM returns the PublicKey in PEM format.
@@ -112,6 +114,7 @@ type Options struct {
 	PolicyRef     string
 	PublicKey     string
 	RekorURL      string
+	Intent        string
 }
 
 // NewOfflinePolicy construct and return a new instance of Policy that is used
@@ -236,6 +239,8 @@ func NewPolicy(ctx context.Context, opts Options) (Policy, error) {
 		p.checkOpts = opts
 	}
 
+	p.intent = opts.Intent
+
 	return &p, nil
 }
 
@@ -304,6 +309,10 @@ func (p policy) EffectiveTime() time.Time {
 	}
 
 	return *p.effectiveTime
+}
+
+func (p policy) Intent() string {
+	return p.intent
 }
 
 func isNow(choosenTime string) bool {


### PR DESCRIPTION
This commit adds a new flag to the `ec validate command`, `--intent` which is propagated to rego as config value - similarly to how effectiveTime is propagated.

The idea is to provide a mechanism to change the behavior of a policy rule depending on why the user is validating an image.

For example, the
[schedule](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#schedule_package) package contains policy rules that are meant to enforce restrictions depending on the day. This is meant to disallow releases on the weekends or on certain days (holidays).

Those policy rules are NOT meant to disallow changes from being merged.

This allows the user to use the same policy config for multiple purposes.

Ok, so why not just have multiple policy configs?

This is certainly a possibility! It does come with its own challenges:

1. Deviation in what is checked during integration vs release is prone to cause unexpected issues at release time.
1. Maintenance. Duplicating every policy config sounds like a good way to increase toil for everyone.

The "intent" appraoch does away with the maintenance cost for users, at the expense of making certain policy rules slightly more complex. (I think that's a good trade-off.)

But it only reduces the deviation problem. You'd still get a different result in integration than in release. But... that's what the requested feature is all about so not sure if we can do much about that. This approach does use the same policy config in both cases so at least it removes issues caused by those not being in sync.

Anyways, this is a proof of concept meant to help the conversation.