### PR TITLE
Remove rebasing logic from uncommitted check

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,10 +62,6 @@ jobs:
 
       - name: Check for uncommitted changes
         run: |
-          git fetch origin "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
-          git switch -c checks --track "origin/${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
-          trap "git switch - --detach" EXIT
-          git rebase
           if ! git diff --exit-code -s; then
             for f in $(git diff --exit-code --name-only); do
               echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"


### PR DESCRIPTION
I think we might not need this, if a file was changed on main and the PR touches it it will show up in the diff or the PR will be marked conflicting. If we need this merge queues is probably a better approach.