### PR TITLE
Use schema from the api

### DIFF
--- a/cmd/validate/policy.go
+++ b/cmd/validate/policy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
-	"github.com/enterprise-contract/ec-cli/internal/policy"
 	validate_utils "github.com/enterprise-contract/ec-cli/internal/validate"
 )
 
@@ -52,10 +51,6 @@ func ValidatePolicyCmd(validate policyValidationFunc) *cobra.Command {
 			ec validate policy --policy-configuration github.com/org/repo/policy.yaml
 `),
 		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
-			if len(policy.ECPSchema) == 0 {
-				return fmt.Errorf("ECP schema is not defined")
-			}
-
 			ctx := cmd.Context()
 
 			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)

--- a/cmd/validate/policy_test.go
+++ b/cmd/validate/policy_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/enterprise-contract/ec-cli/internal/policy"
 )
 
 func Test_ValidatePolicyCmd(t *testing.T) {
@@ -61,13 +59,6 @@ func Test_ValidatePolicyErrors(t *testing.T) {
 		// Test PreRunE function
 		err := cmd.PreRunE(cmd, []string{})
 		assert.NoError(t, err)
-	})
-
-	t.Run("PreRunE", func(t *testing.T) {
-		policy.ECPSchema = ""
-		// Test PreRunE function
-		err := cmd.PreRunE(cmd, []string{})
-		assert.ErrorContains(t, err, "ECP schema is not defined")
 	})
 
 	t.Run("RunE", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.4
 require (
 	cuelang.org/go v0.7.1
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.38
+	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.39
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gkampitakis/go-snaps v0.5.2
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxER
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/proto v1.12.1 h1:6n/Z2pZAnBwuhU66Gs8160B8rrrYKo7h2F2sCOnNceE=
 github.com/emicklei/proto v1.12.1/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.38 h1:YG6seujtPCeIbfEtxRrhrtWtu2ra/dx1n+3U70XqLvM=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.38/go.mod h1:Bgvy+NM2duL5dzB4Tw+ftWbp5Aly7/cLfJzvFV0xkuk=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.39 h1:Zhezy3JCebmX91rHuXCdkErtSjjHy0GlMWuAnZ4SXRU=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.39/go.mod h1:ZbXKv7/iy8Ns91rqKzbccwJbaKY+nRTCWRN24hbssNY=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -52,20 +52,8 @@ const (
 // allows controlling time in tests
 var now = time.Now
 
-var ECPSchema string
-
 func ValidatePolicy(ctx context.Context, policyConfig string) error {
 	return validatePolicyConfig(policyConfig)
-}
-
-// generate the JSON schema for the EnterpriseContractPolicySpec dependency at compile time
-func init() {
-	schemaJson, err := jsonSchemaFromPolicySpec(&ecc.EnterpriseContractPolicySpec{})
-	if err != nil {
-		fmt.Println("Error creating JSON schema:", err)
-		os.Exit(1)
-	}
-	ECPSchema = string(schemaJson)
 }
 
 // Create a JSON schema from a Go type, and return the JSON as a byte slice
@@ -525,7 +513,7 @@ func validateIdentity(identity cosign.Identity) error {
 }
 
 func validatePolicyConfig(policyConfig string) error {
-	policySchema, err := jsonschema.CompileString("schema.json", ECPSchema)
+	policySchema, err := jsonschema.CompileString("schema.json", ecc.Schema)
 
 	if err != nil {
 		log.Errorf("Failed to compile schema: %s", err)


### PR DESCRIPTION
We do not want to maintain two copies of schema generation logic. This
builds on PR#286[1] to use the schema generated in the controller/api,
instead of generating the schema at runtime.

[1] enterprise-contract/enterprise-contract-controller#286