### PR TITLE
Refactor to remove repetition in policy sources

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -41,13 +41,10 @@ import (
 	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/config"
 	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci/files"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
-	"github.com/enterprise-contract/ec-cli/internal/policy/source"
 	"github.com/enterprise-contract/ec-cli/internal/signature"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 	"github.com/enterprise-contract/ec-cli/pkg/schema"
 )
-
-var newConftestEvaluator = evaluator.NewConftestEvaluator
 
 // imageRefTransport is used to inject the type of transport to use with the
 // remote.WithTransport function. By default, remote.DefaultTransport is
@@ -107,29 +104,6 @@ func NewApplicationSnapshotImage(ctx context.Context, component app.SnapshotComp
 		return nil, err
 	}
 
-	// Return an evaluator for each of these
-	for _, sourceGroup := range p.Spec().Sources {
-		// Todo: Make each fetch run concurrently
-		log.Debugf("Fetching policy source group '%s'", sourceGroup.Name)
-		policySources, err := source.FetchPolicySources(sourceGroup)
-		if err != nil {
-			log.Debugf("Failed to fetch policy source group '%s'!", sourceGroup.Name)
-			return nil, err
-		}
-
-		for _, policySource := range policySources {
-			log.Debugf("policySource: %#v", policySource)
-		}
-
-		c, err := newConftestEvaluator(ctx, policySources, p, sourceGroup)
-		if err != nil {
-			log.Debug("Failed to initialize the conftest evaluator!")
-			return nil, err
-		}
-
-		log.Debug("Conftest evaluator initialized")
-		a.Evaluators = append(a.Evaluators, c)
-	}
 	return a, nil
 }
 

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -35,7 +35,7 @@ import (
 
 // ValidateImage executes the required method calls to evaluate a given policy
 // against a given image url.
-func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Policy, detailed bool) (*output.Output, error) {
+func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Policy, evaluators []evaluator.Evaluator, detailed bool) (*output.Output, error) {
 	log.Debugf("Validating image %s", comp.ContainerImage)
 
 	out := &output.Output{ImageURL: comp.ContainerImage, Detailed: detailed, Policy: p}
@@ -107,9 +107,11 @@ func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Pol
 	}
 
 	var allResults []evaluator.Outcome
-	for _, e := range a.Evaluators {
+
+	for _, e := range evaluators {
 		// Todo maybe: Handle each one concurrently
 		results, data, err := e.Evaluate(ctx, []string{inputPath})
+		log.Debug("\n\nRunning conftest policy check\n\n")
 		defer e.Destroy()
 
 		if err != nil {

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -56,7 +56,7 @@ const (
 	imageRef      = imageRegistry + ":" + imageTag + "@sha256:" + imageDigest
 )
 
-func TestValidateImage(t *testing.T) {
+func TestBuiltinChecks(t *testing.T) {
 	cases := []struct {
 		name               string
 		client             *mockASIClient
@@ -129,10 +129,12 @@ func TestValidateImage(t *testing.T) {
 			p, err := policy.NewOfflinePolicy(ctx, policy.Now)
 			assert.NoError(t, err)
 
+			evaluators := []evaluator.Evaluator{}
+
 			ctx = application_snapshot_image.WithClient(ctx, c.client)
 			ctx = withImageConfig(ctx, c.component.ContainerImage)
 
-			actual, err := ValidateImage(ctx, c.component, p, false)
+			actual, err := ValidateImage(ctx, c.component, p, evaluators, false)
 			assert.NoError(t, err)
 
 			assert.Equal(t, c.expectedWarnings, actual.Warnings())


### PR DESCRIPTION
This commit refactors the code to remove the fetching of policy sources as a part of the loop for source groups.