### PR TITLE
Handle Index Images with no-platoform manifests

### DIFF
--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -221,9 +221,15 @@ func expandImageIndex(ctx context.Context, snap *app.SnapshotSpec) {
 
 		// The image is an image index and accessible so remove the image index itself and add index manifests
 		components = components[:len(components)-1]
-		for _, manifest := range indexManifest.Manifests {
+		for i, manifest := range indexManifest.Manifests {
+			var arch string
+			if manifest.Platform != nil && manifest.Platform.Architecture != "" {
+				arch = manifest.Platform.Architecture
+			} else {
+				arch = fmt.Sprintf("noarch-%d", i)
+			}
 			archComponent := component
-			archComponent.Name = fmt.Sprintf("%s-%s-%s", component.Name, manifest.Digest, manifest.Platform.Architecture)
+			archComponent.Name = fmt.Sprintf("%s-%s-%s", component.Name, manifest.Digest, arch)
 			archComponent.ContainerImage = fmt.Sprintf("%s@%s", ref.Context().Name(), manifest.Digest)
 			components = append(components, archComponent)
 		}


### PR DESCRIPTION
When expending an Image Index into Image Manifests, a component is expanded into pseudo components. These are suffixed with the architecture of the particular Image Manifest. However! The manifest descriptor in an Image Index are not required to provide a platform (where the architecture is defined).

Prior to this commit, such Image Indexes would cause a segfault due to a nil pointer exception. This commit resolves that issue by defaulting to a different value if a platform is not specified.

Fixes #1671
Ref: EC-674