### PR TITLE
`validate image`: Allow custom Rego variables with new `--extra` flag

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -18,9 +18,11 @@ package validate
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/hashicorp/go-multierror"
@@ -28,6 +30,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
@@ -50,6 +53,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		certificateOIDCIssuer       string
 		certificateOIDCIssuerRegExp string
 		effectiveTime               string
+		extraRuleData               []string
 		filePath                    string // Deprecated: images replaced this
 		imageRef                    string
 		info                        bool
@@ -213,6 +217,52 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			}); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
+				// inject extra variables into rule data per source
+				if len(data.extraRuleData) > 0 {
+					var policySpec = p.Spec()
+					var sources = policySpec.Sources
+					for i := range sources {
+						var source = sources[i]
+						var rule_data_raw []byte
+						unmarshaled := make(map[string]interface{})
+
+						if source.RuleData != nil {
+							rule_data_raw, err = source.RuleData.MarshalJSON()
+							if err != nil {
+								log.Errorf("Unable to parse ruledata to raw data")
+							}
+							err = json.Unmarshal(rule_data_raw, &unmarshaled)
+							if err != nil {
+								log.Errorf("Unable to parse ruledata into standard JSON object")
+							}
+						} else {
+							sources[i].RuleData = new(extv1.JSON)
+						}
+
+						for j := range data.extraRuleData {
+							parts := strings.SplitN(data.extraRuleData[j], "=", 2)
+							if len(parts) < 2 {
+								log.Errorf("Incorrect syntax for --extra-rule-data")
+							}
+							unmarshaled[parts[0]] = parts[1]
+						}
+						rule_data_raw, err = json.Marshal(unmarshaled)
+						if err != nil {
+							log.Errorf("Unable to parse updated ruledata: %s", err.Error())
+						}
+
+						if rule_data_raw == nil {
+							log.Errorf("Invalid rule data JSON")
+						}
+
+						err = sources[i].RuleData.UnmarshalJSON(rule_data_raw)
+						if err != nil {
+							log.Errorf("Unable to marshal updated JSON: %s", err.Error())
+						}
+					}
+					policySpec.Sources = sources
+					p = p.WithSpec(policySpec)
+				}
 				data.policy = p
 			}
 
@@ -418,6 +468,10 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		effective dates in the future. The value can be "now" (default) - for
 		current time, "attestation" - for time from the youngest attestation, or
 		a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
+	`))
+
+	cmd.Flags().StringSliceVar(&data.extraRuleData, "extra-rule-data", data.extraRuleData, hd.Doc(`
+		Extra data to be provided to the Rego policy evaluator. Use format 'key=value'. May be used multiple times.
 	`))
 
 	cmd.Flags().StringVar(&data.snapshot, "snapshot", "", hd.Doc(`

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -21,6 +21,7 @@ package validate
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -671,6 +672,104 @@ configuration:
 
 	err = cmd.Execute()
 	assert.NoError(t, err)
