### PR TITLE
Use go-toolset golang base image for redhat builds

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -19,17 +19,15 @@
 # This works fine but will produce an EC violation
 # FROM docker.io/library/golang:1.21 AS build
 
-# This currently has go version 1.20 but we need version 1.21
-#FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:f04d515e747fbd9ef5e55a7d34808e4abf1d62623515d0e97c12b51cc0008de3 AS build
 
 ARG BUILD_SUFFIX="redhat"
 ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN microdnf -y --nodocs --setopt=keepcache=0 install golang git-core
+# Avoid safe directory git failures building with default user from go-toolset
+USER root
 
 WORKDIR /build
 


### PR DESCRIPTION
Use root user instead of the 'default' user from go-toolset to avoid an error like this:

  fatal: detected dubious ownership in repository at '/build'
  To add an exception for this directory, call:
          git config --global --add safe.directory /build

Could also have solved the problem by doing a --chown=default:root when copying in the files.

Ref: https://issues.redhat.com/browse/EC-625