### PR TITLE
Intermediate client server poc

### DIFF
--- a/Dockerfile.tas-client-server
+++ b/Dockerfile.tas-client-server
@@ -1,0 +1,18 @@
+
+# Built with Dockerfile.dist
+FROM quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v01-alpha/cli-v01-alpha@sha256:6aca9b2e9fde177d1398820b4b0609865dc2b0573c2d9e6d475e515a6a123f1c AS ec-image
+#FROM registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha-1705963542@sha256:6aca9b2e9fde177d1398820b4b0609865dc2b0573c2d9e6d475e515a6a123f1c AS ec-image
+
+# (This is from November, so will need to be updated once there's a fresh image built)
+FROM registry.redhat.io/rhtas-tech-preview/client-server-rhel9:1.0.beta-1699564708@sha256:07b1c06290706873ee55e39bad5804ea1d7574b01909adf97d67495ad919f9a1
+
+# Add the ec binaries in with the cosign, gitsign and rekor-cli that are already there
+COPY --from=ec-image /usr/local/bin/ec_darwin_amd64.gz      /var/www/html/clients/darwin/ec-amd64.gz
+COPY --from=ec-image /usr/local/bin/ec_darwin_arm64.gz      /var/www/html/clients/darwin/ec-arm64.gz
+COPY --from=ec-image /usr/local/bin/ec_linux_amd64.gz       /var/www/html/clients/linux/ec-amd64.gz
+COPY --from=ec-image /usr/local/bin/ec_linux_arm64.gz       /var/www/html/clients/linux/ec-arm64.gz
+COPY --from=ec-image /usr/local/bin/ec_linux_ppc64le.gz     /var/www/html/clients/linux/ec-ppc64le.gz
+COPY --from=ec-image /usr/local/bin/ec_linux_s390x.gz       /var/www/html/clients/linux/ec-s390x.gz
+COPY --from=ec-image /usr/local/bin/ec_windows_amd64.exe.gz /var/www/html/clients/windows/ec-amd64.gz
+
+# Everything else, i.e. CMD and LABEL, should be inherited from the base image


### PR DESCRIPTION
It's a long story, but this is an alternative workaround for the
problem where images build from
https://github.com/securesign/sigstore-ocp/blob/9024422e356c22660af7870aecd55a0571f07f58/images/Dockerfile-clientserver
have too many base images, so they overflow the tekton task result
that lists all the base images.

Just a POC so far but it works for me locally. Not sure what the
next step would be, but we could make a component and try building
this in Konflux. And we need an updated base image since the one I'm
using here is very old and doesn't have all the different arches.