+}
+
+func Test_ValidateImageCommandExtraData(t *testing.T) {
+	validate := func(_ context.Context, component app.SnapshotComponent, _ policy.Policy, _ []evaluator.Evaluator, _ bool) (*output.Output, error) {
+		return &output.Output{
+			ImageSignatureCheck: output.VerificationStatus{
+				Passed: true,
+			},
+			ImageAccessibleCheck: output.VerificationStatus{
+				Passed: true,
+			},
+			AttestationSignatureCheck: output.VerificationStatus{
+				Passed: true,
+			},
+			AttestationSyntaxCheck: output.VerificationStatus{
+				Passed: true,
+			},
+			PolicyCheck: []evaluator.Outcome{
+				{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: []evaluator.Result{
+						{
+							Message: "Pass",
+							Metadata: map[string]interface{}{
+								"code": "policy.nice",
+							},
+						},
+					},
+				},
+			},
+			ImageURL: component.ContainerImage,
+			ExitCode: 0,
+		}, nil
+	}
+
+	validateImageCmd := validateImageCmd(validate)
+	cmd := setUpCobra(validateImageCmd)
+
+	fs := afero.NewMemMapFs()
+
+	cmd.SetContext(utils.WithFS(context.TODO(), fs))
+
+	testPolicyJSON := `sources:
+  - policy:
+      - "registry/policy:latest"
+    data:
+      - "registry/policy-data:latest"
+configuration:
+  collections:
+    - minimal
+  include:
+    - "*"
+  exclude: []
+`
+	err := afero.WriteFile(fs, "/policy.json", []byte(testPolicyJSON), 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.SetArgs(append(rootArgs, []string{
+		"--image",
+		"registry/image:tag",
+		"--public-key",
+		utils.TestPublicKey,
+		"--policy",
+		"/policy.json",
+		"--extra-rule-data",
+		"key=value",
+	}...))
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	utils.SetTestRekorPublicKey(t)
+
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	// extract one of the sources, since we can match JSON without needing to compare publicKey (which may change)
+	unmarshaled := make(map[string]interface{})
+	err = json.Unmarshal(out.Bytes(), &unmarshaled)
+	assert.NoError(t, err)
+
+	sourceSample := unmarshaled["policy"].(map[string]interface{})["sources"].([]interface{})[0].(map[string]interface{})
+	sourceSampleMarshaled, err := json.Marshal(sourceSample)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"data": [
+			"registry/policy-data:latest"
+		],
+		"policy": [
+			"registry/policy:latest"
+		],
+		"ruleData": {
+			"key":"value"
+		}
+	  }`, string(sourceSampleMarshaled))
 }
 
 func Test_ValidateImageCommandEmptyPolicyFile(t *testing.T) {

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -120,6 +120,8 @@ effective dates in the future. The value can be "now" (default) - for
 current time, "attestation" - for time from the youngest attestation, or
 a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
  (Default: now)
+--extra-rule-data:: Extra data to be provided to the Rego policy evaluator. Use format 'key=value'. May be used multiple times.
+ (Default: [])
 -f, --file-path:: DEPRECATED - use --images: path to ApplicationSnapshot Spec JSON file
 -h, --help:: help for image (Default: false)
 --ignore-rekor:: Skip Rekor transparency log checks during validation. (Default: false)

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1948,6 +1948,86 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:34: rego_type_error: undefi
 
 ---
 
+[happy day with extra rule data:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.acceptor"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/ec-happy-day}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/ec-happy-day}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/happy-day-policy.git"
+        ],
+        "ruleData": {
+          "key": "value"
+        }
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[happy day with extra rule data:stderr - 1]
+
+---
+
 [rule dependencies:stdout - 1]
 {
   "success": false,

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -99,6 +99,31 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: happy day with extra rule data
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --extra-rule-data key=value --show-successes"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
   Scenario: invalid image signature
     Given a key pair named "known"
     Given a key pair named "unknown"


### PR DESCRIPTION
This PR adds a new option, `--extra`, to the `ec validate image` command. This argument allows users to inject additional variables into the Rego rule data per source. Syntax is simple: `--extra key=value`. The flag can also be used multiple times.

This is an evolution of the idea that @lcarva proposed in https://github.com/enterprise-contract/ec-cli/pull/1277.

Here's an example output from `ec validate image` with `--extra var=value`:

```yaml
policy:
  description: Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default
    config used for new Konflux applications. Available collections are defined in
    https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/release_policy.html#_available_rule_collections.
    If a different policy configuration is desired, this resource can serve as a starting
    point. See the docs on how to include and exclude rules https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules.
  name: Default
  publicKey: /dev/fd/63
  sources:
  - config:
      include:
      - '@slsa3'
    data:
    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
    - github.com/release-engineering/rhtap-ec-policy//data
    name: Default
    policy:
    - github.com/enterprise-contract/ec-policies//policy/lib
    - github.com/enterprise-contract/ec-policies//policy/release
    ruleData:
      var: value
success: true
```

This still needs tests added, but it appears to be functional, as seen above.