### PR TITLE
Fix Rego builtin documentation

### DIFF
--- a/internal/evaluator/documentation/__snapshots__/documentation_test.snap
+++ b/internal/evaluator/documentation/__snapshots__/documentation_test.snap
@@ -283,3 +283,188 @@ description: Parse a valid PURL into an object.
 name: ec.purl.parse
 
 ---
+
+[TestWriteBuiltinsToYAML - 5]
+decl:
+  args:
+  - description: OCI image reference
+    name: ref
+    type: string
+  - description: Sigstore verification options
+    name: opts
+    static:
+    - key: certificate_identity
+      value:
+        type: string
+    - key: certificate_identity_regexp
+      value:
+        type: string
+    - key: certificate_oidc_issuer
+      value:
+        type: string
+    - key: certificate_oidc_issuer_regexp
+      value:
+        type: string
+    - key: ignore_rekor
+      value:
+        type: boolean
+    - key: public_key
+      value:
+        type: string
+    - key: rekor_url
+      value:
+        type: string
+    type: object
+  result:
+    description: the result of the verification request
+    name: result
+    static:
+    - key: attestations
+      value:
+        description: matching attestations
+        name: attestations
+        static:
+        - description: attestation matching provided identity/key
+          name: attestation
+          static:
+          - key: signatures
+            value:
+              description: signatures associated with attestation
+              name: signatures
+              static:
+              - static:
+                - key: certificate
+                  value:
+                    type: string
+                - key: chain
+                  value:
+                    static:
+                    - type: string
+                    type: array
+                - key: keyid
+                  value:
+                    type: string
+                - key: metadata
+                  value:
+                    dynamic:
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    type: object
+                - key: signature
+                  value:
+                    type: string
+                type: object
+              type: array
+          - key: statement
+            value:
+              description: statement from attestation
+              name: statement
+              type: any
+          type: object
+        type: array
+    - key: errors
+      value:
+        description: verification errors
+        name: errors
+        static:
+        - type: string
+        type: array
+    - key: success
+      value:
+        description: true when verification is successful
+        name: success
+        type: boolean
+    type: object
+  type: function
+description: Use sigstore to verify the attestation of an image.
+name: ec.sigstore.verify_attestation
+nondeterministic: true
+
+---
+
+[TestWriteBuiltinsToYAML - 6]
+decl:
+  args:
+  - description: OCI image reference
+    name: ref
+    type: string
+  - description: Sigstore verification options
+    name: opts
+    static:
+    - key: certificate_identity
+      value:
+        type: string
+    - key: certificate_identity_regexp
+      value:
+        type: string
+    - key: certificate_oidc_issuer
+      value:
+        type: string
+    - key: certificate_oidc_issuer_regexp
+      value:
+        type: string
+    - key: ignore_rekor
+      value:
+        type: boolean
+    - key: public_key
+      value:
+        type: string
+    - key: rekor_url
+      value:
+        type: string
+    type: object
+  result:
+    description: the result of the verification request
+    name: result
+    static:
+    - key: errors
+      value:
+        description: verification errors
+        name: errors
+        static:
+        - type: string
+        type: array
+    - key: signatures
+      value:
+        description: matching signatures
+        name: signatures
+        static:
+        - static:
+          - key: certificate
+            value:
+              type: string
+          - key: chain
+            value:
+              static:
+              - type: string
+              type: array
+          - key: keyid
+            value:
+              type: string
+          - key: metadata
+            value:
+              dynamic:
+                key:
+                  type: string
+                value:
+                  type: string
+              type: object
+          - key: signature
+            value:
+              type: string
+          type: object
+        type: array
+    - key: success
+      value:
+        description: true when verification is successful
+        name: success
+        type: boolean
+    type: object
+  type: function
+description: Use sigstore to verify the signature of an image.
+name: ec.sigstore.verify_image
+nondeterministic: true
+
+---

--- a/internal/evaluator/documentation/documentation.go
+++ b/internal/evaluator/documentation/documentation.go
@@ -27,7 +27,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"sigs.k8s.io/yaml"
 
-	_ "github.com/enterprise-contract/ec-cli/internal/evaluator" // imports EC OPA builtins
+	_ "github.com/enterprise-contract/ec-cli/internal/rego" // imports EC OPA builtins
 )
 
 const directoryPermissions = 0755

--- a/internal/evaluator/documentation/documentation_test.go
+++ b/internal/evaluator/documentation/documentation_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,15 +33,18 @@ func TestWriteBuiltinsToYAML(t *testing.T) {
 	dir := t.TempDir()
 	err := writeBultinsToYAML(dir)
 	require.NoError(t, err)
+	found := 0
 	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		require.NoError(t, err)
 		if d.IsDir() {
 			return nil
 		}
 		contents, err := os.ReadFile(path)
+		found += 1
 		require.NoError(t, err)
 		snaps.MatchSnapshot(t, string(contents))
 		return nil
 	})
 	require.NoError(t, err)
+	assert.NotZero(t, found, "did not find any ec builtins")
 }


### PR DESCRIPTION
In the refactor in #1362 the path change was not reflected in the code used for generating the data for building the documentation. Which lead to no Rego builtins being documented on the website. This restores the builtin documentation.