### PR TITLE
Bump version from 0.2 to 0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS+=-j --no-print-directory
-VERSION:=v0.2.$$(git rev-list --count HEAD)-$$(git rev-parse --short HEAD)
+VERSION:=v0.3.$$(git rev-list --count HEAD)-$$(git rev-parse --short HEAD)
 # a list of "dist/ec_{platform}_{arch}" that we support
 ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select((.FirstClass == true or .GOARCH == "ppc64le") and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 # a list of image_* targets that we do not support


### PR DESCRIPTION
The upcoming RHTAS GA build of ec will be tracked in branch release-0.2 and will have version 0.2.\<patch\>. Bump main branch to 0.3 now so we can more easily distinguish between the rolling snapshot builds and the productized RHTAS builds.

Ref: https://issues.redhat.com/browse/EC-438