### PR TITLE
Human readable output

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -69,6 +69,8 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		spec                        *app.SnapshotSpec
 		strict                      bool
 		images                      string
+		noColor                     bool
+		forceColor                  bool
 	}{
 		strict: true,
 	}
@@ -402,6 +404,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				return err
 			}
 			p := format.NewTargetParser(applicationsnapshot.JSON, cmd.OutOrStdout(), utils.FS(cmd.Context()))
+			utils.SetColorEnabled(data.noColor, data.forceColor)
 			if err := report.WriteAll(data.output, p); err != nil {
 				return err
 			}
@@ -486,6 +489,12 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		Include additional information on the failures. For instance for policy
 		violations, include the title and the description of the failed policy
 		rule.`))
+
+	cmd.Flags().BoolVar(&data.noColor, "no-color", data.info, hd.Doc(`
+		Disable color when using text output even when the current terminal supports it`))
+
+	cmd.Flags().BoolVar(&data.forceColor, "color", data.info, hd.Doc(`
+		Enable color when using text output even when the current terminal does not support it`))
 
 	if len(data.input) > 0 || len(data.filePath) > 0 || len(data.images) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -115,6 +115,7 @@ Use a regular expression to match certificate attributes.
 --certificate-identity-regexp:: Regular expression for the URL of the certificate identity for keyless verification
 --certificate-oidc-issuer:: URL of the certificate OIDC issuer for keyless verification
 --certificate-oidc-issuer-regexp:: Regular expresssion for the URL of the certificate OIDC issuer for keyless verification
+--color:: Enable color when using text output even when the current terminal does not support it (Default: false)
 --effective-time:: Run policy checks with the provided time. Useful for testing rules with
 effective dates in the future. The value can be "now" (default) - for
 current time, "attestation" - for time from the youngest attestation, or
@@ -131,6 +132,7 @@ a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
 violations, include the title and the description of the failed policy
 rule. (Default: false)
 -j, --json-input:: DEPRECATED - use --images: JSON representation of an ApplicationSnapshot Spec
+--no-color:: Disable color when using text output even when the current terminal supports it (Default: false)
 --output:: write output to a file in a specific format. Use empty string path for stdout.
 May be used multiple times. Possible formats are:
 json, yaml, text, appstudio, summary, summary-markdown, junit, data, attestation, policy-input, vsa.

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -133,7 +133,7 @@ rule. (Default: false)
 -j, --json-input:: DEPRECATED - use --images: JSON representation of an ApplicationSnapshot Spec
 --output:: write output to a file in a specific format. Use empty string path for stdout.
 May be used multiple times. Possible formats are:
-json, yaml, appstudio, summary, summary-markdown, junit, data, attestation, policy-input, vsa.
+json, yaml, text, appstudio, summary, summary-markdown, junit, data, attestation, policy-input, vsa.
  (Default: [])
 -o, --output-file:: [DEPRECATED] write output to a file. Use empty string for stdout, default behavior
 -p, --policy:: Policy configuration as:

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1721,7 +1721,54 @@ Error: success criteria not met
 Error: success criteria not met
 
 ---
+[detailed failures output:${TMPDIR}/output.txt - 1]
+Name:       Unnamed
+ImageRef:   ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
+Summary:    Violations: 3, Warnings: 0, Successes: 4
+Violations:
+[31m✕[0m [31mmain.reject_with_term[0m
+  Fails always (term1)
+  Reject with term rule
+  Description: This rule will always fail. To exclude this rule add
+  "main.reject_with_term:term1" to the `exclude` section of the policy
+  configuration.
+  Solution: None
 
+[31m✕[0m [31mmain.reject_with_term[0m
+  Fails always (term2)
+  Reject with term rule
+  Description: This rule will always fail. To exclude this rule add
+  "main.reject_with_term:term2" to the `exclude` section of the policy
+  configuration.
+  Solution: None
+
+[31m✕[0m [31mmain.rejector[0m
+  Fails always
+  Reject rule
+  Description: This rule will always fail. To exclude this rule add
+  "main.rejector" to the `exclude` section of the policy configuration.
+  Solution: None
+
+Successes:
+[32m✓[0m [32mbuiltin.attestation.signature_check[0m
+  Attestation signature check passed
+  Description: The attestation signature matches available signing materials.
+
+[32m✓[0m [32mbuiltin.attestation.syntax_check[0m
+  Attestation syntax check passed
+  Description: The attestation has correct syntax.
+
+[32m✓[0m [32mbuiltin.image.signature_check[0m
+  Image signature check passed
+  Description: The image signature matches available signing materials.
+
+[32m✓[0m [32mmain.acceptor[0m
+  Allow rule
+  Description: This rule will never fail
+
+
+
+---
 [future failure is a deny when using effective-date flag:stdout - 1]
 {
   "success": false,

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -377,7 +377,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --info --show-successes --output text=${TMPDIR}/output.txt --output json"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --info --show-successes --output text=${TMPDIR}/output.txt --color --output json"
     Then the exit status should be 1
     Then the output should match the snapshot
     # Throw in some test coverage for `--output text` here

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -377,9 +377,11 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --info  --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --info --show-successes --output text=${TMPDIR}/output.txt --output json"
     Then the exit status should be 1
     Then the output should match the snapshot
+    # Throw in some test coverage for `--output text` here
+    And the "${TMPDIR}/output.txt" file should match the snapshot
 
   Scenario: policy rule filtering
     Given a key pair named "known"

--- a/go.mod
+++ b/go.mod
@@ -221,6 +221,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/maruel/natural v1.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -944,6 +944,8 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=

--- a/internal/applicationsnapshot/templates/_results.tmpl
+++ b/internal/applicationsnapshot/templates/_results.tmpl
@@ -1,0 +1,18 @@
+{{- $color := .Color -}}
+{{- $indent := 2 -}}
+{{- $wrap := 78 -}}
+{{- range .Results -}}
+{{- colorIndicator $color }} {{ colorText $color .Metadata.code }}
+{{ if and (ne .Message "Pass") .Message -}}
+  {{- indentWrap $indent $wrap .Message }}
+{{ end -}}
+{{ if .Metadata.title -}}
+  {{- indentWrap $indent $wrap .Metadata.title }}
+{{ end -}}
+{{ if .Metadata.description -}}
+  {{- indentWrap $indent $wrap (printf "Description: %s" .Metadata.description) }}
+{{ end -}}
+{{ if and (ne .Message "Pass") .Metadata.solution -}}
+  {{- indentWrap $indent $wrap (printf "Solution: %s" .Metadata.solution) }}
+{{ end }}
+{{ end -}}

--- a/internal/applicationsnapshot/templates/text_report.tmpl
+++ b/internal/applicationsnapshot/templates/text_report.tmpl
@@ -1,0 +1,17 @@
+{{ range .Components -}}
+Name:       {{ .Name }}
+ImageRef:   {{ .ContainerImage }}
+Summary:    Violations: {{ len .Violations }}, Warnings: {{ len .Warnings }}, Successes: {{ .SuccessCount }}
+{{ if gt (len .Violations) 0 -}}
+Violations:
+{{ template "_results.tmpl" (toMap "Results" .Violations "Color" "red") }}
+{{- end -}}
+{{ if gt (len .Warnings) 0 -}}
+Warnings:
+{{ template "_results.tmpl" (toMap "Results" .Warnings "Color" "yellow") }}
+{{- end -}}
+{{ if and (gt .SuccessCount 0) (.Successes) -}}
+Successes:
+{{ template "_results.tmpl" (toMap "Results" .Successes "Color" "green") }}
+{{- end -}}
+{{- end }}

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -1,0 +1,144 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+// Some wrappers for outputing text using a set of go templates
+// stored as files in a directory and read in using go:embed.
+// Includes a standard set of (hopefully) useful helper functions.
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/mitchellh/go-wordwrap"
+)
+
+const (
+	defaultMainTemplate = "main.tmpl"
+	defaultGlob         = "*/*.tmpl"
+)
+
+func RenderFromTemplates(input any, efs embed.FS) ([]byte, error) {
+	return RenderFromTemplatesWithMain(input, defaultMainTemplate, efs)
+}
+
+func RenderFromTemplatesWithMain(input any, main string, efs embed.FS) ([]byte, error) {
+	return RenderFromTemplatesWithGlob(input, main, []string{defaultGlob}, efs)
+}
+
+func RenderFromTemplatesWithGlob(input any, main string, glob []string, efs embed.FS) ([]byte, error) {
+	// Create blank template
+	t := template.New("_")
+
+	// Bring in helper functions
+	t = t.Funcs(templateHelpers)
+
+	// Bring in all the templates
+	t, err := t.ParseFS(efs, glob...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Render output
+	var buf bytes.Buffer
+	err = t.ExecuteTemplate(&buf, main, input)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return result
+	return buf.Bytes(), nil
+}
+
+// Helper funcs for use in templates
+
+func passWarnFailChooser(color string, choices []string) string {
+	switch strings.ToLower(color) {
+	case "violation", "fail", "red":
+		return choices[0]
+	case "warning", "warn", "yellow":
+		return choices[1]
+	case "success", "pass", "green":
+		return choices[2]
+	default:
+		return choices[3]
+	}
+}
+
+func ansiColorText(code string, str string) string {
+	if code == "" {
+		return str
+	}
+	return fmt.Sprintf("\x1b[%sm%s\x1b[0m", code, str)
+}
+
+// Surround text with ansi color codes
+func colorText(color string, str string) string {
+	code := passWarnFailChooser(color, []string{"31", "33", "32", ""})
+	return ansiColorText(code, str)
+}
+
+// Return one char to indicate a fail/warn/pass
+func indicator(color string) string {
+	return passWarnFailChooser(color, []string{"✕", "›", "✓", "*"})
+}
+
+// Make it color also
+func colorIndicator(color string) string {
+	return colorText(color, indicator(color))
+}
+
+// Wrap text to a certain width
+func wrap(width int, s string) string {
+	return wordwrap.WrapString(s, uint(width))
+}
+
+// Indent with spaces and also wrap
+func indentWrap(indent int, width int, s string) string {
+	indentStr := strings.Repeat(" ", indent)
+	return indentStr + strings.ReplaceAll(wrap(width-indent, s), "\n", "\n"+indentStr)
+}
+
+// A way to assemble a map from keys and values in a template
+func toMap(values ...interface{}) (map[string]interface{}, error) {
+	if len(values)%2 != 0 {
+		return nil, fmt.Errorf("toMap called with an odd number of args")
+	}
+	m := make(map[string]interface{}, len(values)/2)
+	for i := 0; i < len(values); i += 2 {
+		key, ok := values[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("toMap keys must be strings")
+		}
+		m[key] = values[i+1]
+	}
+	return m, nil
+}
+
+// For use in template.Funcs above
+// Todo maybe: Use reflect to find the functions and make this dynamic
+var templateHelpers = template.FuncMap{
+	"colorText":      colorText,
+	"indicator":      indicator,
+	"colorIndicator": colorIndicator,
+	"wrap":           wrap,
+	"indentWrap":     indentWrap,
+	"toMap":          toMap,
+}

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -83,7 +83,7 @@ func passWarnFailChooser(color string, choices []string) string {
 }
 
 func ansiColorText(code string, str string) string {
-	if code == "" {
+	if code == "" || !ColorEnabled {
 		return str
 	}
 	return fmt.Sprintf("\x1b[%sm%s\x1b[0m", code, str)

--- a/internal/utils/templates_test.go
+++ b/internal/utils/templates_test.go
@@ -1,0 +1,39 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package utils
+
+import (
+	"embed"
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed test_templates/*.tmpl
+var testTemplatesFS embed.FS
+
+func TestTemplateRender(t *testing.T) {
+	input := map[string]any{
+		"name": "spam world",
+	}
+	output, err := RenderFromTemplates(input, testTemplatesFS)
+	assert.NoError(t, err)
+	assert.Equal(t, "✓ Hello and bonjour, spam world.\n\n", string(output))
+}

--- a/internal/utils/test_templates/_name.tmpl
+++ b/internal/utils/test_templates/_name.tmpl
@@ -1,0 +1,1 @@
+and {{ .greeting }}, {{ .name }}.

--- a/internal/utils/test_templates/main.tmpl
+++ b/internal/utils/test_templates/main.tmpl
@@ -1,0 +1,1 @@
+{{ indicator "green" }} Hello {{ template "_name.tmpl" (toMap "greeting" "bonjour" "name" .name) }}


### PR DESCRIPTION
Cleaned up and ready for serious review now.

I think this could be merged as is, but it does need some extra work on the following:
* Instead of top level grouping by component, it should be top level grouping by violation/warning/success.
* There should be a way to disable/enable colors, ideally with auto detection of terminal color support (as @zregvart suggested in the review here).

Those could be in followup PRs, or could be included in this one.

Ref: [EC-563](https://issues.redhat.com/browse/EC-563).
