### PR TITLE
Set container image name label explicitly

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -129,6 +129,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL \
+  name="ec-cli" \
   description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   summary="Provides the binaries for downloading the EC CLI. Also used as a Tekton task runner image for EC tasks." \


### PR DESCRIPTION
Avoid an EC warning that I assume might become a violation some day: 'The "name" label should not be inherited from the parent image'

Before this the name inherited from the base image was 'ubi9-minimal'.

Will add this change to main branch later.

Motivated largely by wanting to trigger another Konflux build...