### PR TITLE
Consolidate build process across each Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,31 +14,60 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:bc552efb4966aaa44b02532be3168ac1ff18e2af299d0fe89502a1d9fabafbc5 AS downloads
+## Build
+
+FROM docker.io/library/golang:1.21 AS build
+
+ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /build
+
+# Copy just the mod file for better layer caching when building locally
+COPY go.mod go.sum .
+RUN go mod download
+
+# Now copy everything including .git
+COPY . .
+
+RUN ["/usr/bin/bash", "-c", "/build/build.sh \"${BUILD_LIST}\" \"${TARGETOS}\" \"${TARGETARCH}\""]
+
+# Extract this so we can download the matching cosign version below
+RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt
+
+## Downloads
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:bc552efb4966aaa44b02532be3168ac1ff18e2af299d0fe89502a1d9fabafbc5 AS download
 
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG COSIGN_VERSION
+WORKDIR /download
 
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} /opt/
-ADD https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt /opt/
+COPY --from=build /build/cosign_version.txt /download/
 
-RUN cd /opt && \
+# Download the matching version of cosign
+RUN COSIGN_VERSION=$(cat /download/cosign_version.txt) && \
+    curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${TARGETOS}-${TARGETARCH} && \
+    curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt && \
     sha256sum --check <(grep -w "cosign-${TARGETOS}-${TARGETARCH}" < cosign_checksums.txt) && \
-    mv cosign-$TARGETOS-$TARGETARCH cosign && \
+    mv "cosign-${TARGETOS}-${TARGETARCH}" cosign && \
     chmod +x cosign
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:bc552efb4966aaa44b02532be3168ac1ff18e2af299d0fe89502a1d9fabafbc5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3@sha256:582e18f13291d7c686ec4e6e92d20b24c62ae0fc72767c46f30a69b1a6198055
 
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY --from=downloads /opt/cosign /usr/local/bin/
+COPY --from=download /download/cosign /usr/bin/cosign
 RUN cosign version
 
 RUN microdnf -y install git-core jq && microdnf clean all
 
-COPY "dist/ec_"$TARGETOS"_"$TARGETARCH /usr/bin/ec
+COPY --from=build /build/dist/ /usr/bin/
+
+# Copy the one ec binary that can run in this container
+COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec
 
 ENTRYPOINT ["/usr/bin/ec"]

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -41,7 +41,7 @@ RUN go mod download
 # Now copy everything including .git
 COPY . .
 
-RUN ["/usr/bin/bash", "-c", "/build/build.sh \"${BUILD_LIST}\" \"${TARGETOS}\" \"${TARGETARCH}\""]
+RUN /build/build.sh "${BUILD_LIST}"
 
 # Extract this so we can download the matching cosign version below
 RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -17,7 +17,7 @@
 ## Build
 
 # This works fine but will produce an EC violation
-#FROM docker.io/library/golang:1.21 AS build
+# FROM docker.io/library/golang:1.21 AS build
 
 # This currently has go version 1.20 but we need version 1.21
 #FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build
@@ -25,13 +25,12 @@
 # This image has go version 1.21 but requires an extra pull secret to access
 # See https://source.redhat.com/groups/public/teamnado/wiki/brew_registry for how to get your own pull secret
 # See our Konflux pull secret at https://console.redhat.com/preview/application-pipeline/secrets
+
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21@sha256:4fe910174caaaae09ff75b6f1b1c2f4460fd9acfe38ec778a818a54de7f31afc AS build
 
+ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 ARG TARGETOS
 ARG TARGETARCH
-
-ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
-#ARG BUILD_LIST="linux_amd64"
 
 WORKDIR /build
 
@@ -42,76 +41,7 @@ RUN go mod download
 # Now copy everything including .git
 COPY . .
 
