### PR TITLE
Don't wrap image ref in text output

### DIFF
--- a/internal/applicationsnapshot/templates/_results.tmpl
+++ b/internal/applicationsnapshot/templates/_results.tmpl
@@ -16,7 +16,7 @@
     {{- colorIndicator $type }} {{ colorText $type (printf "[%s] %s" $type .Metadata.code) }}{{ nl -}}
 
     {{- if $imageRef -}}
-      {{- indentWrap $indent $wrap (printf "ImageRef: %s" $imageRef ) }}{{ nl -}}
+      {{- indent $indent (printf "ImageRef: %s" $imageRef ) }}{{ nl -}}
     {{- end -}}
 
     {{/* For a success the message is generally just "Pass" so don't show it */}}

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -125,10 +125,19 @@ func wrap(width int, s string) string {
 	return wordwrap.WrapString(s, uint(width))
 }
 
+// A string with n spaces
+func indentStr(n int) string {
+	return strings.Repeat(" ", n)
+}
+
+// Indent a certain number of spaces
+func indent(n int, s string) string {
+	return indentStr(n) + s
+}
+
 // Indent with spaces and also wrap
-func indentWrap(indent int, width int, s string) string {
-	indentStr := strings.Repeat(" ", indent)
-	return indentStr + strings.ReplaceAll(wrap(width-indent, s), "\n", "\n"+indentStr)
+func indentWrap(n int, width int, s string) string {
+	return indent(n, strings.ReplaceAll(wrap(width-n, s), "\n", "\n"+indentStr(n)))
 }
 
 // A way to assemble a map from keys and values in a template
@@ -159,6 +168,7 @@ var templateHelpers = template.FuncMap{
 	"indicator":      indicator,
 	"colorIndicator": colorIndicator,
 	"wrap":           wrap,
+	"indent":         indent,
 	"indentWrap":     indentWrap,
 	"toMap":          toMap,
 	"nl":             nl,

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -157,8 +157,8 @@ func toMap(values ...interface{}) (map[string]interface{}, error) {
 }
 
 // Can make it easier to get the right number of line breaks
-func nl() (string, error) {
-	return "\n", nil
+func nl() string {
+	return "\n"
 }
 
 // For use in template.Funcs above


### PR DESCRIPTION
The wrapping only wraps on whitespace, so before this patch we'd end up with output like this for long image refs, which IMO looks untidy. Let's just have an over-long line rather than wrapping it like that.

```
› [Warning] cve.unpatched_cve_warnings
  ImageRef:
  quay.io/redhat-user-workloads/somelong-app-name/some-long-component-name@etc...
```

With the agressive space eating done by -}} and {{- it's easier to keep using the indentWrap helper func rather than try to add the two space indent some other way.

This is a followup tweak for the functionality introduced in #1656.