### PR TITLE
Name the version in snapshot release description

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,7 +169,7 @@ jobs:
         with:
           make_latest: true
           name: Rolling release
-          body: Stable rolling release. Version can be determined by running `ec version`.
+          body: Stable rolling release, currently the same as `${{ steps.add_tags.outputs.tag_name }}`.
           tag_name: snapshot
           generate_release_notes: false
           files: dist/*


### PR DESCRIPTION
Since we know what the version is going to be, I guess we might as well mention it instead of asking users to figure it out for themselves.

A small followup tweak for...

Ref: https://issues.redhat.com/browse/EC-602