### PR TITLE
Fix logic for no matching rule

### DIFF
--- a/acceptance/examples/rule_data.rego
+++ b/acceptance/examples/rule_data.rego
@@ -1,15 +1,32 @@
 package main
 
-deny[result] {
-	not data.rule_data__configuration__
+import rego.v1
 
-	result := "No custom rule data"
+# METADATA
+# title: missing data
+# custom:
+#   short_name: missing_data
+#   failure_msg:
+deny contains result if {
+	not data.rule_data__configuration__
+	result := {
+		"code": "main.missing_data",
+		"msg": "No custom rule data"
+	}
 }
 
 rule_data(key) := object.get(data.rule_data__configuration__, key, "")
 
-deny[result] {
+# METADATA
+# title: unexpected data
+# custom:
+#   short_name: unexpected_data
+#   failure_msg: Missing Red Hat manifests
+deny contains result if {
 	count([v | v := [rule_data("custom") == "data1", rule_data("other") == "data2"][_]; v]) != 1
 
-	result := sprintf("Unexpected rule data in custom or other. Data is: %s", [data.rule_data__configuration__])
+	result := {
+		"code": "main.unexpected_data",
+		"msg": sprintf("Unexpected rule data in custom or other. Data is: %s", [data.rule_data__configuration__])
+	}
 }

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -448,6 +448,30 @@ Error: success criteria not met
           "metadata": {
             "code": "builtin.image.signature_check"
           }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.missing_data"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.missing_data"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.unexpected_data"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "main.unexpected_data"
+          }
         }
       ],
       "success": true,

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -473,10 +473,10 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]Out
 		result.Exceptions = exceptions
 		result.Skipped = skipped
 
-		totalRules += len(result.Warnings) + len(result.Failures) + len(result.Successes)
-
 		// Replace the placeholder successes slice with the actual successes.
 		result.Successes = c.computeSuccesses(result, rules, effectiveTime)
+
+		totalRules += len(result.Warnings) + len(result.Failures) + len(result.Successes)
 
 		results = append(results, result)
 	}


### PR DESCRIPTION
If a source group produces no warnings, failures, or successes, we want to raise an error as that is a no-op and likely indicates a typo in the policy configuration.

This commit fix the check by ensuring the total number of matching rules is computed *after* the exclude/include from the policy config is applied.

Ref: EC-583