### PR TITLE
acceptance tests only use the release policy

### DIFF
--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -109,7 +109,8 @@ policy:
 ${____known_PUBLIC_KEY}
   sources:
   - policy:
-    - github.com/enterprise-contract/ec-policies//policy
+    - github.com/enterprise-contract/ec-policies//policy/release
+    - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
 
 ---
@@ -174,7 +175,8 @@ policy:
 ${____known_PUBLIC_KEY}
   sources:
   - policy:
-    - github.com/enterprise-contract/ec-policies//policy
+    - github.com/enterprise-contract/ec-policies//policy/release
+    - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
 
 ---
@@ -264,7 +266,8 @@ policy:
     -----END PUBLIC KEY-----
   sources:
   - policy:
-    - github.com/enterprise-contract/ec-policies//policy
+    - github.com/enterprise-contract/ec-policies//policy/release
+    - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
 
 ---
@@ -366,7 +369,8 @@ policy:
     -----END PUBLIC KEY-----
   sources:
   - policy:
-    - github.com/enterprise-contract/ec-policies//policy
+    - github.com/enterprise-contract/ec-policies//policy/release
+    - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
 
 ---
@@ -624,7 +628,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy"
+          "github.com/enterprise-contract/ec-policies//policy/release",
+          "github.com/enterprise-contract/ec-policies//policy/lib"
         ]
       }
     ],
@@ -719,7 +724,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy"
+          "github.com/enterprise-contract/ec-policies//policy/release",
+          "github.com/enterprise-contract/ec-policies//policy/lib"
         ]
       }
     ],
@@ -836,7 +842,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy"
+          "github.com/enterprise-contract/ec-policies//policy/release",
+          "github.com/enterprise-contract/ec-policies//policy/lib"
         ]
       }
     ],
@@ -953,7 +960,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy"
+          "github.com/enterprise-contract/ec-policies//policy/release",
+          "github.com/enterprise-contract/ec-policies//policy/lib"
         ]
       }
     ],

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -14,7 +14,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy"
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
             ]
           }
         ],
@@ -43,7 +44,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy"
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
             ]
           }
         ],
@@ -74,7 +76,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy"
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
             ]
           }
         ],
@@ -110,7 +113,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy"
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
             ]
           }
         ],
@@ -144,7 +148,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy"
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
             ]
           }
         ],


### PR DESCRIPTION
This solves the issue where the beta policy was being pulled in while only the releaseis needed. The beta policy contains code that might not be in the release branches.

https://issues.redhat.com/browse/EC-471