### PR TITLE
ADD ability to specify policy config yaml as URL

### DIFF
--- a/internal/policy/source/chooser.go
+++ b/internal/policy/source/chooser.go
@@ -1,0 +1,57 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package source
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/spf13/afero"
+
+	"github.com/enterprise-contract/ec-cli/internal/utils"
+)
+
+var policyFileBaseNames = []string{
+	".ec/policy",
+	"policy",
+}
+
+var policyFileExtensions = []string{
+	"json",
+	"yaml",
+	"yml",
+}
+
+// choosePolicyFile picks a file from a given directory to use as an EC policy file
+// Uses policyFileBaseNames and policyFileExtensions to decide what to look for
+func choosePolicyFile(ctx context.Context, configDir string) (string, error) {
+	fs := utils.FS(ctx)
+	for _, b := range policyFileBaseNames {
+		for _, e := range policyFileExtensions {
+			configFile := path.Join(configDir, fmt.Sprintf("%s.%s", b, e))
+			fileExists, err := afero.Exists(fs, configFile)
+			if err != nil {
+				return "", err
+			}
+			if fileExists {
+				return configFile, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no suitable config file found in %s", configDir)
+}

--- a/internal/policy/source/chooser_test.go
+++ b/internal/policy/source/chooser_test.go
@@ -1,0 +1,87 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/enterprise-contract/ec-cli/internal/utils"
+)
+
+func TestChoosePolicyFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		want    string
+		wantErr bool
+		errText string
+	}{
+		{
+			name:    "No files",
+			files:   []string{},
+			wantErr: true,
+			errText: "no suitable config file found",
+		},
+		{
+			name:  "One policy.json file",
+			files: []string{"/policy.json"},
+			want:  "/policy.json",
+		},
+		{
+			name:  "One .ec/policy.yaml file",
+			files: []string{"/.ec/policy.yaml"},
+			want:  "/.ec/policy.yaml",
+		},
+		{
+			name:  "Multiple files with basename precedence",
+			files: []string{"/.ec/policy.yml", "/policy.yaml"},
+			want:  "/.ec/policy.yml",
+		},
+		{
+			name:  "Multiple files with extension precedence",
+			files: []string{"/policy.yml", "/policy.yaml", "/policy.json"},
+			want:  "/policy.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			ctx := utils.WithFS(context.Background(), fs)
+
+			for _, f := range tt.files {
+				err := afero.WriteFile(fs, f, []byte(""), 0644)
+				assert.NoError(t, err)
+			}
+
+			ff, err := choosePolicyFile(ctx, "/")
+			if tt.wantErr {
+				assert.Equal(t, "", ff)
+				assert.ErrorContains(t, err, tt.errText)
+			} else {
+				assert.Equal(t, tt.want, ff)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/validate/helpers.go
+++ b/internal/validate/helpers.go
@@ -29,10 +29,11 @@ import (
 
 // Determine policyConfig
 func GetPolicyConfig(ctx context.Context, policyConfiguration string) (string, error) {
-	// Check if policyConfiguration is a git url. If so, try to download a config file from git.
-	// If successful we write that into the data.policyConfiguration var.
-	if source.SourceIsGit(policyConfiguration) {
-		log.Debugf("Fetching policy config from git url %s", policyConfiguration)
+	// If policyConfiguration is not detected as a file and is detected as a git URL,
+	// or if policyConfiguration is an https URL try to download a config file from
+	// the provided source. If successful we read its contents and return it.
+	if source.SourceIsGit(policyConfiguration) && !source.SourceIsFile(policyConfiguration) || source.SourceIsHttp(policyConfiguration) {
+		log.Debugf("Fetching policy config from url: %s", policyConfiguration)
 
 		// Create a temporary dir to download the config. This is separate from the workDir usd
 		// later for downloading policy sources, but it doesn't matter because this dir is not
@@ -45,32 +46,38 @@ func GetPolicyConfig(ctx context.Context, policyConfiguration string) (string, e
 		defer utils.CleanupWorkDir(fs, tmpDir)
 
 		// Git download and find a suitable config file
-		configFile, err := source.GitConfigDownload(ctx, tmpDir, policyConfiguration)
+		configFile, err := source.GoGetterDownload(ctx, tmpDir, policyConfiguration)
 		if err != nil {
 			return "", err
 		}
-
-		// Changing data.policyConfiguration to the name of the newly downloaded file means we can
-		// use the code below to load the config
-		policyConfiguration = configFile
+		return readPolicyConfigurationFile(ctx, configFile)
+	} else if source.SourceIsFile(policyConfiguration) && utils.HasJsonOrYamlExt(policyConfiguration) {
+		// If policyConfiguration is detected as a file and it has a json or yaml extension,
+		// we read its contents and return it.
+		return readPolicyConfigurationFile(ctx, policyConfiguration)
 	}
 
-	// Check if policyConfig is a file path. If so, try to read it. If successful we write
-	// that into the data.policyConfiguration var.
-	if utils.HasJsonOrYamlExt(policyConfiguration) {
-		fs := utils.FS(ctx)
-		policyBytes, err := afero.ReadFile(fs, policyConfiguration)
-		if err != nil {
-			return "", err
-		}
-		// Check for empty file as that would cause a false "success"
-		if len(policyBytes) == 0 {
-			err := fmt.Errorf("file %s is empty", policyConfiguration)
-			return "", err
-		}
-		log.Debugf("Loaded %s as policyConfiguration", policyConfiguration)
-		policyConfiguration = string(policyBytes)
-	}
+	// If policyConfiguration is not a file path, git url, or https url,
+	// we assume it's a string and return it as is.
 	return policyConfiguration, nil
+
+}
+
+// Read policyConfiguration file and return its contents.
+func readPolicyConfigurationFile(ctx context.Context, policyConfiguration string) (string, error) {
+	// Check if policyConfig is a file path. If so, try to read it.
+	// If successful we write that into the data.policyConfiguration var.
+	fs := utils.FS(ctx)
+	policyBytes, err := afero.ReadFile(fs, policyConfiguration)
+	if err != nil {
+		return "", err
+	}
+	// Check for empty file as that would cause a false "success"
+	if len(policyBytes) == 0 {
+		err := fmt.Errorf("file %s is empty", policyConfiguration)
+		return "", err
+	}
+	log.Debugf("Loaded %s as policyConfiguration", policyConfiguration)
+	return string(policyBytes), nil
 
 }


### PR DESCRIPTION
This commit adds the ability to specify an https URL for a policy config YAML file.

Resolves: EC-40
Resolves: #964 