### PR TITLE
Support for mocking builtin functions

### DIFF
--- a/acceptance/examples/mock_test.rego
+++ b/acceptance/examples/mock_test.rego
@@ -1,0 +1,9 @@
+package mock_test
+
+import rego.v1
+
+test_mocking_ec_oci_blob if {
+    ec.test.mock("ec.oci.blob", ["ref"], "wubba lubba dub dub")
+
+    ec.oci.blob("ref") == "wubba lubba dub dub"
+}

--- a/cmd/opa/opa.go
+++ b/cmd/opa/opa.go
@@ -19,7 +19,8 @@ import (
 	"github.com/open-policy-agent/opa/cmd"
 	"github.com/spf13/cobra"
 
-	_ "github.com/enterprise-contract/ec-cli/internal/evaluator" // imports EC OPA builtins
+	_ "github.com/enterprise-contract/ec-cli/internal/rego" // imports EC OPA builtins
+	"github.com/enterprise-contract/ec-cli/internal/rego/testing"
 )
 
 var OPACmd *cobra.Command
@@ -28,4 +29,24 @@ func init() {
 	OPACmd = cmd.RootCommand
 	OPACmd.Use = "opa"
 	OPACmd.Short = OPACmd.Short + " (embedded)"
+
+	mockingSupport()
+}
+
+func mockingSupport() {
+	test, _, err := OPACmd.Find([]string{"test"})
+	if err != nil {
+		panic(err)
+	}
+
+	orig := test.PreRunE
+	test.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := orig(cmd, args); err != nil {
+			return err
+		}
+
+		testing.RegisterMockSupport()
+
+		return nil
+	}
 }

--- a/features/opa.feature
+++ b/features/opa.feature
@@ -1,8 +1,12 @@
 Feature: embed OPA CLI
   The ec command line should embedd functionality of OPA CLI
 
-  @focus
   Scenario: OPA sub-command is available
     When ec command is run with "opa --help"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: Mocking support
+    When ec command is run with "opa test acceptance/examples/mock_test.rego"
     Then the exit status should be 0
     Then the output should match the snapshot

--- a/internal/rego/oci/oci.go
+++ b/internal/rego/oci/oci.go
@@ -37,6 +37,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/enterprise-contract/ec-cli/internal/fetchers/oci"
+	"github.com/enterprise-contract/ec-cli/internal/rego/testing"
 )
 
 const (
@@ -153,6 +154,10 @@ func ociBlob(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	uri, ok := a.Value.(ast.String)
 	if !ok {
 		return nil, nil
+	}
+
+	if mocked, ok := testing.Mocked(bctx, ociBlobName, ast.NewTerm(ast.NewArray(a))); ok {
+		return mocked, nil
 	}
 
 	ref, err := name.NewDigest(string(uri))

--- a/internal/rego/testing/mock.go
+++ b/internal/rego/testing/mock.go
@@ -1,0 +1,83 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// IMPORTANT: The rego functions in this file never return an error. Instead, they return no value
+// when an error is encountered. If they did return an error, opa would exit abruptly and it would
+// not produce a report of which policy rules succeeded/failed.
+
+package testing
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/topdown/builtins"
+	"github.com/open-policy-agent/opa/types"
+)
+
+var mocks = map[string]map[int]ast.Value{}
+
+func RegisterMockSupport() {
+	decl := rego.Function{
+		Name:        "ec.test.mock",
+		Description: "Mock a function, available only in tests.",
+		Decl: types.NewFunction(
+			types.Args(
+				types.Named("function", types.S).Description("Function to mock"),
+				types.Named("args", types.NewArray(nil, types.A)).Description("Arguments to match"),
+				types.Named("return", types.A).Description("Mocked return value"),
+			),
+			nil,
+		),
+		Memoize:          false,
+		Nondeterministic: true,
+	}
+
+	rego.RegisterBuiltin3(&decl, mock)
+}
+
+func mock(bctx rego.BuiltinContext, function *ast.Term, args *ast.Term, ret *ast.Term) (*ast.Term, error) {
+	f, err := builtins.StringOperand(function.Value, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	fun := string(f)
+
+	m, ok := mocks[fun]
+
+	if !ok {
+		m = map[int]ast.Value{}
+		mocks[fun] = m
+	}
+
+	m[args.Value.Hash()] = ret.Value
+
+	return ast.BooleanTerm(true), nil
+}
+
+func Mocked(bctx rego.BuiltinContext, fun string, args *ast.Term) (*ast.Term, bool) {
+	m, ok := mocks[fun]
+	if !ok {
+		return nil, false
+	}
+
+	val, ok := m[args.Value.Hash()]
+	if !ok {
+		return nil, false
+	}
+
+	return ast.NewTerm(val), true
+}


### PR DESCRIPTION
Adds a new builtin: `ec.testing.mock` that can be used only when invoked via `ec opa test` command. When invoked with a name of the function, arguments and the mocked return value, that information is stored in the private static map within the `internal/rego/testing` package, and supporting builtins can check for a short circuit mocked value return by invoking the `testing.Mocked` function.