### PR TITLE
Expose --extra-rule-data in v-e-c task

### DIFF
--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -57,6 +57,7 @@ paths can be provided by using the `:` separator.
 *EFFECTIVE_TIME* (`string`):: Run policy checks with the provided time.
 +
 *Default*: `now`
+*EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
 
 == Results
 

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -274,6 +274,100 @@ success: true
 
 ---
 
+[Extra rule data provided to task:report - 1]
+components:
+- attestations:
+  - predicateBuildType: tekton.dev/v1beta1/TaskRun
+    predicateType: https://slsa.dev/provenance/v0.2
+    signatures:
+    - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+      sig: MEUCIHFVZeVR59n9UvN1dwF9Lh3Gv8XWLPDPIIJcnQ8e3TtvAiEA0z/5v6ggvmQyQ1EnYTJo9rwxOYuve4th4P/0639orLg=
+    type: https://in-toto.io/Statement/v0.1
+  - predicateBuildType: tekton.dev/v1beta1/PipelineRun
+    predicateType: https://slsa.dev/provenance/v0.2
+    signatures:
+    - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+      sig: MEUCIQClx1zvZGvyRu5gCHiC+oWVZTmWJGQlocSZMnzx/5omZAIgUiLQuMm+USYE+H0PDn/xPSVVQjkhWjDc3fulkxVzlC0=
+    type: https://in-toto.io/Statement/v0.1
+  - predicateBuildType: tekton.dev/v1beta1/PipelineRun
+    predicateType: https://slsa.dev/provenance/v0.2
+    signatures:
+    - keyid: SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE
+      sig: MEUCIGS176zN5aoorLQMukjoCkHm7ocu7UhnKXLhzEdsgp4BAiEAviub3Lf4thLmSTU6ZqnEjw02kkrb9LKBBa1t8hVgAM4=
+    type: https://in-toto.io/Statement/v0.1
+  containerImage: quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d
+  name: ""
+  signatures:
+  - keyid: ""
+    sig: MEUCIFPod1d9HhGt+TEQPG4j+LINjkifCFFOFrE4jbkvexGGAiEAqSp3ROZUsIOwWro6Tv+lRiR7sdMR0U6Crs1ISuQhHtA=
+  source: {}
+  success: true
+  successes:
+  - metadata:
+      code: builtin.attestation.signature_check
+      description: The attestation signature matches available signing materials.
+      title: Attestation signature check passed
+    msg: Pass
+  - metadata:
+      code: builtin.attestation.syntax_check
+      description: The attestation has correct syntax.
+      title: Attestation syntax check passed
+    msg: Pass
+  - metadata:
+      code: builtin.image.signature_check
+      description: The image signature matches available signing materials.
+      title: Image signature check passed
+    msg: Pass
+  - metadata:
+      code: slsa_provenance_available.allowed_predicate_types_provided
+      collections:
+      - minimal
+      - slsa3
+      - redhat
+      - policy_data
+      description: Confirm the `allowed_predicate_types` rule data was provided, since
+        it is required by the policy rules in this package.
+      title: Allowed predicate types provided
+    msg: Pass
+  - metadata:
+      code: slsa_provenance_available.attestation_predicate_type_accepted
+      collections:
+      - minimal
+      - slsa3
+      - redhat
+      depends_on:
+      - attestation_type.known_attestation_type
+      description: Verify that the predicateType field of the attestation indicates
+        the in-toto SLSA Provenance format was used to attest the PipelineRun.
+      title: Expected attestation predicate type found
+    msg: Pass
+ec-version: ${EC_VERSION}
+effective-time: "${TIMESTAMP}"
+key: |
+  -----BEGIN PUBLIC KEY-----
+  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+  zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+  -----END PUBLIC KEY-----
+policy:
+  configuration:
+    include:
+    - slsa_provenance_available
+  publicKey: |-
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
+    zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
+    -----END PUBLIC KEY-----
+  sources:
+  - policy:
+    - github.com/enterprise-contract/ec-policies//policy/release
+    - github.com/enterprise-contract/ec-policies//policy/lib
+    ruleData:
+      key1: value1
+      key2: value2
+success: true
+
+---
+
 [Initialize TUF fails:report - 1]
 ${TIMESTAMP} Skipping step because a previous step failed
 
@@ -411,6 +505,12 @@ TUF_MIRROR not set. Skipping TUF root initialization.
 ---
 
 [Golden container image:results - 1]
