### PR TITLE
Sync params between push and pull Pipelines

### DIFF
--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -21,6 +21,8 @@ spec:
     value: Dockerfile.dist
   - name: git-url
     value: '{{source_url}}'
+  - name: image-expires-after
+    value: ''
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:{{revision}}
   - name: path-context
@@ -31,6 +33,8 @@ spec:
     value: gomod
   - name: build-source-image
     value: 'true'
+  - name: build-args-file
+    value: ''
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This commit adds two parameters to the embedded push build Pipeline, `image-expires-after` and `build-args-file`.

These are used by the pipelineSpec of both push and pull Pipelines. In the push case, those values are empty and effectively a no-op. They are added to both Pipelines simply to facilitate keeping those Pipelines in sync.

Ref: EC-556