### PR TITLE
Fix cosign version shown by the ec version command

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -83,7 +83,7 @@ func ComputeInfo() (*VersionInfo, error) {
 	info.Components = append(info.Components, dependencyVersion("ECC", "github.com/enterprise-contract/enterprise-contract-controller/api", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("OPA", "github.com/open-policy-agent/opa", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Conftest", "github.com/open-policy-agent/conftest", buildInfo.Deps))
-	info.Components = append(info.Components, dependencyVersion("Cosign", "github.com/sigstore/cosign", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Cosign", "github.com/sigstore/cosign/v2", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Sigstore", "github.com/sigstore/sigstore", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Rekor", "github.com/sigstore/rekor", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Tekton Pipeline", "github.com/tektoncd/pipeline", buildInfo.Deps))

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -63,7 +63,7 @@ func TestComputeInfo(t *testing.T) {
 				{Path: "github.com/enterprise-contract/enterprise-contract-controller/api", Version: "v1"},
 				{Path: "github.com/open-policy-agent/opa", Version: "v2"},
 				{Path: "github.com/open-policy-agent/conftest", Version: "v3"},
-				{Path: "github.com/sigstore/cosign", Version: "v4"},
+				{Path: "github.com/sigstore/cosign/v2", Version: "v4"},
 				{Path: "github.com/sigstore/sigstore", Version: "v5"},
 				{Path: "github.com/sigstore/rekor", Version: "v6"},
 				{Path: "github.com/tektoncd/pipeline", Version: "v7"},


### PR DESCRIPTION
It was showing "N/A", now it shows "v2.2.2" as expected.

Ref: https://issues.redhat.com/browse/EC-345