### PR TITLE
Add policy.yaml for ec verifications in Konflux

### DIFF
--- a/.ec/policy.yaml
+++ b/.ec/policy.yaml
@@ -1,0 +1,45 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# Initially copied from
+# https://github.com/enterprise-contract/config/blob/main/redhat-no-hermetic/policy.yaml
+#
+# See also
+# https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/OP/EnterpriseContractPolicy/registry-rhtap-contract.yaml
+# which is used by the release pipeline
+#
+name: ec-cli-custom
+description: >-
+  Policy used by the ec verify Integration Tests in Konflux for ec-cli
+  component builds. Based on the standard `redhat-non-hermetic` config
+  with customizations when/if required.
+sources:
+  - name: Default
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/release
+    data:
+      - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+      - github.com/release-engineering/rhtap-ec-policy//data
+    config:
+      include:
+        - '@redhat'
+      exclude:
+        # Temporary until https://issues.redhat.com/browse/EC-360 is fixed
+        - hermetic_build_task
+        - tasks.required_tasks_found:prefetch-dependencies

--- a/.ec/policy.yaml
+++ b/.ec/policy.yaml
@@ -43,3 +43,9 @@ sources:
         # Temporary until https://issues.redhat.com/browse/EC-360 is fixed
         - hermetic_build_task
         - tasks.required_tasks_found:prefetch-dependencies
+    ruleData:
+      # Temporary until https://issues.redhat.com/browse/EC-520 is fixed
+      # (The default here is [critical,high])
+      restrict_cve_security_levels: [critical]
+      # (The default here is [])
+      warn_cve_security_levels: [high]

--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -97,7 +97,7 @@ When it's done you can merge. (Continue to next section while you're waiting...)
 Go to the integration tests at ${KONFLUX_APPS_URL}/${KONFLUX_APPLICATION_NAME}/integrationtests
 Edit ${KONFLUX_APPLICATION_NAME}-enterprise-contract and add a parameter as follows:
   Name: POLICY_CONFIGURATION
-  Value: github.com/enterprise-contract/config//redhat-no-hermetic
+  Value: github.com/enterprise-contract/ec-cli
 Save changes
 
 # Apply cli pipeline modifications


### PR DESCRIPTION
We were previously using the standard redhat-non-hermetic config directly from https://github.com/enterprise-contract/config/blob/main/redhat-no-hermetic/policy.yaml

Now we have a need to use a customized policy so let's create one. I figured we could keep it here in this repo under .ec, in the style of .tekton, .github, etc.

As mentioned in the comments, ec by convention will look for a .ec/policy.yaml file at the git url specified.

Ref: [EC-520](https://issues.redhat.com/browse/EC-520)