### PR TITLE
Keep patching pipelines if one patch doesn't apply

### DIFF
--- a/hack/patch-release-pipelines.sh
+++ b/hack/patch-release-pipelines.sh
@@ -63,7 +63,8 @@ for p in pull-request push; do
 
     # Create a diff file and apply the patch
     # (Can't use git apply since it is a different file)
-    git diff $sha^ $sha $main_pipeline | patch -p1 $release_pipeline
+    # If the patch doesn't apply, keep going anyhow
+    git diff $sha^ $sha $main_pipeline | patch -p1 $release_pipeline || true
 
     # Stage the changes
     git add $release_pipeline


### PR DESCRIPTION
When using the patch pipeline script for the v0.2 release branch, one of the patches, specifically the change from f1a1972, didn't apply. The patch program interactively asked by first if I should "reverse" it (no), then if I should apply it anyway (no).

The behavior is what we want, but it returns an error code, so the script aborts. Make it so the script keeps going in that kind of situation.

It does mean you have to pay attention and look at why and how the patch doesn't apply.

Ref: https://issues.redhat.com/browse/EC-434