### PR TITLE
Use source_url not repo_url in git clone task

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -21,7 +21,7 @@ spec:
   - name: dockerfile
     value: Dockerfile.dist
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     value: 5d
   - name: output-image

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -20,7 +20,7 @@ spec:
   - name: dockerfile
     value: Dockerfile.dist
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:{{revision}}
   - name: path-context


### PR DESCRIPTION
I'm not sure how or where to confirm it, but the new pipeline created by Konflux uses source_url instead of repo_url, so I'm assuming that is the preferred way to do it, the repo_url is deprecated.

Minor followup fix while getting the Konflux pipelines ready in the v0.2 release branch in...
Ref: https://issues.redhat.com/browse/EC-434