### PR TITLE
Add `ec validate policy` to validate policyConfig

### DIFF
--- a/cmd/validate/policy.go
+++ b/cmd/validate/policy.go
@@ -1,0 +1,94 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	hd "github.com/MakeNowJust/heredoc"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+
+	"github.com/enterprise-contract/ec-cli/internal/policy"
+	validate_utils "github.com/enterprise-contract/ec-cli/internal/validate"
+)
+
+type policyValidationFunc func(context.Context, string) error
+
+func ValidatePolicyCmd(validate policyValidationFunc) *cobra.Command {
+	var data = struct {
+		policyConfiguration string
+		output              []string
+		strict              bool
+	}{
+		strict: true,
+	}
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Validate the provided EnterpriseContractPolicy spec",
+		Long: hd.Doc(`
+			Validate the provided EnterpriseContractPolicy spec against the EnterpriseContractPolicy spec schema used in this version of the ec CLI
+		`),
+		Example: hd.Doc(`
+			Validate a local policy configuration file:
+			ec validate policy --policy-configuration policy.yaml
+
+			Validate a policy configuration file from a github repository:
+			ec validate policy --policy-configuration github.com/org/repo/policy.yaml
+`),
+		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
+			if len(policy.ECPSchema) == 0 {
+				return fmt.Errorf("ECP schema is not defined")
+			}
+
+			ctx := cmd.Context()
+
+			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)
+			if err != nil {
+				allErrors = multierror.Append(allErrors, err)
+				return
+			}
+			data.policyConfiguration = policyConfiguration
+
+			return
+
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Policy conforms to the schema.
+			ctx := cmd.Context()
+			err := validate(ctx, data.policyConfiguration)
+			if err != nil {
+				return fmt.Errorf("policy configuration does not conform to the EnterpriseContractPolicy spec")
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Policy configuration conforms to the EnterpriseContractPolicy spec")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&data.policyConfiguration, "policy", "p", data.policyConfiguration, hd.Doc(`
+	Policy configuration as:
+	* file (policy.yaml)
+	* git reference (github.com/user/repo//default?ref=main), or
+	* inline JSON ('{sources: {...}, configuration: {...}}')")`))
+
+	if err := cmd.MarkFlagRequired("policy"); err != nil {
+		panic(err)
+	}
+
+	return cmd
+}

--- a/cmd/validate/policy_test.go
+++ b/cmd/validate/policy_test.go
@@ -1,0 +1,78 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package validate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/enterprise-contract/ec-cli/internal/policy"
+)
+
+func Test_ValidatePolicyCmd(t *testing.T) {
+	validate := func(ctx context.Context, policyConfiguration string) error {
+		// Mock implementation of the validate function
+		return nil
+	}
+
+	cmd := ValidatePolicyCmd(validate)
+
+	t.Run("PreRunE", func(t *testing.T) {
+		// Test PreRunE function
+		err := cmd.PreRunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("RunE", func(t *testing.T) {
+		// Test RunE function
+		err := cmd.RunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+}
+
+func Test_ValidatePolicyErrors(t *testing.T) {
+	validate := func(ctx context.Context, policyConfiguration string) error {
+		// Mock implementation of the validate function
+		return errors.New("error")
+	}
+
+	cmd := ValidatePolicyCmd(validate)
+
+	t.Run("PreRunE", func(t *testing.T) {
+		// Test PreRunE function
+		err := cmd.PreRunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("PreRunE", func(t *testing.T) {
+		policy.ECPSchema = ""
+		// Test PreRunE function
+		err := cmd.PreRunE(cmd, []string{})
+		assert.ErrorContains(t, err, "ECP schema is not defined")
+	})
+
+	t.Run("RunE", func(t *testing.T) {
+		// Test RunE function
+		err := cmd.RunE(cmd, []string{})
+		assert.ErrorContains(t, err, "policy configuration does not conform to the EnterpriseContractPolicy spec")
+	})
+}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/enterprise-contract/ec-cli/internal/definition"
 	"github.com/enterprise-contract/ec-cli/internal/image"
 	"github.com/enterprise-contract/ec-cli/internal/input"
+	"github.com/enterprise-contract/ec-cli/internal/policy"
 	_ "github.com/enterprise-contract/ec-cli/internal/rego"
 )
 
@@ -35,6 +36,7 @@ func init() {
 	ValidateCmd.AddCommand(validateImageCmd(image.ValidateImage))
 	ValidateCmd.AddCommand(validateDefinitionCmd(definition.ValidateDefinition))
 	ValidateCmd.AddCommand(validateInputCmd(input.ValidateInput))
+	ValidateCmd.AddCommand(ValidatePolicyCmd(policy.ValidatePolicy))
 }
 
 func NewValidateCmd() *cobra.Command {


### PR DESCRIPTION
This commit adds the `ec validate policy` subcommand which specifically validates a policy config (yaml, json, or inline) against the schema generated from the Enteprise Contract Controller Policy Spec dependency used by ec.