### PR TITLE
Remove deprecated params for the init task

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -144,12 +144,6 @@ spec:
         value: $(params.rebuild)
       - name: skip-checks
         value: $(params.skip-checks)
-      - name: skip-optional
-        value: $(params.skip-optional)
-      - name: pipelinerun-name
-        value: $(context.pipelineRun.name)
-      - name: pipelinerun-uid
-        value: $(context.pipelineRun.uid)
       taskRef:
         params:
         - name: name

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -141,12 +141,6 @@ spec:
         value: $(params.rebuild)
       - name: skip-checks
         value: $(params.skip-checks)
-      - name: skip-optional
-        value: $(params.skip-optional)
-      - name: pipelinerun-name
-        value: $(context.pipelineRun.name)
-      - name: pipelinerun-uid
-        value: $(context.pipelineRun.uid)
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
Migration doc:
https://github.com/redhat-appstudio/build-definitions/blob/main/task/init/0.2/MIGRATION.md