### PR TITLE
Stop tracking pipeline bundles

### DIFF
--- a/cmd/track/track_bundle.go
+++ b/cmd/track/track_bundle.go
@@ -52,9 +52,9 @@ func trackBundleCmd(track trackBundleFn, pullImage pullImageFn, pushImage pushIm
 		Long: hd.Doc(`
 			Record tracking information about Tekton bundles
 
-			Given one or more Tekton Bundles, categorize each as "pipeline-bundles",
-			"tekton-bundles", or both. Then, generate a YAML representation of this
-			categorization.
+			Given one or more Tekton Bundles, categorize each as "task-bundles",
+			ignoring those that are not. Then, generate a YAML representation of
+			this categorization.
 
 			Each Tekton Bundle is expected to be a proper OCI image reference. They
 			may contain a tag, a digest, or both. If a digest is not provided, this

--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -1,11 +1,6 @@
 
 [:stdout - 1]
 /-/-/-/
-pipeline-bundles:
-  ${REGISTRY}/acceptance/bundle:
-    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
-      tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
@@ -20,20 +15,12 @@ task-bundles:
 
 [:stdout - 2]
 /-/-/-/
-pipeline-bundles:
-  ${REGISTRY}/acceptance/bundle:
-    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
-      tag: tag
-    - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-      effective_on: "2006-01-02T15:04:05Z"
-      tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
       effective_on: "${TIMESTAMP}"
       tag: tag
-    - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
+    - digest: sha256:0af8c4f92f4b252b3ef0cbd712e7352196bc33a96c58b6e1d891b26e171deae8
       effective_on: "2006-01-02T15:04:05Z"
       tag: tag
 
@@ -45,25 +32,41 @@ task-bundles:
 
 [Fresh tags:stdout - 1]
 /-/-/-/
-pipeline-bundles:
-  ${REGISTRY}/acceptance/bundle:
-    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
-      tag: tag
-    - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-      effective_on: "${TIMESTAMP}"
-      tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
       effective_on: "${TIMESTAMP}"
       tag: tag
-    - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
+    - digest: sha256:0af8c4f92f4b252b3ef0cbd712e7352196bc33a96c58b6e1d891b26e171deae8
       effective_on: "${TIMESTAMP}"
       tag: tag
 
 ---
 
 [Fresh tags:stderr - 1]
+
+---
+
+[Pipeline definition is ignored from mixed bundle:stdout - 1]
+/-/-/-/
+task-bundles:
+  ${REGISTRY}/acceptance/bundle:
+    - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
+      effective_on: "${TIMESTAMP}"
+      tag: tag
+
+---
+
+[Pipeline definition is ignored from mixed bundle:stderr - 1]
+
+---
+
+[Pipeline definition is ignored on its own:stdout - 1]
+/-/-/-/
+{}
+
+---
+
+[Pipeline definition is ignored on its own:stderr - 1]
 
 ---

--- a/features/track_bundle.feature
+++ b/features/track_bundle.feature
@@ -7,7 +7,6 @@ Feature: track bundles
   Scenario:
     Given a tekton bundle image named "acceptance/bundle:tag" containing
       | Task     | task1     |
-      | Pipeline | pipeline1 |
     When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag"
     Then the exit status should be 0
     Then the output should match the snapshot
@@ -15,20 +14,14 @@ Feature: track bundles
   Scenario: Push data bundle to OCI registry
     Given a tekton bundle image named "acceptance/bundle:tag" containing
       | Task     | task1     |
-      | Pipeline | pipeline1 |
     When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag --output oci:${REGISTRY}/tracked/bundle:tag"
     Then the exit status should be 0
     Then registry image "tracked/bundle:tag" should contain a layer with
     """
     ---
-    pipeline-bundles:
-      ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-          effective_on: "${TODAY_PLUS_30_DAYS}"
-          tag: tag
     task-bundles:
       ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
+        - digest: sha256:0af8c4f92f4b252b3ef0cbd712e7352196bc33a96c58b6e1d891b26e171deae8
           effective_on: "${TODAY_PLUS_30_DAYS}"
           tag: tag
 
@@ -37,30 +30,20 @@ Feature: track bundles
   Scenario: Replace data bundle in OCI registry
     Given a tekton bundle image named "acceptance/bundle:1.0" containing
       | Task     | task1     |
-      | Pipeline | pipeline1 |
     When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:1.0 --output oci:${REGISTRY}/tracked/bundle:tag"
     When a tekton bundle image named "acceptance/bundle:1.1" containing
       | Task     | task2     |
-      | Pipeline | pipeline2 |
     When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:1.1 --input oci:${REGISTRY}/tracked/bundle:tag --replace"
     Then the exit status should be 0
     Then registry image "tracked/bundle:tag" should contain a layer with
     """
     ---
-    pipeline-bundles:
-      ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:980e69d9bbfb10d28506863fa479b361cd25b38483951a17d60932f777ac0240
-          effective_on: "${TODAY_PLUS_30_DAYS}"
-          tag: "1.1"
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-          effective_on: "${TODAY_PLUS_30_DAYS}"
-          tag: "1.0"
     task-bundles:
       ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:980e69d9bbfb10d28506863fa479b361cd25b38483951a17d60932f777ac0240
+        - digest: sha256:7af058b8a7adb24b74875411d625afbf90af6b4ed41b740606032edf1c4a0d1d
           effective_on: "${TODAY_PLUS_30_DAYS}"
           tag: "1.1"
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
+        - digest: sha256:0af8c4f92f4b252b3ef0cbd712e7352196bc33a96c58b6e1d891b26e171deae8
           effective_on: "${TODAY_PLUS_30_DAYS}"
           tag: "1.0"
 
@@ -69,19 +52,13 @@ Feature: track bundles
   Scenario: `ec track bundle` produced OPA bundle can be fetched via `conftest pull`
     Given a tekton bundle image named "acceptance/bundle:tag" containing
       | Task     | task1     |
-      | Pipeline | pipeline1 |
     When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag --output oci:${REGISTRY}/tracked/bundle:tag"
     Then running conftest "pull oci://${REGISTRY}/tracked/bundle:tag" produces "policy/data/data/acceptable_tekton_bundles.yml" containing:
     """
     ---
-    pipeline-bundles:
-      ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-          effective_on: "${TODAY_PLUS_30_DAYS}"
-          tag: tag
     task-bundles:
       ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
+        - digest: sha256:0af8c4f92f4b252b3ef0cbd712e7352196bc33a96c58b6e1d891b26e171deae8
           effective_on: "${TODAY_PLUS_30_DAYS}"
           tag: tag
 
@@ -90,15 +67,9 @@ Feature: track bundles
   Scenario: Fresh tags
     Given a tekton bundle image named "acceptance/bundle:tag" containing
       | Task     | task1     |
-      | Pipeline | pipeline1 |
       And a track bundle file named "${TMPDIR}/bundles.yaml" containing
     """
     ---
-    pipeline-bundles:
-      ${REGISTRY}/acceptance/bundle:
-        - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-          effective_on: 2006-01-02T15:04:05Z
-          tag: tag
     task-bundles:
       ${REGISTRY}/acceptance/bundle:
         - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
@@ -107,7 +78,21 @@ Feature: track bundles
     """
       And a tekton bundle image named "acceptance/bundle:tag" containing
       | Task     | task1-updated     |
-      | Pipeline | pipeline1-updated |
     When ec command is run with "track bundle --input ${TMPDIR}/bundles.yaml --bundle ${REGISTRY}/acceptance/bundle:tag"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: Pipeline definition is ignored from mixed bundle
+    Given a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1     |
+      | Pipeline | pipeline1 |
+    When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: Pipeline definition is ignored on its own
+    Given a tekton bundle image named "acceptance/bundle:tag" containing
+      | Pipeline | pipeline1 |
+    When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag"
     Then the exit status should be 0
     Then the output should match the snapshot

--- a/internal/tracker/bundle_info.go
+++ b/internal/tracker/bundle_info.go
@@ -49,8 +49,6 @@ func newBundleInfo(ctx context.Context, ref image.ImageReference) (*bundleInfo, 
 	for _, layer := range manifest.Layers {
 		if kind, ok := layer.Annotations[oci.KindAnnotation]; ok {
 			switch kind {
-			case "pipeline":
-				info.collections.Insert(pipelineCollection)
 			case "task":
 				info.collections.Insert(taskCollection)
 			}

--- a/internal/tracker/tracker_gen_test.go
+++ b/internal/tracker/tracker_gen_test.go
@@ -43,7 +43,6 @@ func TestTrackerAddKeepsOrder(t *testing.T) {
 	arbitraries.RegisterGen(gen.SliceOf(
 		gen.Struct(reflect.TypeOf(bundleRecord{}), map[string]gopter.Gen{
 			"Digest":     gen.RegexMatch("^sha256:[a-f0-9]{64}$"),
-			"Collection": nonEmptyIdentifier,
 			"Tag":        gen.Identifier(),
 			"Repository": nonEmptyIdentifier,
 		})))
@@ -52,7 +51,11 @@ func TestTrackerAddKeepsOrder(t *testing.T) {
 
 	properties.Property("collections are sorted", arbitraries.ForAll(
 		func(records []bundleRecord) bool {
-			tracker := Tracker{}
+			tracker, err := newTracker(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			for _, r := range records {
 				tracker.addBundleRecord(r)
 			}

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -81,7 +81,7 @@ func TestTrack(t *testing.T) {
 			},
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/repo:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -99,7 +99,7 @@ func TestTrack(t *testing.T) {
 			},
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -117,7 +117,7 @@ func TestTrack(t *testing.T) {
 			},
 			input: []byte(hd.Doc(
 				`---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/repo:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -125,7 +125,7 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(
 				`---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/repo:
 				    - digest: ` + sampleHashTwo.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -142,7 +142,7 @@ func TestTrack(t *testing.T) {
 			},
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -150,7 +150,7 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -167,24 +167,15 @@ func TestTrack(t *testing.T) {
 				"registry.com/two:2.0@" + sampleHashTwo.String(),
 			},
 			input: []byte(hd.Doc(`
-				task-bundles:
-				  registry.com/one:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
+				---
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/two:
 				    - digest: ` + sampleHashTwo.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
 				      tag: "2.0"
-				task-bundles:
-				  registry.com/one:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
 			`),
 		},
 		{
@@ -194,11 +185,6 @@ func TestTrack(t *testing.T) {
 			},
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashOne.String() + `
@@ -213,7 +199,7 @@ func TestTrack(t *testing.T) {
 			},
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -221,7 +207,7 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -236,18 +222,6 @@ func TestTrack(t *testing.T) {
 			prune: true,
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + yesterday + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + yesterday + `"
-				      tag: "1.0"
-				    # Unrelated tag should be ignored.
-				    - digest: sha256:abc
-				      effective_on: "` + yesterday + `"
-				      tag: "0.9"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashThree.String() + `
@@ -263,17 +237,6 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + yesterday + `"
-				      tag: "1.0"
-				    - digest: sha256:abc
-				      effective_on: "` + yesterday + `"
-				      tag: "0.9"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashOne.String() + `
@@ -295,20 +258,6 @@ func TestTrack(t *testing.T) {
 			prune: true,
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.3"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.3"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.2"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.2"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashThree.String() + `
@@ -326,17 +275,6 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.3"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "0.2"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashOne.String() + `
@@ -358,20 +296,6 @@ func TestTrack(t *testing.T) {
 			prune: true,
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashThree.String() + `
@@ -389,23 +313,6 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 				---
-				pipeline-bundles:
-				  registry.com/mixed:
-				    - digest: ` + sampleHashOne.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashThree.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
-				    - digest: ` + sampleHashTwo.String() + `
-				      effective_on: "` + expectedEffectiveOn + `"
-				      tag: "1.0"
 				task-bundles:
 				  registry.com/mixed:
 				    - digest: ` + sampleHashOne.String() + `
@@ -430,7 +337,7 @@ func TestTrack(t *testing.T) {
 			freshen: true,
 			input: []byte(hd.Doc(`
 				---
-				pipeline-bundles:
+				task-bundles:
 				  registry.com/one:
 				    - digest: ` + sampleHashOne.String() + `
 				      effective_on: "` + expectedEffectiveOn + `"
@@ -438,7 +345,7 @@ func TestTrack(t *testing.T) {
 			`)),
 			output: hd.Doc(`
 			---
-			pipeline-bundles:
+			task-bundles:
 			  registry.com/one:
 			    - digest: ` + sampleHashOneUpdated.String() + `
 			      effective_on: "` + expectedEffectiveOn + `"
@@ -526,19 +433,19 @@ var testObjects = map[string]map[string]map[string]runtime.Object{
 
 var testImages = map[string]v1.Image{
 	"registry.com/one:1.0@" + sampleHashOne.String(): mustCreateFakeBundleImage([]fakeDefinition{
-		{name: "pipeline-v1", kind: "pipeline"},
+		{name: "task-v1", kind: "task"},
 	}),
 	"registry.com/one:1.0@" + sampleHashOneUpdated.String(): mustCreateFakeBundleImage([]fakeDefinition{
-		{name: "pipeline-v1", kind: "pipeline"},
+		{name: "task-v1", kind: "task"},
 	}),
 	"registry.com/two:2.0@" + sampleHashTwo.String(): mustCreateFakeBundleImage([]fakeDefinition{
-		{name: "pipeline-v2", kind: "pipeline"},
+		{name: "task-v2", kind: "task"},
 	}),
 	"registry.com/repo:one@" + sampleHashOne.String(): mustCreateFakeBundleImage([]fakeDefinition{
-		{name: "pipeline-v1", kind: "pipeline"},
+		{name: "task-v1", kind: "task"},
 	}),
 	"registry.com/repo:two@" + sampleHashTwo.String(): mustCreateFakeBundleImage([]fakeDefinition{
-		{name: "pipeline-v2", kind: "pipeline"},
+		{name: "task-v2", kind: "task"},
 	}),
 	"registry.com/mixed:1.0@" + sampleHashOne.String(): mustCreateFakeBundleImage([]fakeDefinition{
 		{name: "pipeline-v1", kind: "pipeline"},


### PR DESCRIPTION
We currently have no use for the list of digests for Pipeline bundles. No policy rules use it.

Ref: EC-351