### PR TITLE
Set name label in Dockerfile.dist

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -73,6 +73,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL \
+  name="ec-cli" \
   description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   summary="Provides the binaries for downloading the EC CLI. Also used as a Tekton task runner image for EC tasks." \


### PR DESCRIPTION
Images built in Konflux are required to have the `name` label set to a value different than the value of the same label from the parent image.

(I'm pretty sure this is to satisfy some requirement in the legacy build pipeline and is not actually used by anything in Konflux.)