### PR TITLE
Use the existing cache for multi platform release with Podman update

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -126,6 +126,10 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Update podman
+        run: |
+          "${GITHUB_WORKSPACE}/hack/ubuntu-podman-update.sh"
+
       - name: Acceptance test
         run: make acceptance
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Update podman
+        run: |
+          "${GITHUB_WORKSPACE}/hack/ubuntu-podman-update.sh"
+
       - name: Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ push-snapshot-image: build-snapshot-image ## Push the ec-cli image with the "sna
 $(ALL_SUPPORTED_IMG_OS_ARCH): TARGETOS=$(word 2,$(subst _, ,$@))
 $(ALL_SUPPORTED_IMG_OS_ARCH): TARGETARCH=$(word 3,$(subst _, ,$@))
 $(ALL_SUPPORTED_IMG_OS_ARCH):
-	@podman build -t $(IMAGE_REPO):$(IMAGE_TAG)-$(TARGETOS)-$(TARGETARCH) -f Dockerfile --platform $(TARGETOS)/$(TARGETARCH)
+	@podman build -t $(IMAGE_REPO):$(IMAGE_TAG)-$(TARGETOS)-$(TARGETARCH) -f Dockerfile --platform $(TARGETOS)/$(TARGETARCH) --volume "$$(go env GOCACHE)":/go/cache:Z --volume "$$(go env GOMODCACHE)":/go/mod:Z --env GOCACHE=/go/cache --env GOMODCACHE=/go/mod
 
 # Currently it shows the following:
 #  image_linux_amd64

--- a/hack/ubuntu-podman-update.sh
+++ b/hack/ubuntu-podman-update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ubuntu_version=$(lsb_release -sr)
+key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+
+echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+sudo apt update
+sudo apt install podman


### PR DESCRIPTION
Use the existing cache for multi platform release. With this we can reuse the existing caches for releases for all os/arch  combinations. This should save a bit of time, but also help with disk space.