### PR TITLE
Use `GITHUB_REF` as default

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Check for uncommitted changes
         run: |
-          git fetch origin "${GITHUB_BASE_REF}"
-          git switch -c checks --track "origin/${GITHUB_BASE_REF}"
+          git fetch origin "${GITHUB_BASE_REF:-$GITHUB_REF}"
+          git switch -c checks --track "origin/${GITHUB_BASE_REF:-$GITHUB_REF}"
           trap "git switch - --detach" SIGINT
           git rebase
           if ! git diff --exit-code -s; then


### PR DESCRIPTION
When `GITHUB_BASE_REF` is not defined, i.e. the workflow is not running for a pull request, this uses `GITHUB_REF` instead.