### PR TITLE
Add ec.oci.image_manifest rego function

### DIFF
--- a/acceptance/examples/oci_image_manifest.rego
+++ b/acceptance/examples/oci_image_manifest.rego
@@ -1,0 +1,37 @@
+package manifest
+
+import rego.v1
+
+# METADATA
+# custom:
+#   short_name: match
+deny contains result if {
+	manifest := ec.oci.image_manifest(input.image.ref)
+	not manifest_matches(manifest)
+
+	result := {
+		"code": "manifest.match",
+		"msg": json.marshal(manifest),
+	}
+}
+
+manifest_matches(manifest) if {
+	manifest.annotations["org.opencontainers.image.base.name"] != ""
+	manifest.mediaType == "application/vnd.docker.distribution.manifest.v2+json"
+	manifest.schemaVersion == 2
+	non_empty_descriptor(manifest.config, "application/vnd.docker.container.image.v1+json")
+	count(manifest.layers) == 2
+	non_empty_descriptor(manifest.layers[0], "application/vnd.docker.image.rootfs.diff.tar.gzip")
+	non_empty_descriptor(manifest.layers[1], "application/vnd.docker.image.rootfs.diff.tar.gzip")
+}
+
+non_empty_descriptor(descriptor, media_type) if {
+	descriptor.annotations == {}
+	descriptor.artifactType == ""
+	descriptor.data == ""
+	startswith(descriptor.digest, "sha256:")
+	count(descriptor.digest) == count("sha256:") + 64
+	descriptor.mediaType == media_type
+	descriptor.size > 0
+	descriptor.urls == []
+}

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -3344,3 +3344,80 @@ time="${TIMESTAMP}" level=error msg="Parsing PURL \"this-is-not-a-valid-purl\" f
 Error: success criteria not met
 
 ---
+
+[fetch OCI image manifest:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/oci-image-manifest@sha256:${REGISTRY_acceptance/oci-image-manifest:latest_DIGEST}",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "manifest.match"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/oci-image-manifest}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/oci-image-manifest}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/oci-image-manifest-policy"
+        ]
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[fetch OCI image manifest:stderr - 1]
+
+---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -926,6 +926,31 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: fetch OCI image manifest
+    Given a key pair named "known"
+    Given an image named "acceptance/oci-image-manifest"
+    Given a valid image signature of "acceptance/oci-image-manifest" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/oci-image-manifest"
+    Given a valid attestation of "acceptance/oci-image-manifest" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/oci-image-manifest"
+    Given a git repository named "oci-image-manifest-policy" with
+      | main.rego | examples/oci_image_manifest.rego |
+    Given policy configuration named "ec-policy" with specification
+      """
+      {
+        "sources": [
+          {
+            "policy": [
+              "git::https://${GITHOST}/git/oci-image-manifest-policy"
+            ]
+          }
+        ]
+      }
+      """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/oci-image-manifest --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR}  --show-successes"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
   Scenario: tracing and debug logging
     Given a key pair named "trace_debug"
       And an image named "acceptance/trace-debug"

