### PR TITLE
Remove one line break in the task pipeline

### DIFF
--- a/.tekton/verify-enterprise-contract-task-main-ci-push.yaml
+++ b/.tekton/verify-enterprise-contract-task-main-ci-push.yaml
@@ -6,8 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ec-main-ci

--- a/hack/copy-task-release-pipelines.sh
+++ b/hack/copy-task-release-pipelines.sh
@@ -41,8 +41,6 @@ for p in pull-request push; do
   main_pipeline=".tekton/verify-enterprise-contract-task-main-ci-$p.yaml"
   release_pipeline=".tekton/verify-enterprise-contract-task-$short_release_name-$p.yaml"
 
-  # Beware: If the branch name is long enough there'll be a newline after
-  # "target_branch ==" and the second sed command won't work
   cat $main_pipeline \
     | sed "s/main-ci/$short_release_name/g" \
     | sed "s/target_branch == \"main\"/target_branch == \"$current_branch\"/" \


### PR DESCRIPTION
It's a long story related to the release branch hack/copy-task... script and the sed hackery within it. I think this will make life easier and afaict it won't cause and unwanted problems.