### PR TITLE
Revert bad commits merged to main not release-v0.2

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -4,25 +4,28 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/enterprise-contract/ec-cli?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-v0.2"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-v02
-    appstudio.openshift.io/component: cli-v02
+    appstudio.openshift.io/application: ec-main-ci
+    appstudio.openshift.io/component: cli-main-ci
     pipelines.appstudio.openshift.io/type: build
-  name: cli-v02-on-push
+  name: cli-main-ci-on-pull-request
   namespace: rhtap-contract-tenant
 spec:
   params:
   - name: dockerfile
     value: Dockerfile.dist
   - name: git-url
-    value: '{{source_url}}'
+    value: '{{repo_url}}'
+  - name: image-expires-after
+    value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/cli-v02:{{revision}}
+    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -10,25 +10,25 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-v02
-    appstudio.openshift.io/component: verify-enterprise-contract-task-v02
+    appstudio.openshift.io/application: ec-main-ci
+    appstudio.openshift.io/component: cli-main-ci
     pipelines.appstudio.openshift.io/type: build
-  name: verify-enterprise-contract-task-v02-on-push
+  name: cli-main-ci-on-push
   namespace: rhtap-contract-tenant
 spec:
   params:
   - name: dockerfile
-    value: docker/Dockerfile
+    value: Dockerfile.dist
   - name: git-url
-    value: '{{source_url}}'
-  - name: image-expires-after
-    value: 5d
+    value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/verify-enterprise-contract-task-v02:{{revision}}
+    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:{{revision}}
   - name: path-context
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -125,6 +125,9 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
+    - description: ""
+      name: JAVA_COMMUNITY_DEPENDENCIES
+      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:
@@ -149,6 +152,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "0"
+      - name: fetchTags
+        value: "true"
       runAfter:
       - init
       taskRef:
@@ -197,16 +204,26 @@ spec:
       params:
       - name: IMAGE
         value: $(params.output-image)
-      - name: CONTEXT 
-        value: ./source/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: tkn-bundle
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-tkn-bundle:0.1@sha256:3612482c00030acbb261b4c8f501c15fb43e241edccb5225ca8e9f5a2d47c46c
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:cfb32c9f1ec9c217bc81389d6aeacdb9e7a092a7fa86d4fed7b6fbb2612f5c1d
         - name: kind
           value: task
         resolver: bundles
@@ -218,6 +235,55 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e831f3e10362ecb21910f45ff48c3af1c0c8bea4858ca25f4f436153499f9802
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
+        workspace: workspace
+    - name: deprecated-base-image-check
+      params:
+      - name: BASE_IMAGES_DIGESTS
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3@sha256:ba55ff56b8718406278d72fd5e3de88da110dd4391aa7581923b8d219a29f841
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: clair-scan
       params:
       - name: image-digest
@@ -232,6 +298,26 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1@sha256:5097b69c7b8ed19bbc09b3b119214305ed382a185aece344806875e6c43203b8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:4bcabe436ddbef6af8f8108ee234d83e116e63e91f64a77191e1492db11bf56b
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/verify-enterprise-contract-task-main-ci-pull-request.yaml
+++ b/.tekton/verify-enterprise-contract-task-main-ci-pull-request.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-v0.2"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-v02
-    appstudio.openshift.io/component: verify-enterprise-contract-task-v02
+    appstudio.openshift.io/application: ec-main-ci
+    appstudio.openshift.io/component: verify-enterprise-contract-task-main-ci
     pipelines.appstudio.openshift.io/type: build
-  name: verify-enterprise-contract-task-v02-on-pull-request
+  name: verify-enterprise-contract-task-main-ci-on-pull-request
   namespace: rhtap-contract-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/verify-enterprise-contract-task-v02:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/verify-enterprise-contract-task-main-ci:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/verify-enterprise-contract-task-main-ci-push.yaml
+++ b/.tekton/verify-enterprise-contract-task-main-ci-push.yaml
@@ -4,34 +4,31 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/enterprise-contract/ec-cli?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-v0.2"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-v02
-    appstudio.openshift.io/component: cli-v02
+    appstudio.openshift.io/application: ec-main-ci
+    appstudio.openshift.io/component: verify-enterprise-contract-task-main-ci
     pipelines.appstudio.openshift.io/type: build
-  name: cli-v02-on-pull-request
+  name: verify-enterprise-contract-task-main-ci-on-push
   namespace: rhtap-contract-tenant
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile.dist
+    value: docker/Dockerfile
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v02/cli-v02:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/verify-enterprise-contract-task-main-ci:{{revision}}
   - name: path-context
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: build-source-image
-    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -128,9 +125,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:
@@ -155,10 +149,6 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
-      - name: depth
-        value: "0"
-      - name: fetchTags
-        value: "true"
       runAfter:
       - init
       taskRef:
@@ -207,26 +197,16 @@ spec:
       params:
       - name: IMAGE
         value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
+      - name: CONTEXT 
+        value: ./source/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: tkn-bundle
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:cfb32c9f1ec9c217bc81389d6aeacdb9e7a092a7fa86d4fed7b6fbb2612f5c1d
+          value: quay.io/redhat-appstudio-tekton-catalog/task-tkn-bundle:0.1@sha256:3612482c00030acbb261b4c8f501c15fb43e241edccb5225ca8e9f5a2d47c46c
         - name: kind
           value: task
         resolver: bundles
@@ -238,55 +218,6 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
-    - name: build-source-image
-      params:
-      - name: BINARY_IMAGE
-        value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: source-build
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e831f3e10362ecb21910f45ff48c3af1c0c8bea4858ca25f4f436153499f9802
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      - input: $(params.build-source-image)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: workspace
-        workspace: workspace
-    - name: deprecated-base-image-check
-      params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: deprecated-image-check
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3@sha256:ba55ff56b8718406278d72fd5e3de88da110dd4391aa7581923b8d219a29f841
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clair-scan
       params:
       - name: image-digest
@@ -301,26 +232,6 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1@sha256:5097b69c7b8ed19bbc09b3b119214305ed382a185aece344806875e6c43203b8
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:4bcabe436ddbef6af8f8108ee234d83e116e63e91f64a77191e1492db11bf56b
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
I accidentially created the release branch PR against main branch and merged it. Force push to main would have been easier, but let's aim to not violate the rules about main branch.

Apologies for the mess!

The three squashed reverts:

* Revert "chore: Copy task bundle pipelines for v0.2"

  This reverts commit f0b887694433ba7349aa4273d3b003fb501dc6b4.

* Revert "chore: Modify default cli pipelines for v0.2"

  This reverts commit 074b9db947b20c17c0e40ef022cd71d3aefd908f.

* Revert "Red Hat Konflux update cli-v02"

  This reverts commit bd12824ebf6a5eb2cd1b86c558c831a0936dfecf.