### PR TITLE
Add +redhat to version for Konflux builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ARG TARGETARCH
 COPY --from=download /download/cosign /usr/bin/cosign
 RUN cosign version
 
-RUN microdnf -y install git-core jq && microdnf clean all
+RUN microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
 
 # Copy the one ec binary that can run in this container
 COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -28,6 +28,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS build
 
+ARG BUILD_SUFFIX="redhat"
 ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 ARG TARGETOS
 ARG TARGETARCH
@@ -43,7 +44,7 @@ RUN go mod download
 # Now copy everything including .git
 COPY . .
 
-RUN /build/build.sh "${BUILD_LIST}"
+RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 # Extract this so we can download the matching cosign version below
 RUN go list --mod=readonly -f '{{.Version}}' -m github.com/sigstore/cosign/v2 | tee cosign_version.txt

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -22,10 +22,6 @@
 # This currently has go version 1.20 but we need version 1.21
 #FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build
 
-# This image has go version 1.21 but requires an extra pull secret to access
-# See https://source.redhat.com/groups/public/teamnado/wiki/brew_registry for how to get your own pull secret
-# See our Konflux pull secret at https://console.redhat.com/preview/application-pipeline/secrets
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS build
 
 ARG BUILD_SUFFIX="redhat"

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,14 @@ dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating sys
 
 # Dockerfile.dist is used by the Konflux build pipeline where it's built using
 # buildah not podman. This is for testing that build locally.
-# Todo: Why not use buildah here for consistency with the Konflux build?
 .PHONY: dist-container
 dist-container: clean
-	podman build . \
-	  --file Dockerfile.dist \
+	buildah bud --file Dockerfile.dist \
 	  --tag dist-container \
 	  --platform $(BUILD_LOCAL_PLATFORM) \
 	  --build-arg BUILD_SUFFIX=local \
-	  --build-arg BUILD_LIST=$(BUILD_LOCAL_ARCH)
+	  --build-arg BUILD_LIST=$(BUILD_LOCAL_ARCH) \
+	  .
 
 # For local debugging of the above
 dist-container-run:

--- a/Makefile
+++ b/Makefile
@@ -56,16 +56,21 @@ dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating sys
 
 # Dockerfile.dist is used by the Konflux build pipeline where it's built using
 # buildah not podman. This is for testing that build locally.
-# Todo: Don't hard code the platform here. Should probably do multi-arch builds similar
-# to dist-image. Also, why not use buildah here for consistency with the Konflux build?
+# Todo: Why not use buildah here for consistency with the Konflux build?
 .PHONY: dist-container
 dist-container: clean
-	podman build . --file Dockerfile.dist --tag dist-container --platform linux/amd64 # --no-cache
+	podman build . \
+	  --file Dockerfile.dist \
+	  --tag dist-container \
+	  --platform $(BUILD_LOCAL_PLATFORM) \
+	  --build-arg BUILD_SUFFIX=local \
+	  --build-arg BUILD_LIST=$(BUILD_LOCAL_ARCH)
 
 # For local debugging of the above
 dist-container-run:
 	podman run --rm -it --entrypoint=/bin/bash dist-container
 
+BUILD_LOCAL_PLATFORM:=$(shell go env GOOS)/$(shell go env GOARCH)
 BUILD_LOCAL_ARCH:=$(shell go env GOOS)_$(shell go env GOARCH)
 .PHONY: build
 build: dist/ec_$(BUILD_LOCAL_ARCH) ## Build the ec binary for the current platform

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,10 @@ set -o pipefail
 
 BUILDS="${1}"
 
-EC_FULL_VERSION=$(hack/derive-version.sh)
+# Generally blank, but will be set to "redhat" for Konflux builds
+BUILD_SUFFIX="${2:-""}"
+
+EC_FULL_VERSION=$(hack/derive-version.sh "${BUILD_SUFFIX}")
 
 echo "EC_FULL_VERSION=$EC_FULL_VERSION"
 echo "BUILDS=$BUILDS"

--- a/hack/derive-version.sh
+++ b/hack/derive-version.sh
@@ -65,4 +65,12 @@ else
   FULL_VERSION="v${MAJOR_MINOR}.${PATCH_NUM}"
 fi
 
+# Generally blank but will be set to "redhat" for Konflux builds
+BUILD_SUFFIX="${1:-""}"
+
+# This is build metadata in semver terms, see https://semver.org/#spec-item-10
+if [ -n "${BUILD_SUFFIX}" ]; then
+  FULL_VERSION="${FULL_VERSION}+${BUILD_SUFFIX}"
+fi
+
 echo ${FULL_VERSION}


### PR DESCRIPTION
The motivation is so there's a way to distinguish a Red Hat Konflux build of ec from an GitHub upstream build.

After this patch, `ec version` will show something like `v0.4.1+redhat` for a Konflux build, and `v0.4.1` for the same build if it was done in GitHub.

Ref: [EC-573](https://issues.redhat.com/browse/EC-573)