### PR TITLE
Fix Rego builtin docs generation

### DIFF
--- a/internal/evaluator/documentation/documentation.go
+++ b/internal/evaluator/documentation/documentation.go
@@ -38,7 +38,7 @@ var yamlDir = flag.String("yaml", "", "Location of the generated YAML files")
 func main() {
 	flag.Parse()
 
-	dir := filepath.Dir(filepath.Clean(*yamlDir)) // snyk is making us do this, Dir invokes Clean, but it doesn't know about this
+	dir := filepath.Clean(*yamlDir)
 
 	if err := writeBultinsToYAML(dir); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
The superfluous call to `filepath.Dir` changed the destination path from `dist/rego-reference` to `dist` and the YAML files for the Rego reference were generated in the wrong place. This removes that call.

Resolves: EC-365