### PR TITLE
Simpler version number logic for release branch

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -70,13 +70,7 @@ RUN \
     EC_GIT_SHA=$( git rev-parse --short HEAD ); \
     echo "EC_GIT_SHA=$EC_GIT_SHA"; \
     \
-    EC_GIT_ORIGIN_BRANCH=$( git for-each-ref --points-at HEAD --format='%(refname:short)' refs/remotes/origin/ ); \
-    echo "EC_GIT_ORIGIN_BRANCH=$EC_GIT_ORIGIN_BRANCH"; \
-    \
-    EC_GIT_BRANCH=${EC_GIT_ORIGIN_BRANCH#"origin/"}; \
-    echo "EC_GIT_BRANCH=$EC_GIT_BRANCH"; \
-    \
-    EC_VERSION=${EC_GIT_BRANCH#"release-"}; \
+    EC_VERSION="v0.2"; \
     echo "EC_VERSION=$EC_VERSION"; \
     \
     EC_BASE_TAG="${EC_VERSION}.0"; \
@@ -86,18 +80,10 @@ RUN \
     EC_PATCH_NUM=$( git rev-list --merges --count ${EC_BASE_TAG}..HEAD ); \
     echo "EC_PATCH_NUM=$EC_PATCH_NUM"; \
     \
-    if [ -z "$EC_VERSION" ]; then \
-      EC_FULL_VERSION="_ci_build-${EC_GIT_SHA}"; \
-    else \
-      EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"; \
-    fi; \
+    EC_FULL_VERSION="${EC_VERSION}.${EC_PATCH_NUM}"; \
     echo "EC_FULL_VERSION=$EC_FULL_VERSION"; \
     \
-    if [ -z "$EC_VERSION" -o "$EC_GIT_BRANCH" = "$EC_VERSION" ]; then \
-      BUILDS="${TARGETOS}_${TARGETARCH}"; \
-    else \
-      BUILDS="${BUILD_LIST}"; \
-    fi; \
+    BUILDS="${BUILD_LIST}"; \
     echo "BUILDS=$BUILDS"; \
     \
     for os_arch in ${BUILDS}; do \


### PR DESCRIPTION
This is a quick-fix, and partly motivated by EC-511. I'm having trouble getting a green build in release branch, and I'm hoping this will make a re-triggered build behave sanely.

Remove the complicated logic related to detecting the branch name, extracting the version number, and deciding if it's a real release build. Just hard code it. (Will worry about porting this to main branch later.)

Ref: https://issues.redhat.com/browse/EC-511