### PR TITLE
Fix release script when main pipeline isn't there

### DIFF
--- a/hack/patch-release-pipelines.sh
+++ b/hack/patch-release-pipelines.sh
@@ -61,7 +61,7 @@ for p in pull-request push; do
 
   # Loop over each commit
   for sha in $changes; do
-    git show $sha $main_pipeline
+    git show $sha -- $main_pipeline
 
     echo ""
     echo "Applying the above changes to '$release_pipeline'"


### PR DESCRIPTION
There are cases where you might want to run the patch pipelines script more than once, e.g. to apply some digest bumps after the main customizations have been done.

Now that we're removing the main branch pipelines in the release branch, we get an error running it a second time. This patch fixes that error.