### PR TITLE
Provide better error messaging around policy URLs

### DIFF
--- a/cmd/inspect/inspect_policy_test.go
+++ b/cmd/inspect/inspect_policy_test.go
@@ -20,6 +20,7 @@ package inspect
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -54,6 +55,9 @@ func TestFetchSourcesFromPolicy(t *testing.T) {
 		dir := args.String(0)
 
 		if err := fs.MkdirAll(dir, 0755); err != nil {
+			panic(err)
+		}
+		if err := afero.WriteFile(fs, fmt.Sprintf("%s/foo.rego", args.String(0)), []byte("package foo\n\nbar = 1"), 0644); err != nil {
 			panic(err)
 		}
 	}
@@ -93,6 +97,9 @@ func TestFetchSources(t *testing.T) {
 		dir := args.String(0)
 
 		if err := fs.MkdirAll(dir, 0755); err != nil {
+			panic(err)
+		}
+		if err := afero.WriteFile(fs, fmt.Sprintf("%s/foo.rego", args.String(0)), []byte("package foo\n\nbar = 1"), 0644); err != nil {
 			panic(err)
 		}
 	}

--- a/internal/opa/inspect.go
+++ b/internal/opa/inspect.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/ast/json"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -196,6 +197,12 @@ func InspectDir(afs afero.Fs, dir string) ([]*ast.AnnotationsRef, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Ensure that we have actual rules, and a directory without rego files.
+	if len(regoPaths) == 0 {
+		log.Debug("No rego files found after cloning policy url.")
+		return nil, errors.New("no rego files found in policy subdirectory")
 	}
 
 	// Inspect all rego files found


### PR DESCRIPTION
This comment addresses EC-285 and attempts to provide a better error message to users when they provide a policy URL in a format that is ambiguous or difficult for go-getter to parse.

Users will now receive suggestions if it appears they were trying to reference a github or gitlab repository, but include a scheme ('https' or 'http').