### PR TITLE
Fix built in Rego function documentations

### DIFF
--- a/docs/template/rego.hbs
+++ b/docs/template/rego.hbs
@@ -19,6 +19,6 @@
 {{#if decl.result.static}}
 The object contains the following attributes:
 
-{{{ describe decl.result 1 }}}
+{{{ describe decl.result }}}
 
 {{/if}}


### PR DESCRIPTION
This tries to fix the result description of built in functions. The existing code worked well for the functions we had, up until we added the `ec.oci.image_manifest` function which has an elaborate return type.

I've tried to follow the go types and mimic the possible field values as defined there, the end result is quite convoluted and probably difficult to follow until one tries to reproduce this on their own.

The end result is slightly different than what we have currently, in that the top level object is included now, whereas previously it wasn't, it was easier to do it this way and end up with something resembling a coherent structure.