--- a/internal/evaluator/__snapshots__/rego_test.snap
+++ b/internal/evaluator/__snapshots__/rego_test.snap
@@ -1,0 +1,869 @@
+
+[TestOCIImageManifest/complete_image_manifest - 1]
+{
+ "type": "object",
+ "value": [
+  [
+   {
+    "type": "string",
+    "value": "annotations"
+   },
+   {
+    "type": "object",
+    "value": [
+     [
+      {
+       "type": "string",
+       "value": "manifest.annotation.1"
+      },
+      {
+       "type": "string",
+       "value": "config.annotation.value.1"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "manifest.annotation.2"
+      },
+      {
+       "type": "string",
+       "value": "config.annotation.value.2"
+      }
+     ]
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "config"
+   },
+   {
+    "type": "object",
+    "value": [
+     [
+      {
+       "type": "string",
+       "value": "annotations"
+      },
+      {
+       "type": "object",
+       "value": [
+        [
+         {
+          "type": "string",
+          "value": "config.annotation.1"
+         },
+         {
+          "type": "string",
+          "value": "config.annotation.value.1"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "config.annotation.2"
+         },
+         {
+          "type": "string",
+          "value": "config.annotation.value.2"
+         }
+        ]
+       ]
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "artifactType"
+      },
+      {
+       "type": "string",
+       "value": "artifact-type"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "data"
+      },
+      {
+       "type": "string",
+       "value": "{\"data\": \"config\"}"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "digest"
+      },
+      {
+       "type": "string",
+       "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "mediaType"
+      },
+      {
+       "type": "string",
+       "value": "application/vnd.oci.image.config.v1+json"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "platform"
+      },
+      {
+       "type": "object",
+       "value": [
+        [
+         {
+          "type": "string",
+          "value": "architecture"
+         },
+         {
+          "type": "string",
+          "value": "arch"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "features"
+         },
+         {
+          "type": "array",
+          "value": [
+           {
+            "type": "string",
+            "value": "feature-1"
+           },
+           {
+            "type": "string",
+            "value": "feature-2"
+           }
+          ]
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os"
+         },
+         {
+          "type": "string",
+          "value": "os"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os.features"
+         },
+         {
+          "type": "array",
+          "value": [
+           {
+            "type": "string",
+            "value": "os-feature-1"
+           },
+           {
+            "type": "string",
+            "value": "os-feature-2"
+           }
+          ]
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os.version"
+         },
+         {
+          "type": "string",
+          "value": "os-version"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "variant"
+         },
+         {
+          "type": "string",
+          "value": "variant"
+         }
+        ]
+       ]
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "size"
+      },
+      {
+       "type": "number",
+       "value": 123
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "urls"
+      },
+      {
+       "type": "array",
+       "value": [
+        {
+         "type": "string",
+         "value": "https://config-1.local/spam"
+        },
+        {
+         "type": "string",
+         "value": "https://config-2.local/spam"
+        }
+       ]
+      }
+     ]
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "layers"
+   },
+   {
+    "type": "array",
+    "value": [
+     {
+      "type": "object",
+      "value": [
+       [
+        {
+         "type": "string",
+         "value": "annotations"
+        },
+        {
+         "type": "object",
+         "value": [
+          [
+           {
+            "type": "string",
+            "value": "layer.annotation.1"
+           },
+           {
+            "type": "string",
+            "value": "layer.annotation.value.1"
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "layer.annotation.2"
+           },
+           {
+            "type": "string",
+            "value": "layer.annotation.value.2"
+           }
+          ]
+         ]
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "artifactType"
+        },
+        {
+         "type": "string",
+         "value": "artifact-type"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "data"
+        },
+        {
+         "type": "string",
+         "value": "{\"data\": \"layer\"}"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "digest"
+        },
+        {
+         "type": "string",
+         "value": "sha256:325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "mediaType"
+        },
+        {
+         "type": "string",
+         "value": "application/vnd.oci.image.layer.v1.tar+gzip"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "platform"
+        },
+        {
+         "type": "object",
+         "value": [
+          [
+           {
+            "type": "string",
+            "value": "architecture"
+           },
+           {
+            "type": "string",
+            "value": "arch"
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "features"
+           },
+           {
+            "type": "array",
+            "value": [
+             {
+              "type": "string",
+              "value": "feature-1"
+             },
+             {
+              "type": "string",
+              "value": "feature-2"
+             }
+            ]
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "os"
+           },
+           {
+            "type": "string",
+            "value": "os"
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "os.features"
+           },
+           {
+            "type": "array",
+            "value": [
+             {
+              "type": "string",
+              "value": "os-feature-1"
+             },
+             {
+              "type": "string",
+              "value": "os-feature-2"
+             }
+            ]
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "os.version"
+           },
+           {
+            "type": "string",
+            "value": "os-version"
+           }
+          ],
+          [
+           {
+            "type": "string",
+            "value": "variant"
+           },
+           {
+            "type": "string",
+            "value": "variant"
+           }
+          ]
+         ]
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "size"
+        },
+        {
+         "type": "number",
+         "value": 9999
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "urls"
+        },
+        {
+         "type": "array",
+         "value": [
+          {
+           "type": "string",
+           "value": "https://layer-1.local/spam"
+          },
+          {
+           "type": "string",
+           "value": "https://layer-2.local/spam"
+          }
+         ]
+        }
+       ]
+      ]
+     }
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "mediaType"
+   },
+   {
+    "type": "string",
+    "value": "application/vnd.oci.image.manifest.v1+json"
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "schemaVersion"
+   },
+   {
+    "type": "number",
+    "value": 2
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "subject"
+   },
+   {
+    "type": "object",
+    "value": [
+     [
+      {
+       "type": "string",
+       "value": "annotations"
+      },
+      {
+       "type": "object",
+       "value": [
+        [
+         {
+          "type": "string",
+          "value": "subject.annotation.1"
+         },
+         {
+          "type": "string",
+          "value": "subject.annotation.value.1"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "subject.annotation.2"
+         },
+         {
+          "type": "string",
+          "value": "subject.annotation.value.2"
+         }
+        ]
+       ]
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "artifactType"
+      },
+      {
+       "type": "string",
+       "value": "artifact-type"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "data"
+      },
+      {
+       "type": "string",
+       "value": "{\"data\": \"subject\"}"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "digest"
+      },
+      {
+       "type": "string",
+       "value": "sha256:d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "mediaType"
+      },
+      {
+       "type": "string",
+       "value": "application/vnd.oci.image.manifest.v1+json"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "platform"
+      },
+      {
+       "type": "object",
+       "value": [
+        [
+         {
+          "type": "string",
+          "value": "architecture"
+         },
+         {
+          "type": "string",
+          "value": "arch"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "features"
+         },
+         {
+          "type": "array",
+          "value": [
+           {
+            "type": "string",
+            "value": "feature-1"
+           },
+           {
+            "type": "string",
+            "value": "feature-2"
+           }
+          ]
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os"
+         },
+         {
+          "type": "string",
+          "value": "os"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os.features"
+         },
+         {
+          "type": "array",
+          "value": [
+           {
+            "type": "string",
+            "value": "os-feature-1"
+           },
+           {
+            "type": "string",
+            "value": "os-feature-2"
+           }
+          ]
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "os.version"
+         },
+         {
+          "type": "string",
+          "value": "os-version"
+         }
+        ],
+        [
+         {
+          "type": "string",
+          "value": "variant"
+         },
+         {
+          "type": "string",
+          "value": "variant"
+         }
+        ]
+       ]
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "size"
+      },
+      {
+       "type": "number",
+       "value": 8888
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "urls"
+      },
+      {
+       "type": "array",
+       "value": [
+        {
+         "type": "string",
+         "value": "https://subject-1.local/spam"
+        },
+        {
+         "type": "string",
+         "value": "https://subject-2.local/spam"
+        }
+       ]
+      }
+     ]
+    ]
+   }
+  ]
+ ]
+}
+---
+
+[TestOCIImageManifest/minimal_image_manifest - 1]
+{
+ "type": "object",
+ "value": [
+  [
+   {
+    "type": "string",
+    "value": "annotations"
+   },
+   {
+    "type": "object",
+    "value": []
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "config"
+   },
+   {
+    "type": "object",
+    "value": [
+     [
+      {
+       "type": "string",
+       "value": "annotations"
+      },
+      {
+       "type": "object",
+       "value": []
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "artifactType"
+      },
+      {
+       "type": "string",
+       "value": ""
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "data"
+      },
+      {
+       "type": "string",
+       "value": ""
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "digest"
+      },
+      {
+       "type": "string",
+       "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "mediaType"
+      },
+      {
+       "type": "string",
+       "value": "application/vnd.oci.image.config.v1+json"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "size"
+      },
+      {
+       "type": "number",
+       "value": 123
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "urls"
+      },
+      {
+       "type": "array",
+       "value": []
+      }
+     ]
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "layers"
+   },
+   {
+    "type": "array",
+    "value": [
+     {
+      "type": "object",
+      "value": [
+       [
+        {
+         "type": "string",
+         "value": "annotations"
+        },
+        {
+         "type": "object",
+         "value": []
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "artifactType"
+        },
+        {
+         "type": "string",
+         "value": ""
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "data"
+        },
+        {
+         "type": "string",
+         "value": ""
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "digest"
+        },
+        {
+         "type": "string",
+         "value": "sha256:325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "mediaType"
+        },
+        {
+         "type": "string",
+         "value": "application/vnd.oci.image.layer.v1.tar+gzip"
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "size"
+        },
+        {
+         "type": "number",
+         "value": 9999
+        }
+       ],
+       [
+        {
+         "type": "string",
+         "value": "urls"
+        },
+        {
+         "type": "array",
+         "value": []
+        }
+       ]
+      ]
+     }
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "mediaType"
+   },
+   {
+    "type": "string",
+    "value": "application/vnd.oci.image.manifest.v1+json"
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "schemaVersion"
+   },
+   {
+    "type": "number",
+    "value": 2
+   }
+  ]
+ ]
+}
+---

--- a/internal/evaluator/documentation/__snapshots__/documentation_test.snap
+++ b/internal/evaluator/documentation/__snapshots__/documentation_test.snap
@@ -19,6 +19,214 @@ nondeterministic: true
 [TestWriteBuiltinsToYAML - 2]
 decl:
   args:
+  - description: OCI image reference
+    name: ref
+    type: string
+  result:
+    description: the Image Manifest object
+    name: object
+    static:
+    - key: annotations
+      value:
+        dynamic:
+          key:
+            type: string
+          value:
+            type: string
+        type: object
+    - key: config
+      value:
+        static:
+        - key: annotations
+          value:
+            dynamic:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+        - key: artifactType
+          value:
+            type: string
+        - key: data
+          value:
+            type: string
+        - key: digest
+          value:
+            type: string
+        - key: mediaType
+          value:
+            type: string
+        - key: platform
+          value:
+            static:
+            - key: architecture
+              value:
+                type: string
+            - key: features
+              value:
+                static:
+                - type: string
+                type: array
+            - key: os
+              value:
+                type: string
+            - key: os.features
+              value:
+                static:
+                - type: string
+                type: array
+            - key: os.version
+              value:
+                type: string
+            - key: variant
+              value:
+                type: string
+            type: object
+        - key: size
+          value:
+            type: number
+        - key: urls
+          value:
+            static:
+            - type: string
+            type: array
+        type: object
+    - key: layers
+      value:
+        static:
+        - static:
+          - key: annotations
+            value:
+              dynamic:
+                key:
+                  type: string
+                value:
+                  type: string
+              type: object
+          - key: artifactType
+            value:
+              type: string
+          - key: data
+            value:
+              type: string
+          - key: digest
+            value:
+              type: string
+          - key: mediaType
+            value:
+              type: string
+          - key: platform
+            value:
+              static:
+              - key: architecture
+                value:
+                  type: string
+              - key: features
+                value:
+                  static:
+                  - type: string
+                  type: array
+              - key: os
+                value:
+                  type: string
+              - key: os.features
+                value:
+                  static:
+                  - type: string
+                  type: array
+              - key: os.version
+                value:
+                  type: string
+              - key: variant
+                value:
+                  type: string
+              type: object
+          - key: size
+            value:
+              type: number
+          - key: urls
+            value:
+              static:
+              - type: string
+              type: array
+          type: object
+        type: array
+    - key: mediaType
+      value:
+        type: string
+    - key: schemaVersion
+      value:
+        type: number
+    - key: subject
+      value:
+        static:
+        - key: annotations
+          value:
+            dynamic:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+        - key: artifactType
+          value:
+            type: string
+        - key: data
+          value:
+            type: string
+        - key: digest
+          value:
+            type: string
+        - key: mediaType
+          value:
+            type: string
+        - key: platform
+          value:
+            static:
+            - key: architecture
+              value:
+                type: string
+            - key: features
+              value:
+                static:
+                - type: string
+                type: array
+            - key: os
+              value:
+                type: string
+            - key: os.features
+              value:
+                static:
+                - type: string
+                type: array
+            - key: os.version
+              value:
+                type: string
+            - key: variant
+              value:
+                type: string
+            type: object
+        - key: size
+          value:
+            type: number
+        - key: urls
+          value:
+            static:
+            - type: string
+            type: array
+        type: object
+    type: object
+  type: function
+description: Fetch an Image Manifest from an OCI registry.
+name: ec.oci.image_manifest
+nondeterministic: true
+
+---
+
+[TestWriteBuiltinsToYAML - 3]
+decl:
+  args:
   - description: the PURL
     name: purl
     type: string
@@ -32,7 +240,7 @@ name: ec.purl.is_valid
 
 ---
 
-[TestWriteBuiltinsToYAML - 3]
+[TestWriteBuiltinsToYAML - 4]
 decl:
   args:
   - description: the PURL

--- a/internal/evaluator/rego.go
+++ b/internal/evaluator/rego.go
@@ -23,11 +23,13 @@ package evaluator
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -38,9 +40,12 @@ import (
 	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci"
 )
 
-const ociBlobName = "ec.oci.blob"
-const purlIsValidName = "ec.purl.is_valid"
-const purlParseName = "ec.purl.parse"
+const (
+	ociBlobName          = "ec.oci.blob"
+	ociImageManifestName = "ec.oci.image_manifest"
+	purlIsValidName      = "ec.purl.is_valid"
+	purlParseName        = "ec.purl.parse"
+)
 
 func registerOCIBlob() {
 	decl := rego.Function{
@@ -65,6 +70,81 @@ func registerOCIBlob() {
 	ast.RegisterBuiltin(&ast.Builtin{
 		Name:             decl.Name,
 		Description:      "Fetch a blob from an OCI registry.",
+		Decl:             decl.Decl,
+		Nondeterministic: decl.Nondeterministic,
+	})
+}
+
+func registerOCIImageManifest() {
+	platform := types.NewObject(
+		[]*types.StaticProperty{
+			{Key: "architecture", Value: types.S},
+			{Key: "os", Value: types.S},
+			{Key: "os.version", Value: types.S},
+			{Key: "os.features", Value: types.NewArray([]types.Type{types.S}, nil)},
+			{Key: "variant", Value: types.S},
+			{Key: "features", Value: types.NewArray([]types.Type{types.S}, nil)},
+		},
+		nil,
+	)
+
+	// annotations represents the map[string]string rego type
+	annotations := types.NewObject(nil, types.NewDynamicProperty(types.S, types.S))
+
+	descriptor := types.NewObject(
+		[]*types.StaticProperty{
+			{Key: "mediaType", Value: types.S},
+			{Key: "size", Value: types.N},
+			{Key: "digest", Value: types.S},
+			{Key: "data", Value: types.S},
+			{Key: "urls", Value: types.NewArray(
+				[]types.Type{types.S}, nil,
+			)},
+			{Key: "annotations", Value: annotations},
+			{Key: "platform", Value: platform},
+			{Key: "artifactType", Value: types.S},
+		},
+		nil,
+	)
+
+	manifest := types.NewObject(
+		[]*types.StaticProperty{
+			// Specifying the properties like this ensure the compiler catches typos when
+			// evaluating rego functions.
+			{Key: "schemaVersion", Value: types.N},
+			{Key: "mediaType", Value: types.S},
+			{Key: "config", Value: descriptor},
+			{Key: "layers", Value: types.NewArray(
+				[]types.Type{descriptor}, nil,
+			)},
+			{Key: "annotations", Value: annotations},
+			{Key: "subject", Value: descriptor},
+		},
+		nil,
+	)
+
+	decl := rego.Function{
+		Name: ociImageManifestName,
+		Decl: types.NewFunction(
+			types.Args(
+				types.Named("ref", types.S).Description("OCI image reference"),
+			),
+			types.Named("object", manifest).Description("the Image Manifest object"),
+		),
+		// As per the documentation, enable memoization to ensure function evaluation is
+		// deterministic. But also mark it as non-deterministic because it does rely on external
+		// entities, i.e. OCI registry. https://www.openpolicyagent.org/docs/latest/extensions/
+		Memoize:          true,
+		Nondeterministic: true,
+	}
+
+	rego.RegisterBuiltin1(&decl, ociImageManifest)
+	// Due to https://github.com/open-policy-agent/opa/issues/6449, we cannot set a description for
+	// the custom function through the call above. As a workaround we re-register the function with
+	// a declaration that does include the description.
+	ast.RegisterBuiltin(&ast.Builtin{
+		Name:             decl.Name,
+		Description:      "Fetch an Image Manifest from an OCI registry.",
 		Decl:             decl.Decl,
 		Nondeterministic: decl.Nondeterministic,
 	})
@@ -204,6 +284,114 @@ func ociBlob(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	return ast.StringTerm(blob.String()), nil
 }
 
+func ociImageManifest(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	log := log.WithField("rego", ociImageManifestName)
+	uri, ok := a.Value.(ast.String)
+	if !ok {
+		return nil, nil
+	}
+
+	ref, err := name.NewDigest(string(uri))
+	if err != nil {
+		log.Errorf("new digest: %s", err)
+		return nil, nil
+	}
+
+	opts := []remote.Option{
+		remote.WithTransport(remote.DefaultTransport),
+		remote.WithContext(bctx.Context),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+	}
+
+	image, err := oci.NewClient(bctx.Context).Image(ref, opts...)
+	if err != nil {
+		log.Errorf("fetch image: %s", err)
+		return nil, nil
+	}
+
+	manifest, err := image.Manifest()
+	if err != nil {
+		log.Errorf("fetch manifest: %s", err)
+		return nil, nil
+	}
+
+	if manifest == nil {
+		log.Error("manifest is nil")
+		return nil, nil
+	}
+
+	layers := []*ast.Term{}
+	for _, layer := range manifest.Layers {
+		layers = append(layers, newDescriptorTerm(layer))
+	}
+
+	manifestTerms := [][2]*ast.Term{
+		ast.Item(ast.StringTerm("schemaVersion"), ast.NumberTerm(json.Number(fmt.Sprintf("%d", manifest.SchemaVersion)))),
+		ast.Item(ast.StringTerm("mediaType"), ast.StringTerm(string(manifest.MediaType))),
+		ast.Item(ast.StringTerm("config"), newDescriptorTerm(manifest.Config)),
+		ast.Item(ast.StringTerm("layers"), ast.ArrayTerm(layers...)),
+		ast.Item(ast.StringTerm("annotations"), newAnnotationsTerm(manifest.Annotations)),
+	}
+
+	if s := manifest.Subject; s != nil {
+		manifestTerms = append(manifestTerms, ast.Item(ast.StringTerm("subject"), newDescriptorTerm(*s)))
+	}
+
+	return ast.ObjectTerm(manifestTerms...), nil
+}
+
+func newPlatformTerm(p v1.Platform) *ast.Term {
+	osFeatures := []*ast.Term{}
+	for _, f := range p.OSFeatures {
+		osFeatures = append(osFeatures, ast.StringTerm(f))
+	}
+
+	features := []*ast.Term{}
+	for _, f := range p.Features {
+		features = append(features, ast.StringTerm(f))
+	}
+
+	return ast.ObjectTerm(
+		ast.Item(ast.StringTerm("architecture"), ast.StringTerm(p.Architecture)),
+		ast.Item(ast.StringTerm("os"), ast.StringTerm(p.OS)),
+		ast.Item(ast.StringTerm("os.version"), ast.StringTerm(p.OSVersion)),
+		ast.Item(ast.StringTerm("os.features"), ast.ArrayTerm(osFeatures...)),
+		ast.Item(ast.StringTerm("variant"), ast.StringTerm(p.Variant)),
+		ast.Item(ast.StringTerm("features"), ast.ArrayTerm(features...)),
+	)
+}
+
+func newDescriptorTerm(d v1.Descriptor) *ast.Term {
+	urls := []*ast.Term{}
+	for _, url := range d.URLs {
+		urls = append(urls, ast.StringTerm(url))
+	}
+
+	dTerms := [][2]*ast.Term{
+		ast.Item(ast.StringTerm("mediaType"), ast.StringTerm(string(d.MediaType))),
+		ast.Item(ast.StringTerm("size"), ast.NumberTerm(json.Number(fmt.Sprintf("%d", d.Size)))),
+		ast.Item(ast.StringTerm("digest"), ast.StringTerm(d.Digest.String())),
+		ast.Item(ast.StringTerm("data"), ast.StringTerm(string(d.Data))),
+		ast.Item(ast.StringTerm("urls"), ast.ArrayTerm(urls...)),
+		ast.Item(ast.StringTerm("annotations"), newAnnotationsTerm(d.Annotations)),
+		ast.Item(ast.StringTerm("artifactType"), ast.StringTerm(d.ArtifactType)),
+	}
+
+	if d.Platform != nil {
+		dTerms = append(dTerms, ast.Item(ast.StringTerm("platform"), newPlatformTerm(*d.Platform)))
+	}
+
+	return ast.ObjectTerm(dTerms...)
+}
+
+func newAnnotationsTerm(annotations map[string]string) *ast.Term {
+	annotationTerms := [][2]*ast.Term{}
+	for key, value := range annotations {
+		annotationTerms = append(annotationTerms, ast.Item(ast.StringTerm(key), ast.StringTerm(value)))
+	}
+	return ast.ObjectTerm(annotationTerms...)
+}
+
 func purlIsValid(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	uri, ok := a.Value.(ast.String)
 	if !ok {
@@ -248,6 +436,7 @@ func purlParse(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 
 func init() {
 	registerOCIBlob()
+	registerOCIImageManifest()
 	registerPURLIsValid()
 	registerPURLParse()
 }

--- a/internal/evaluator/rego_test.go
+++ b/internal/evaluator/rego_test.go
@@ -23,6 +23,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gkampitakis/go-snaps/snaps"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	v1fake "github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/open-policy-agent/opa/ast"
@@ -101,6 +104,178 @@ func TestOCIBlob(t *testing.T) {
 				data, ok := blob.Value.(ast.String)
 				require.True(t, ok)
 				require.Equal(t, c.data, string(data))
+			}
+		})
+	}
+}
+
+func TestOCIImageManifest(t *testing.T) {
+	cases := []struct {
+		name        string
+		ref         *ast.Term
+		manifest    *v1.Manifest
+		imageErr    error
+		manifestErr error
+		wantErr     bool
+	}{
+		{
+			name: "complete image manifest",
+			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
+			manifest: &v1.Manifest{
+				SchemaVersion: 2,
+				MediaType:     types.OCIManifestSchema1,
+				Config: v1.Descriptor{
+					MediaType: types.OCIConfigJSON,
+					Size:      123,
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+					},
+					Data: []byte(`{"data": "config"}`),
+					URLs: []string{"https://config-1.local/spam", "https://config-2.local/spam"},
+					Annotations: map[string]string{
+						"config.annotation.1": "config.annotation.value.1",
+						"config.annotation.2": "config.annotation.value.2",
+					},
+					Platform: &v1.Platform{
+						Architecture: "arch",
+						OS:           "os",
+						OSVersion:    "os-version",
+						OSFeatures:   []string{"os-feature-1", "os-feature-2"},
+						Variant:      "variant",
+						Features:     []string{"feature-1", "feature-2"},
+					},
+					ArtifactType: "artifact-type",
+				},
+				Layers: []v1.Descriptor{
+					{
+						MediaType: types.OCILayer,
+						Size:      9999,
+						Digest: v1.Hash{
+							Algorithm: "sha256",
+							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
+						},
+						Data: []byte(`{"data": "layer"}`),
+						URLs: []string{"https://layer-1.local/spam", "https://layer-2.local/spam"},
+						Annotations: map[string]string{
+							"layer.annotation.1": "layer.annotation.value.1",
+							"layer.annotation.2": "layer.annotation.value.2",
+						},
+						Platform: &v1.Platform{
+							Architecture: "arch",
+							OS:           "os",
+							OSVersion:    "os-version",
+							OSFeatures:   []string{"os-feature-1", "os-feature-2"},
+							Variant:      "variant",
+							Features:     []string{"feature-1", "feature-2"},
+						},
+						ArtifactType: "artifact-type",
+					},
+				},
+				Annotations: map[string]string{
+					"manifest.annotation.1": "config.annotation.value.1",
+					"manifest.annotation.2": "config.annotation.value.2",
+				},
+				Subject: &v1.Descriptor{
+					MediaType: types.OCIManifestSchema1,
+					Size:      8888,
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						Hex:       "d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa",
+					},
+					Data: []byte(`{"data": "subject"}`),
+					URLs: []string{"https://subject-1.local/spam", "https://subject-2.local/spam"},
+					Annotations: map[string]string{
+						"subject.annotation.1": "subject.annotation.value.1",
+						"subject.annotation.2": "subject.annotation.value.2",
+					},
+					Platform: &v1.Platform{
+						Architecture: "arch",
+						OS:           "os",
+						OSVersion:    "os-version",
+						OSFeatures:   []string{"os-feature-1", "os-feature-2"},
+						Variant:      "variant",
+						Features:     []string{"feature-1", "feature-2"},
+					},
+					ArtifactType: "artifact-type",
+				},
+			},
+		},
+		{
+			name: "minimal image manifest",
+			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
+			manifest: &v1.Manifest{
+				SchemaVersion: 2,
+				MediaType:     types.OCIManifestSchema1,
+				Config: v1.Descriptor{
+					MediaType: types.OCIConfigJSON,
+					Size:      123,
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+					},
+				},
+				Layers: []v1.Descriptor{
+					{
+						MediaType: types.OCILayer,
+						Size:      9999,
+						Digest: v1.Hash{
+							Algorithm: "sha256",
+							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "missing digest",
+			ref:     ast.StringTerm("registry.local/spam:latest"),
+			wantErr: true,
+		},
+		{
+			name:    "bad image ref",
+			ref:     ast.StringTerm("......registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
+			wantErr: true,
+		},
+		{
+			name:    "invalid ref type",
+			ref:     ast.IntNumberTerm(42),
+			wantErr: true,
+		},
+		{
+			name:        "image error",
+			ref:         ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
+			manifestErr: errors.New("kaboom!"),
+			wantErr:     true,
+		},
+		{
+			name:     "nil manifest",
+			ref:      ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
+			manifest: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client := fake.FakeClient{}
+			if c.imageErr != nil {
+				client.On("Image", mock.Anything, mock.Anything).Return(nil, c.imageErr)
+			} else {
+				imageManifest := v1fake.FakeImage{}
+				imageManifest.ManifestReturns(c.manifest, c.manifestErr)
+				client.On("Image", mock.Anything, mock.Anything).Return(&imageManifest, nil)
+			}
+			ctx := oci.WithClient(context.Background(), &client)
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			got, err := ociImageManifest(bctx, c.ref)
+			require.NoError(t, err)
+			if c.wantErr {
+				require.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				snaps.MatchJSON(t, got)
 			}
 		})
 	}
@@ -185,6 +360,7 @@ func TestPURLParse(t *testing.T) {
 func TestFunctionsRegistered(t *testing.T) {
 	names := []string{
 		ociBlobName,
+		ociImageManifestName,
 		purlIsValidName,
 		purlParseName,
 	}


### PR DESCRIPTION
This commit adds a new custom rego function, `ec.oci.image_manifest`. This function retrieves the Image Manifest from an OCI registry. (It does not download the image, just its manifest.)

The main use case this is trying to achieve is validating image references that may occur in the SLSA Provenance attestation of an image being validated. For example, the SLSA Provenance may contain a link to the corresponding source container image. This function allows policy rules to be created to verify that such references actually exists.

Ref: EC-235