### PR TITLE
Implement support for multiple output formats in ec test

### DIFF
--- a/docs/modules/ROOT/pages/ec_test.adoc
+++ b/docs/modules/ROOT/pages/ec_test.adoc
@@ -83,7 +83,7 @@ the output will include a detailed trace of how the policy was evaluated, e.g.
 -n, --namespace:: Test policies in a specific namespace (Default: [main])
 --no-color:: Disable color when printing (Default: false)
 --no-fail:: Return an exit code of zero even if a policy fails (Default: false)
--o, --output:: Output format for conftest results - valid options are: [stdout json tap table junit github appstudio] (Default: stdout)
+-o, --output:: Output format for conftest results - valid options are: [stdout json tap table junit github appstudio]. You can optionally specify a file for the output, e.g. -o json=out.json (Default: [])
 --parser:: Parser to use to parse the configurations. Valid parsers: [cue dockerfile edn hcl1 hcl2 hocon ignore ini json jsonnet properties spdx textproto toml vcl xml yaml dotenv]
 -p, --policy:: Path to the Rego policy files directory (Default: [policy])
 --proto-file-dirs:: A list of directories containing Protocol Buffer definitions (Default: [])


### PR DESCRIPTION
This PR revamps the `--output` flag in `ec test` to accept `format=file` syntax. This will allow multiple output formats to different files on disk.

For example: `--output json=test.json --output appstudio=appstudio.txt` will produce two files, `test.json` and `appstudio.txt`, in JSON and Appstudio format, respectively.

Ref: https://issues.redhat.com/browse/EC-55