### PR TITLE
Update version format for Konflux builds

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -53,27 +53,29 @@ COPY . .
 # The normal way to get the branch name is this:
 #   EC_GIT_BRANCH=$( git rev-parse --abbrev-ref HEAD )
 # but it doesn't work because the git-clone task checks out a sha directly
-# rather than a branch. That's why we need to use `git for-each-ref`.
+# rather than a branch. That's why we need to use `git for-each-ref`. Beware
+# that testing this locally requires that you push the relevant branches to
+# your 'origin' remote.
 #
 # Note that EC_GIT_ORIGIN_BRANCH, EC_GIT_BRANCH may be blank in a pre-merge PR
 # because the PR branch refs are generally not present. In that case we'll use
 # "_ci_build" as the version.
 #
-# Alternative for EC_BUILD_NUM using the nearest tag in case we decide we don't
+# Alternative for EC_PATCH_NUM using the nearest tag in case we decide we don't
 # like the merge-base technique:
-#   EC_BUILD_NUM=$( git rev-list --count $( git describe --tags --abbrev=0 )..HEAD ); \
+#   EC_PATCH_NUM=$( git rev-list --count $( git describe --tags --abbrev=0 )..HEAD ); \
 #
 RUN \
     EC_GIT_SHA=$( git rev-parse --short HEAD ); \
     EC_GIT_ORIGIN_BRANCH=$( git for-each-ref --points-at HEAD --format='%(refname:short)' refs/remotes/origin/ ); \
     EC_GIT_BRANCH=${EC_GIT_ORIGIN_BRANCH#"origin/"}; \
     EC_VERSION=${EC_GIT_BRANCH#"release-"}; \
-    EC_BUILD_NUM=$( git rev-list --count $( git merge-base --fork-point origin/main )..HEAD ); \
+    EC_PATCH_NUM=$( git rev-list --count $( git merge-base --fork-point origin/main )..HEAD ); \
     \
     if [ -z "$EC_VERSION" ]; then \
       EC_FULL_VERSION="_ci_build-${EC_GIT_SHA}"; \
     else \
-      EC_FULL_VERSION="${EC_VERSION}-${EC_BUILD_NUM}-${EC_GIT_SHA}"; \
+      EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"; \
     fi; \
     \
     if [ -z "$EC_VERSION" -o "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -75,7 +75,7 @@ RUN \
     if [ -z "$EC_VERSION" ]; then \
       EC_FULL_VERSION="_ci_build-${EC_GIT_SHA}"; \
     else \
-      EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"; \
+      EC_FULL_VERSION="v${EC_VERSION}.${EC_PATCH_NUM}"; \
     fi; \
     \
     if [ -z "$EC_VERSION" -o "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS+=-j --no-print-directory
-VERSION:=v0.1.$$(git rev-list --count HEAD)-$$(git rev-parse --short HEAD)
+VERSION:=v0.2.$$(git rev-list --count HEAD)-$$(git rev-parse --short HEAD)
 # a list of "dist/ec_{platform}_{arch}" that we support
 ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select((.FirstClass == true or .GOARCH == "ppc64le") and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 # a list of image_* targets that we do not support


### PR DESCRIPTION
For example, in release branch `release-0.2`, use `v0.2.<patch>` for the version in Konflux builds, instead of `0.2-<build-number>-<sha>`.

Also bump version from 0.1 to 0.2.

Ref: [EC-438](https://issues.redhat.com/browse/EC-438)