### PR TITLE
Check for uncommitted changes on rebased branch

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,6 +62,10 @@ jobs:
 
       - name: Check for uncommitted changes
         run: |
+          git fetch origin "${GITHUB_BASE_REF}"
+          git switch -c checks --track "origin/${GITHUB_BASE_REF}"
+          trap "git switch - --detach" SIGINT
+          git rebase
           if ! git diff --exit-code -s; then
             for f in $(git diff --exit-code --name-only); do
               echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"


### PR DESCRIPTION
With this if there are fixes on the base branch that are preventing the PR from merging, or if the PR is not rebased on the latest from the base branch and is missing a change from the base branch -- they should be detected.