### PR TITLE
Use go-toolset golang base image for redhat builds

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -19,26 +19,22 @@
 # This works fine but will produce an EC violation
 # FROM docker.io/library/golang:1.21 AS build
 
-# This currently has go version 1.20 but we need version 1.21
-#FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:f04d515e747fbd9ef5e55a7d34808e4abf1d62623515d0e97c12b51cc0008de3 AS build
 
 ARG BUILD_SUFFIX="redhat"
 ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN microdnf -y --nodocs --setopt=keepcache=0 install golang git-core
-
 WORKDIR /build
 
 # Copy just the mod file for better layer caching when building locally
-COPY go.mod go.sum .
+# (Use chown to match the user set in ubi9/go-toolset and avoid a git safe directory error)
+COPY --chown=1001:0 go.mod go.sum .
 RUN go mod download
 
 # Now copy everything including .git
-COPY . .
+COPY --chown=1001:0 . .
 
 RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 


### PR DESCRIPTION
The --chown=1001:0 was required to avoid an error like this:

  fatal: detected dubious ownership in repository at '/build'
  To add an exception for this directory, call:
          git config --global --add safe.directory /build

I'm not exactly sure the reason why, but I believe it's because the new base image comes with a user called 'default' with uid 1001. When we copy the source code into the build container it comes in owned by root, and that causes git to be suspicious when it runs as user default.

Ref: https://issues.redhat.com/browse/EC-625