### PR TITLE
Support multiple terms

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -67,6 +67,10 @@ xref:ec-policies:ROOT:release_policy.adoc#test_package[Test package] emits resul
 test case. A particular test case can be ignored without ignoring the remaining
 ones.
 
+It is also possible that a policy rule emits a list of terms. In such cases, the matcher only needs
+to match one of those terms. For example, if a policy rule emits multiple terms (`a`, `b`, and `c`),
+then a matcher that includes `b` will successfully match it.
+
 A "rule name:term"::
 
 This is similar to "package name:term", but allows finer granularity by only

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -449,6 +449,42 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			},
 		},
 		{
+			name: "exclude by package name with multiple terms",
+			results: []Outcome{
+				{
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"eggs", "sgge"}}},
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.sausage"}},
+						{Metadata: map[string]any{"code": "not_breakfast.spam", "term": []any{"eggs", "sgge"}}},
+					},
+					Warnings: []Result{
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"eggs", "sgge"}}},
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.hash"}},
+						{Metadata: map[string]any{"code": "not_breakfast.ham", "term": []any{"eggs", "sgge"}}},
+					},
+				},
+			},
+			config: &ecc.EnterpriseContractPolicyConfiguration{Exclude: []string{"breakfast:eggs"}},
+			want: []Outcome{
+				{
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.sausage"}},
+						{Metadata: map[string]any{"code": "not_breakfast.spam", "term": []any{"eggs", "sgge"}}},
+					},
+					Warnings: []Result{
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.hash"}},
+						{Metadata: map[string]any{"code": "not_breakfast.ham", "term": []any{"eggs", "sgge"}}},
+					},
+					Skipped:    []Result{},
+					Exceptions: []Result{},
+				},
+			},
+		},
+		{
 			name: "exclude by package name with wildcard and term",
 			results: []Outcome{
 				{
@@ -717,6 +753,38 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 					},
 					Warnings: []Result{
 						{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+					},
+					Skipped:    []Result{},
+					Exceptions: []Result{},
+				},
+			},
+		},
+		{
+			name: "include by package with multiple terms",
+			results: []Outcome{
+				{
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"eggs", "sgge"}}},
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.sausage"}},
+						{Metadata: map[string]any{"code": "not_breakfast.spam", "term": []any{"eggs", "sgge"}}},
+					},
+					Warnings: []Result{
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"eggs", "sgge"}}},
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"bacon", "nocab"}}},
+						{Metadata: map[string]any{"code": "breakfast.hash"}},
+						{Metadata: map[string]any{"code": "not_breakfast.ham", "term": []any{"eggs", "sgge"}}},
+					},
+				},
+			},
+			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast:eggs"}},
+			want: []Outcome{
+				{
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"eggs", "sgge"}}},
+					},
+					Warnings: []Result{
+						{Metadata: map[string]any{"code": "breakfast.ham", "term": []any{"eggs", "sgge"}}},
 					},
 					Skipped:    []Result{},
 					Exceptions: []Result{},
@@ -1147,7 +1215,7 @@ func TestMakeMatchers(t *testing.T) {
 	cases := []struct {
 		name string
 		code string
-		term string
+		term any
 		want []string
 	}{
 		{
@@ -1155,6 +1223,15 @@ func TestMakeMatchers(t *testing.T) {
 			want: []string{
 				"breakfast", "breakfast.*", "breakfast.spam", "breakfast:eggs", "breakfast.*:eggs",
 				"breakfast.spam:eggs", "*",
+			},
+		},
+		{
+			name: "valid with multiple terms", code: "breakfast.spam", term: []any{"eggs", "ham"},
+			want: []string{
+				"breakfast", "breakfast.*", "breakfast.spam",
+				"breakfast:eggs", "breakfast.*:eggs", "breakfast.spam:eggs",
+				"breakfast:ham", "breakfast.*:ham", "breakfast.spam:ham",
+				"*",
 			},
 		},
 		{


### PR DESCRIPTION
Some policy rules emit a list of terms. This commit adds support in the CLI to process those lists.

Ref: EC-666