### PR TITLE
Test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ test: ## Run all unit tests
 	@echo "Unit tests:"
 	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./...
 	@echo "Integration tests:"
-	@go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | grep -v '\[no test files\]'
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | grep -v '\[no test files\]'
 # Given the nature of generative tests the test timeout is increased from 500ms
 # to 30s to accommodate many samples being generated and test cases being run.
 	@echo "Generative tests:"
-	@go test -race -covermode=atomic -coverprofile=coverage-generative.out -timeout 30s -tags=generative ./... | grep -v '\[no test files\]'
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-generative.out -timeout 30s -tags=generative ./... | grep -v '\[no test files\]'
 
 ACCEPTANCE_TIMEOUT:=20m
 .ONESHELL:

--- a/cmd/validate/common_test.go
+++ b/cmd/validate/common_test.go
@@ -1,0 +1,89 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit || integration
+
+package validate
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/enterprise-contract/ec-cli/cmd/root"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
+)
+
+type MockRemoteClient struct {
+	mock.Mock
+}
+
+func (m *MockRemoteClient) Get(ref name.Reference) (*remote.Descriptor, error) {
+	args := m.Called(ref)
+	result := args.Get(0)
+	if result != nil {
+		return result.(*remote.Descriptor), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockRemoteClient) Index(ref name.Reference) (v1.ImageIndex, error) {
+	args := m.Called(ref)
+	result := args.Get(0)
+	if result != nil {
+		return args.Get(0).(v1.ImageIndex), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func commonMockClient(mockClient *MockRemoteClient) {
+	imageManifestJson := `{"mediaType": "application/vnd.oci.image.manifest.v1+json"}`
+	imageManifestJsonBytes := []byte(imageManifestJson)
+	// TODO: Replace mock.Anything calls with specific values
+	mockClient.On("Get", mock.Anything).Return(&remote.Descriptor{Manifest: imageManifestJsonBytes}, nil)
+}
+
+type mockEvaluator struct {
+	mock.Mock
+}
+
+func (e *mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+	args := e.Called(ctx, inputs)
+
+	return args.Get(0).([]evaluator.Outcome), args.Get(1).(evaluator.Data), args.Error(2)
+}
+
+func (e *mockEvaluator) Destroy() {
+	e.Called()
+}
+
+func (e *mockEvaluator) CapabilitiesPath() string {
+	args := e.Called()
+
+	return args.String(0)
+}
+
+func setUpCobra(command *cobra.Command) *cobra.Command {
+	validateCmd := NewValidateCmd()
+	validateCmd.AddCommand(command)
+	cmd := root.NewRootCmd()
+	cmd.AddCommand(validateCmd)
+	return cmd
+}

--- a/cmd/validate/image_integration_test.go
+++ b/cmd/validate/image_integration_test.go
@@ -1,0 +1,116 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package validate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
+	"github.com/enterprise-contract/ec-cli/internal/output"
+	"github.com/enterprise-contract/ec-cli/internal/policy"
+	"github.com/enterprise-contract/ec-cli/internal/policy/source"
+	"github.com/enterprise-contract/ec-cli/internal/utils"
+)
+
+func TestEvaluatorLifecycle(t *testing.T) {
+	ctx := utils.WithFS(context.Background(), afero.NewMemMapFs())
+	mockRemoteClient := &MockRemoteClient{}
+	commonMockClient(mockRemoteClient)
+	ctx = context.WithValue(ctx, applicationsnapshot.RemoteClientKey{}, mockRemoteClient)
+
+	noEvaluators := 100
+
+	evaluators := make([]*mockEvaluator, 0, noEvaluators)
+	expectations := make([]*mock.Call, 0, noEvaluators)
+
+	for i := 0; i < noEvaluators; i++ {
+		e := mockEvaluator{}
+		call := e.On("Evaluate", ctx, mock.Anything).Return([]evaluator.Outcome{}, evaluator.Data{}, nil)
+
+		evaluators = append(evaluators, &e)
+		expectations = append(expectations, call)
+	}
+
+	for i := 0; i < noEvaluators; i++ {
+		evaluators[i].On("Destroy").NotBefore(expectations...)
+	}
+
+	newConftestEvaluator = func(_ context.Context, s []source.PolicySource, _ evaluator.ConfigProvider, _ v1alpha1.Source) (evaluator.Evaluator, error) {
+		idx, err := strconv.Atoi(s[0].PolicyUrl())
+		require.NoError(t, err)
+
+		return evaluators[idx], nil
+	}
+	t.Cleanup(func() {
+		newConftestEvaluator = evaluator.NewConftestEvaluator
+	})
+
+	validate := func(_ context.Context, component app.SnapshotComponent, _ policy.Policy, evaluators []evaluator.Evaluator, _ bool) (*output.Output, error) {
+		for _, e := range evaluators {
+			_, _, err := e.Evaluate(ctx, []string{})
+			require.NoError(t, err)
+		}
+
+		return &output.Output{ImageURL: component.ContainerImage}, nil
+	}
+
+	validateImageCmd := validateImageCmd(validate)
+	cmd := setUpCobra(validateImageCmd)
+
+	cmd.SetContext(ctx)
+
+	effectiveTimeTest := time.Now().UTC().Format(time.RFC3339Nano)
+
+	sources := make([]string, 0, noEvaluators)
+	for i := 0; i < noEvaluators; i++ {
+		sources = append(sources, fmt.Sprintf(`{"policy": ["%d"]}`, i))
+	}
+
+	cmd.SetArgs([]string{
+		"validate",
+		"image",
+		"--image",
+		"registry/image:tag",
+		"--policy",
+		fmt.Sprintf(`{"publicKey": %s, "sources": [%s]}`, utils.TestPublicKeyJSON, strings.Join(sources, ", ")),
+		"--effective-time",
+		effectiveTimeTest,
+		"--ignore-rekor",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -731,7 +731,12 @@ func Test_ValidateImageCommandExtraData(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 
-	cmd.SetContext(utils.WithFS(context.TODO(), fs))
+	ctx := utils.WithFS(context.TODO(), fs)
+	mockRemoteClient := &MockRemoteClient{}
+	commonMockClient(mockRemoteClient)
+	ctx = context.WithValue(ctx, applicationsnapshot.RemoteClientKey{}, mockRemoteClient)
+
+	cmd.SetContext(ctx)
 
 	testPolicyJSON := `sources:
   - policy:

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -24,31 +24,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 
-	"github.com/enterprise-contract/ec-cli/cmd/root"
 	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
-	"github.com/enterprise-contract/ec-cli/internal/policy/source"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
@@ -62,35 +51,6 @@ type data struct {
 var rootArgs = []string{
 	"validate",
 	"image",
-}
-
-type MockRemoteClient struct {
-	mock.Mock
-}
-
-func (m *MockRemoteClient) Get(ref name.Reference) (*remote.Descriptor, error) {
-	args := m.Called(ref)
-	result := args.Get(0)
-	if result != nil {
-		return result.(*remote.Descriptor), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-func (m *MockRemoteClient) Index(ref name.Reference) (v1.ImageIndex, error) {
-	args := m.Called(ref)
-	result := args.Get(0)
-	if result != nil {
-		return args.Get(0).(v1.ImageIndex), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-func commonMockClient(mockClient *MockRemoteClient) {
-	imageManifestJson := `{"mediaType": "application/vnd.oci.image.manifest.v1+json"}`
-	imageManifestJsonBytes := []byte(imageManifestJson)
-	// TODO: Replace mock.Anything calls with specific values
-	mockClient.On("Get", mock.Anything).Return(&remote.Descriptor{Manifest: imageManifestJsonBytes}, nil)
 }
 
 func Test_determineInputSpec(t *testing.T) {
@@ -1269,14 +1229,6 @@ func Test_FailureImageAccessibilityNonStrict(t *testing.T) {
 	  }`, effectiveTimeTest, utils.TestPublicKeyJSON, utils.TestPublicKeyJSON), out.String())
 }
 
-func setUpCobra(command *cobra.Command) *cobra.Command {
-	validateCmd := NewValidateCmd()
-	validateCmd.AddCommand(command)
-	cmd := root.NewRootCmd()
-	cmd.AddCommand(validateCmd)
-	return cmd
-}
-
 func TestValidateImageCommand_RunE(t *testing.T) {
 	validate := func(_ context.Context, component app.SnapshotComponent, _ policy.Policy, _ []evaluator.Evaluator, _ bool) (*output.Output, error) {
 		return &output.Output{
@@ -1356,97 +1308,4 @@ func TestValidateImageCommand_RunE(t *testing.T) {
 			"publicKey": %s
 		}
 	  }`, effectiveTimeTest, utils.TestPublicKeyJSON, utils.TestPublicKeyJSON), out.String())
-}
-
-type mockEvaluator struct {
-	mock.Mock
-}
-
-func (e *mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
-	args := e.Called(ctx, inputs)
-
-	return args.Get(0).([]evaluator.Outcome), args.Get(1).(evaluator.Data), args.Error(2)
-}
-
-func (e *mockEvaluator) Destroy() {
-	e.Called()
-}
-
-func (e *mockEvaluator) CapabilitiesPath() string {
-	args := e.Called()
-
-	return args.String(0)
-}
-
-func TestEvaluatorLifecycle(t *testing.T) {
-	ctx := utils.WithFS(context.Background(), afero.NewMemMapFs())
-	mockRemoteClient := &MockRemoteClient{}
-	commonMockClient(mockRemoteClient)
-	ctx = context.WithValue(ctx, applicationsnapshot.RemoteClientKey{}, mockRemoteClient)
-
-	noEvaluators := 100
-
-	evaluators := make([]*mockEvaluator, 0, noEvaluators)
-	expectations := make([]*mock.Call, 0, noEvaluators)
-
-	for i := 0; i < noEvaluators; i++ {
-		e := mockEvaluator{}
-		call := e.On("Evaluate", ctx, mock.Anything).Return([]evaluator.Outcome{}, evaluator.Data{}, nil)
-
-		evaluators = append(evaluators, &e)
-		expectations = append(expectations, call)
-	}
-
-	for i := 0; i < noEvaluators; i++ {
-		evaluators[i].On("Destroy").NotBefore(expectations...)
-	}
-
-	newConftestEvaluator = func(_ context.Context, s []source.PolicySource, _ evaluator.ConfigProvider, _ v1alpha1.Source) (evaluator.Evaluator, error) {
-		idx, err := strconv.Atoi(s[0].PolicyUrl())
-		require.NoError(t, err)
-
-		return evaluators[idx], nil
-	}
-	t.Cleanup(func() {
-		newConftestEvaluator = evaluator.NewConftestEvaluator
-	})
-
-	validate := func(_ context.Context, component app.SnapshotComponent, _ policy.Policy, evaluators []evaluator.Evaluator, _ bool) (*output.Output, error) {
-		for _, e := range evaluators {
-			_, _, err := e.Evaluate(ctx, []string{})
-			require.NoError(t, err)
-		}
-
-		return &output.Output{ImageURL: component.ContainerImage}, nil
-	}
-
-	validateImageCmd := validateImageCmd(validate)
-	cmd := setUpCobra(validateImageCmd)
-
-	cmd.SetContext(ctx)
-
-	effectiveTimeTest := time.Now().UTC().Format(time.RFC3339Nano)
-
-	sources := make([]string, 0, noEvaluators)
-	for i := 0; i < noEvaluators; i++ {
-		sources = append(sources, fmt.Sprintf(`{"policy": ["%d"]}`, i))
-	}
-
-	cmd.SetArgs([]string{
-		"validate",
-		"image",
-		"--image",
-		"registry/image:tag",
-		"--policy",
-		fmt.Sprintf(`{"publicKey": %s, "sources": [%s]}`, utils.TestPublicKeyJSON, strings.Join(sources, ", ")),
-		"--effective-time",
-		effectiveTimeTest,
-		"--ignore-rekor",
-	})
-
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-
-	err := cmd.Execute()
-	assert.NoError(t, err)
 }

--- a/internal/tracker/tracker_gen_test.go
+++ b/internal/tracker/tracker_gen_test.go
@@ -34,7 +34,7 @@ func TestTrackerAddKeepsOrder(t *testing.T) {
 	parameters := gopter.DefaultTestParameters()
 
 	// uncomment when test fails and set the seed to the printed value
-	// parameters.Rng.Seed(1234) -
+	// parameters.Rng.Seed(1234)
 	arbitraries := arbitrary.DefaultArbitraries()
 
 	nonEmptyIdentifier := gen.Identifier().SuchThat(func(v string) bool {
@@ -69,7 +69,7 @@ func TestTrackerAddKeepsOrder(t *testing.T) {
 			scanner := bufio.NewScanner(buff)
 			scanner.Split(bufio.ScanLines)
 
-			// at this level of identation, last string was
+			// at this level of indentation, last string was
 			lastAt := map[int]string{}
 			lastLevel := 0
 			for scanner.Scan() {
@@ -83,14 +83,14 @@ func TestTrackerAddKeepsOrder(t *testing.T) {
 				// remove quotes, they're just messing with comparisons below,
 				// i.e. `"y"`` -> "y"
 				line = strings.ReplaceAll(line, `"`, "")
-				// remove trailing colon, it also messes with comparisons below,
-				// i.e. "abc:" -> "abc"
-				line = strings.TrimSuffix(line, ":")
+				// focus only on keys, so disregard everything after and
+				// including ":"
+				line, _, _ = strings.Cut(line, ":")
 
-				// counts the identation, i.e. number of spaces on the left
+				// counts the indentation, i.e. number of spaces on the left
 				level := len(line) - len(strings.TrimLeft(line, " "))
 
-				// we're going to a lower level of identation, meaning we're now
+				// we're going to a lower level of indentation, meaning we're now
 				// processing a key that is not at the same, but at a lower
 				// level, also meaning that the lines processed below this level
 				// were were compared, i.e. we don't want to compare x and y

--- a/internal/utils/testing_sigstore.go
+++ b/internal/utils/testing_sigstore.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build unit
+//go:build unit || integration
 
 // The contents of this file are meant to assist in writing unit tests. It requires the "unit" build
 // tag which is not included when building the ec binary.


### PR DESCRIPTION
Marks `TestEvaluatorLifecycle` test as integration test to get a higher timeout and configures mock client so the `Test_ValidateImageCommandExtraData` test doesn't access the network.