### PR TITLE
Add documentation for failing acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,16 @@ The `--debug` parameter enables debug logging. Setting `EC_DEBUG` environment
 variable can be set to prevent deletion of temporary `ec-work-*` directories so
 that the attestations, policy and data files can be examined.
 
+When running acceptance tests you may experience issues with starting enough Docker containers to successfullyl complete testing. These issues may appear as repeated failures, such as seen below, and a failed acceptance test run:
+```
+time="2024-03-08T09:10:50-05:00" level=warning msg="Failed, retrying in 1s ... (3/3). Error: trying to reuse blob sha256:b5976a979c30628edfeee0a1f1797362b0c84cf6cb4760776aa64ec8e3e4c2b3 at destination: pinging container registry localhost:37837: Get \"http://localhost:37837/v2/\": read tcp 127.0.0.1:34090->127.0.0.1:37837: read: connection reset by peer"
+```
+
+This issue may be resolved by increasing the total number of `fs.inotify.max_user_watches` by executing the following on: Red Hat / Fedora systems (other systems may need modifications to this)
+``` bash
+$ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
+
 [pol]: https://github.com/enterprise-contract/ec-policies/
 [docs]: https://enterprisecontract.dev/docs/ec-cli/main/ec.html


### PR DESCRIPTION
This commit adds a section to the Troubleshooting section of the README.md file that addresses acceptance test failures related to issues with inotify.max_user_watches.