### PR TITLE
Use git switch `GITHUB_REF_NAME`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Check for uncommitted changes
         run: |
-          git fetch origin "${GITHUB_BASE_REF:-$GITHUB_REF}"
-          git switch -c checks --track "origin/${GITHUB_BASE_REF:-$GITHUB_REF}"
+          git fetch origin "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
+          git switch -c checks --track "origin/${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
           trap "git switch - --detach" SIGINT
           git rebase
           if ! git diff --exit-code -s; then


### PR DESCRIPTION
The `GITHUB_REF` expands to `ref/heads/main` which is not a valid ref when combined with the remote name of `origin` (`origin/ref/heads/main`)

This changes it to `GITHUB_REF_NAME` which should resolve solely to the name of the branch (`main`), so `origin/main`.