### PR TITLE
Make it so snapshot release is always "latest"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,6 +177,7 @@ jobs:
       - name: Versioned release
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         with:
+          make_latest: false
           name: ${{ steps.add_tags.outputs.tag_name }}
           tag_name: ${{ steps.add_tags.outputs.tag_name }}
           generate_release_notes: false


### PR DESCRIPTION
In commit 33af1620 PR #1578 there was an unintentional side-effect of changing which release was designated as "latest" in GitHub. Let's undo the unintentional change.

Followup to a followup of...

Ref: https://issues.redhat.com/browse/EC-602