### PR TITLE
Use /usr/local/bin for container build ec binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,12 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:2636170dc55a0931d013
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY --from=download /download/cosign /usr/bin/cosign
+COPY --from=download /download/cosign /usr/local/bin/cosign
 RUN cosign version
 
 RUN microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
 
 # Copy the one ec binary that can run in this container
-COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/bin/ec
+COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/local/bin/ec
 
-ENTRYPOINT ["/usr/bin/ec"]
+ENTRYPOINT ["/usr/local/bin/ec"]


### PR DESCRIPTION
It seems tidier to put it there rather than in /usr/bin with many other base image binaries. Also it's consistent with the Red Hat Konflux image build.

Ref: https://issues.redhat.com/browse/EC-642