### PR TITLE
Change tag used for patch num counting

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -73,7 +73,7 @@ RUN \
     EC_VERSION="v0.2"; \
     echo "EC_VERSION=$EC_VERSION"; \
     \
-    EC_BASE_TAG="${EC_VERSION}.0"; \
+    EC_BASE_TAG="${EC_VERSION}-patch-base"; \
     echo "EC_BASE_TAG=$EC_BASE_TAG"; \
     git log -n1 --format="%h %s" "$EC_BASE_TAG"; \
     \


### PR DESCRIPTION
Calling the v0.2.0 makes it look like a specific release tag, which is not really accurate. Let's use a name that better reflects its purpose.