+{
+  "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
+}
+---
+
+[Extra rule data provided to task:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
@@ -744,6 +844,124 @@ true
 ---
 
 [Golden container image:report-json - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "",
+      "containerImage": "quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check",
+            "description": "The attestation signature matches available signing materials.",
+            "title": "Attestation signature check passed"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check",
+            "description": "The attestation has correct syntax.",
+            "title": "Attestation syntax check passed"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check",
+            "description": "The image signature matches available signing materials.",
+            "title": "Image signature check passed"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "slsa_provenance_available.attestation_predicate_type_accepted",
+            "collections": [
+              "minimal",
+              "slsa1",
+              "slsa2",
+              "slsa3",
+              "redhat"
+            ],
+            "depends_on": [
+              "attestation_type.known_attestation_type"
+            ],
+            "description": "Verify that the predicateType field of the attestation indicates the in-toto SLSA Provenance format was used to attest the PipelineRun.",
+            "title": "Expected attestation predicate type found"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "MEUCIFPod1d9HhGt+TEQPG4j+LINjkifCFFOFrE4jbkvexGGAiEAqSp3ROZUsIOwWro6Tv+lRiR7sdMR0U6Crs1ISuQhHtA="
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "tekton.dev/v1beta1/TaskRun",
+          "signatures": [
+            {
+              "keyid": "SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE",
+              "sig": "MEUCIHFVZeVR59n9UvN1dwF9Lh3Gv8XWLPDPIIJcnQ8e3TtvAiEA0z/5v6ggvmQyQ1EnYTJo9rwxOYuve4th4P/0639orLg="
+            }
+          ]
+        },
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "tekton.dev/v1beta1/PipelineRun",
+          "signatures": [
+            {
+              "keyid": "SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE",
+              "sig": "MEUCIQClx1zvZGvyRu5gCHiC+oWVZTmWJGQlocSZMnzx/5omZAIgUiLQuMm+USYE+H0PDn/xPSVVQjkhWjDc3fulkxVzlC0="
+            }
+          ]
+        },
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "tekton.dev/v1beta1/PipelineRun",
+          "signatures": [
+            {
+              "keyid": "SHA256:RHajkr+wMEtGfT2CRFrQEhg/8MY2bDLXVg3F8IuI5nE",
+              "sig": "MEUCIGS176zN5aoorLQMukjoCkHm7ocu7UhnKXLhzEdsgp4BAiEAviub3Lf4thLmSTU6ZqnEjw02kkrb9LKBBa1t8hVgAM4="
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----\n",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "github.com/enterprise-contract/ec-policies//policy/release",
+          "github.com/enterprise-contract/ec-policies//policy/lib"
+        ]
+      }
+    ],
+    "configuration": {
+      "include": [
+        "slsa_provenance_available"
+      ]
+    },
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[Extra rule data provided to task:report-json - 1]
 {
   "success": true,
   "components": [

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -35,6 +35,37 @@ Feature: Verify Enterprise Contract Tekton Tasks
      And the task logs for step "report" should match the snapshot
      And the task results should match the snapshot
 
+  Scenario: Extra rule data provided to task
+    Given a working namespace
+    Given a cluster policy with content:
+      ```
+      {
+        "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----",
+        "sources": [
+          {
+            "policy": [
+              "github.com/enterprise-contract/ec-policies//policy/release",
+              "github.com/enterprise-contract/ec-policies//policy/lib"
+            ]
+          }
+        ],
+        "configuration": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
+      }
+      ```
+    When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
+      | IMAGES               | {"components": [{"containerImage": "quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d"}]} |
+      | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                                                                                                  |
+      | STRICT               | true                                                                                                                                                         |
+      | IGNORE_REKOR         | true                                                                                                                                                         |
+      | EXTRA_RULE_DATA      | key1=value1,key2=value2                                                                                                                                      |
+    Then the task should succeed
+     And the task logs for step "report" should match the snapshot
+     And the task results should match the snapshot
+
   Scenario: Initialize TUF succeeds
     Given a working namespace
     Given a cluster policy with content:

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -110,6 +110,10 @@ spec:
       type: string
       description: Run policy checks with the provided time.
       default: "now"
+    - name: EXTRA_RULE_DATA
+      type: string
+      description: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
+      default: ""
 
   workspaces:
     - name: data
@@ -170,6 +174,7 @@ spec:
         - "--strict=false"
         - "--show-successes"
         - "--effective-time=$(params.EFFECTIVE_TIME)"
+        - "--extra-rule-data=$(params.EXTRA_RULE_DATA)"
         - "--output"
         - "yaml=$(params.HOMEDIR)/report.yaml"
         - "--output"


### PR DESCRIPTION
Adds a new param called `EXTRA_RULE_DATA` in the `verify-enterprise-contract` task that maps to the new `--extra-rule-data` flag. Supports multiple key/value pairs with `key1=value1,key2=value2` syntax.