### PR TITLE
Allow duplicate values for slsa_provenance_v0.2 schema

### DIFF
--- a/pkg/schema/slsa_provenance_v0.2.json
+++ b/pkg/schema/slsa_provenance_v0.2.json
@@ -61,10 +61,7 @@
           "name",
           "digest"
         ]
-      },
-      "uniqueKeys": [
-        "/name"
-      ]
+      }
     },
     "predicateType": {
       "const": "https://slsa.dev/provenance/v0.2"

--- a/pkg/schema/slsa_provenance_v0.2_test.go
+++ b/pkg/schema/slsa_provenance_v0.2_test.go
@@ -91,7 +91,6 @@ func TestSubjectMustBeProvided(t *testing.T) {
 		`{"subject": [{"name": "a", "digest": {"foo": "abcdef0123456789"}}]}`,
 		`{"subject": [{"name": "a", "digest": {"sha256": ""}}]}`,
 		`{"subject": [{"name": "a", "digest": {"sha256": "g%-A"}}]}`,
-		`{"subject": [{"name": "x", "digest": {"sha256": "abcdef"}}, {"name": "x", "digest": {"sha256": "fedcba"}}]}`,
 	)
 }
 


### PR DESCRIPTION
When processing multi-arch images, it is possible for the image index and the index manifests to have the same name. This change enables that. It is also in compliance with
https://slsa.dev/spec/v0.2/provenance#schema