### PR TITLE
Publish versioned release after snapshot release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,14 +164,6 @@ jobs:
 
           git push -f --tags
 
-      - name: Versioned release
-        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
-        with:
-          name: ${{ steps.add_tags.outputs.tag_name }}
-          tag_name: ${{ steps.add_tags.outputs.tag_name }}
-          generate_release_notes: false
-          files: dist/*
-
       - name: Rolling release
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         with:
@@ -179,5 +171,13 @@ jobs:
           name: Rolling release
           body: Stable rolling release. Version can be determined by running `ec version`.
           tag_name: snapshot
+          generate_release_notes: false
+          files: dist/*
+
+      - name: Versioned release
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
+        with:
+          name: ${{ steps.add_tags.outputs.tag_name }}
+          tag_name: ${{ steps.add_tags.outputs.tag_name }}
           generate_release_notes: false
           files: dist/*


### PR DESCRIPTION
There's a short window of time between removing the snapshot build and creating a new one, where the snapshot release doesn't exist. IIUC this change should make that window shorter because we're publishing the snapshot release before the versioned release instead of after.

It looks like the time taken for a release publish is 6 seconds, so this potentially reduces the time we have no snapshot release available from 12 seconds down to 6 seconds, give or take.

There might be a way to eliminate the 6 second gap entirely and also avoid the scenario where a broken release builds means there is no snapshot available at all, but I'll file a separate story for that and we can worry about it later.

Followup patch for:

Ref: https://issues.redhat.com/browse/EC-602