-# Notes:
-# Derive the version from the branch name with the "release-" prefix removed
-# if it's present, e.g. in the branch "release-v0.1-alpha" the version will
-# be "v0.1-alpha"
-#
-# If the branch doesn't start with release- then assume it's not a release
-# branch and build just a single binary to save time and cpu cycles. If the
-# branch is a release branch then build all the binaries in ${BUILD_LIST}.
-#
-# The normal way to get the branch name is this:
-#   EC_GIT_BRANCH=$( git rev-parse --abbrev-ref HEAD )
-# but it doesn't work because the git-clone task checks out a sha directly
-# rather than a branch. That's why we need to use `git for-each-ref`. Beware
-# that testing this locally requires that you push the relevant branches to
-# your 'origin' remote.
-#
-# Note that EC_GIT_ORIGIN_BRANCH, EC_GIT_BRANCH may be blank in a pre-merge PR
-# because the PR branch refs are generally not present. In that case we'll use
-# "_ci_build" as the version.
-#
-# For the EC_PATCH_NUM we assume there is a v0.2.0 (for example) tag created
-# by a human. Using --merges there because we assume every build happens after
-# a PR is merged.
-#
-RUN \
-    EC_GIT_SHA=$( git rev-parse --short HEAD ); \
-    echo "EC_GIT_SHA=$EC_GIT_SHA"; \
-    \
-    EC_GIT_ORIGIN_BRANCH=$( git for-each-ref --points-at HEAD --format='%(refname:short)' refs/remotes/origin/ ); \
-    echo "EC_GIT_ORIGIN_BRANCH=$EC_GIT_ORIGIN_BRANCH"; \
-    \
-    EC_GIT_BRANCH=${EC_GIT_ORIGIN_BRANCH#"origin/"}; \
-    echo "EC_GIT_BRANCH=$EC_GIT_BRANCH"; \
-    \
-    EC_VERSION=${EC_GIT_BRANCH#"release-"}; \
-    echo "EC_VERSION=$EC_VERSION"; \
-    \
-    EC_BASE_TAG="${EC_VERSION}.0"; \
-    echo "EC_BASE_TAG=$EC_BASE_TAG"; \
-    git log -n1 --format="%h %s" "$EC_BASE_TAG"; \
-    \
-    EC_PATCH_NUM=$( git rev-list --merges --count ${EC_BASE_TAG}..HEAD ); \
-    echo "EC_PATCH_NUM=$EC_PATCH_NUM"; \
-    \
-    if [ -z "$EC_VERSION" ]; then \
-      EC_FULL_VERSION="_ci_build-${EC_GIT_SHA}"; \
-    else \
-      EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"; \
-    fi; \
-    echo "EC_FULL_VERSION=$EC_FULL_VERSION"; \
-    \
-    if [ -z "$EC_VERSION" -o "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \
-      BUILDS="${TARGETOS}_${TARGETARCH}"; \
-    else \
-      BUILDS="${BUILD_LIST}"; \
-    fi; \
-    echo "BUILDS=$BUILDS"; \
-    \
-    for os_arch in ${BUILDS}; do \
-      export GOOS="${os_arch%_*}"; \
-      export GOARCH="${os_arch#*_}"; \
-      [ "$GOOS" = "windows" ] && DOT_EXE=".exe" || DOT_EXE=""; \
-      BINFILE="ec_${GOOS}_${GOARCH}${DOT_EXE}"; \
-      echo "Building ${BINFILE} for ${EC_FULL_VERSION}"; \
-      go build \
-          -trimpath \
-          --mod=readonly \
-          -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_FULL_VERSION}" \
-          -o "dist/${BINFILE}"; \
-    done
+RUN ["/usr/bin/bash", "-c", "/build/build.sh \"${BUILD_LIST}\" \"${TARGETOS}\" \"${TARGETARCH}\""]
 
 # Extract this so we can download the matching cosign version below
 RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt

--- a/Makefile
+++ b/Makefile
@@ -218,15 +218,12 @@ push-snapshot-image: build-snapshot-image ## Push the ec-cli image with the "sna
 	@podman push $(PODMAN_OPTS) $(IMAGE_REPO):snapshot
 
 .PHONY: $(ALL_SUPPORTED_IMG_OS_ARCH)
-# Ref: https://www.gnu.org/software/make/manual/make.html#Secondary-Expansion
-.SECONDEXPANSION:
 # Targets are in the form of "image_{platform}_{arch}", we set
-# TARGETOS={platform}, and TARGETARCH={arch}. This target depends on the
-# "dist/ec_{platform}_{arch}" target
+# TARGETOS={platform}, and TARGETARCH={arch}. 
 $(ALL_SUPPORTED_IMG_OS_ARCH): TARGETOS=$(word 2,$(subst _, ,$@))
 $(ALL_SUPPORTED_IMG_OS_ARCH): TARGETARCH=$(word 3,$(subst _, ,$@))
-$(ALL_SUPPORTED_IMG_OS_ARCH): $$(subst image_,dist/ec_,$$@)
-	@podman build -t $(IMAGE_REPO):$(IMAGE_TAG)-$(TARGETOS)-$(TARGETARCH) -f Dockerfile --platform $(TARGETOS)/$(TARGETARCH) --build-arg COSIGN_VERSION=$(COSIGN_VERSION)
+$(ALL_SUPPORTED_IMG_OS_ARCH):
+	@podman build -t $(IMAGE_REPO):$(IMAGE_TAG)-$(TARGETOS)-$(TARGETARCH) -f Dockerfile --platform $(TARGETOS)/$(TARGETARCH)
 
 # Currently it shows the following:
 #  image_linux_amd64

--- a/build.sh
+++ b/build.sh
@@ -40,9 +40,7 @@
 # a PR is merged.
 #
 
-BUILD_LIST="${1:-darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64}"
-TARGETOS=$2
-TARGETARCH=$3
+BUILDS="${1}"
 
 EC_GIT_ORIGIN_BRANCH=$( git for-each-ref --points-at HEAD --format='%(refname:short)' refs/remotes/origin/ )
 echo "EC_GIT_ORIGIN_BRANCH=$EC_GIT_ORIGIN_BRANCH"
@@ -54,14 +52,11 @@ EC_VERSION=${EC_GIT_BRANCH#"release-"}
 if [[ "${EC_GIT_BRANCH}" != release-* ]]; then
     EC_VERSION=v0.3
     EC_PATCH_NUM=$(git rev-list --count HEAD)-$(git rev-parse --short HEAD)
-    BUILDS="${TARGETOS}_${TARGETARCH}"
 else
     EC_BASE_TAG="${EC_VERSION}.0"
     echo "EC_BASE_TAG=$EC_BASE_TAG"
     git log -n1 --format="%h %s" "$EC_BASE_TAG"
-
     EC_PATCH_NUM=$( git rev-list --merges --count ${EC_BASE_TAG}..HEAD )
-    BUILDS="${BUILD_LIST}"
 fi
 
 EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"
@@ -72,8 +67,8 @@ echo "EC_FULL_VERSION=$EC_FULL_VERSION"
 echo "BUILDS=$BUILDS"
 
 for os_arch in ${BUILDS}; do
-    export GOOS="${os_arch%_*}"
-    export GOARCH="${os_arch#*_}"
+    GOOS="${os_arch%_*}"
+    GOARCH="${os_arch#*_}"
     [[ "$GOOS" == "windows" ]] && DOT_EXE=".exe" || DOT_EXE=""
     BINFILE="ec_${GOOS}_${GOARCH}${DOT_EXE}"
     echo "Building ${BINFILE} for ${EC_FULL_VERSION}"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/bash
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Notes:
+# Derive the version from the branch name with the "release-" prefix removed
+# if it's present, e.g. in the branch "release-v0.1-alpha" the version will
+# be "v0.1-alpha"
+#
+# If the branch doesn't start with release- then assume it's not a release
+# branch and build just a single binary to save time and cpu cycles. If the
+# branch is a release branch then build all the binaries in ${BUILD_LIST}.
+#
+# The normal way to get the branch name is this:
+#   EC_GIT_BRANCH=$( git rev-parse --abbrev-ref HEAD )
+# but it doesn't work because the git-clone task checks out a sha directly
+# rather than a branch. That's why we need to use `git for-each-ref`. Beware
+# that testing this locally requires that you push the relevant branches to
+# your 'origin' remote.
+#
+# Note that EC_GIT_ORIGIN_BRANCH, EC_GIT_BRANCH may be blank in a pre-merge PR
+# because the PR branch refs are generally not present. In that case we'll use
+# "_ci_build" as the version.
+#
+# For the EC_PATCH_NUM we assume there is a v0.2.0 (for example) tag created
+# by a human. Using --merges there because we assume every build happens after
+# a PR is merged.
+#
+
+BUILD_LIST="${1:-darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64}"
+TARGETOS=$2
+TARGETARCH=$3
+
+EC_GIT_ORIGIN_BRANCH=$( git for-each-ref --points-at HEAD --format='%(refname:short)' refs/remotes/origin/ )
+echo "EC_GIT_ORIGIN_BRANCH=$EC_GIT_ORIGIN_BRANCH"
+
+EC_GIT_BRANCH=${EC_GIT_ORIGIN_BRANCH#"origin/"}
+echo "EC_GIT_BRANCH=$EC_GIT_BRANCH"
+
+EC_VERSION=${EC_GIT_BRANCH#"release-"}
+if [[ "${EC_GIT_BRANCH}" != release-* ]]; then
+    EC_VERSION=v0.3
+    EC_PATCH_NUM=$(git rev-list --count HEAD)-$(git rev-parse --short HEAD)
+    BUILDS="${TARGETOS}_${TARGETARCH}"
+else
+    EC_BASE_TAG="${EC_VERSION}.0"
+    echo "EC_BASE_TAG=$EC_BASE_TAG"
+    git log -n1 --format="%h %s" "$EC_BASE_TAG"
+
+    EC_PATCH_NUM=$( git rev-list --merges --count ${EC_BASE_TAG}..HEAD )
+    BUILDS="${BUILD_LIST}"
+fi
+
+EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"
+
+echo "EC_VERSION=$EC_VERSION"
+echo "EC_PATCH_NUM=$EC_PATCH_NUM"
+echo "EC_FULL_VERSION=$EC_FULL_VERSION"
+echo "BUILDS=$BUILDS"
+
+for os_arch in ${BUILDS}; do
+    export GOOS="${os_arch%_*}"
+    export GOARCH="${os_arch#*_}"
+    [[ "$GOOS" == "windows" ]] && DOT_EXE=".exe" || DOT_EXE=""
+    BINFILE="ec_${GOOS}_${GOARCH}${DOT_EXE}"
+    echo "Building ${BINFILE} for ${EC_FULL_VERSION}"
+    go build \
+        -trimpath \
+        --mod=readonly \
+        -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_FULL_VERSION}" \
+        -o "dist/${BINFILE}"; \
+    sha256sum -b dist/${BINFILE} > dist/${BINFILE}.sha256; \
+done


### PR DESCRIPTION
Each Dockerfile has a different way of building ec. This moves the build to the Dockerfile and also pulls the cosign version from the mod file.

https://issues.redhat.com/browse/EC-470