### PR TITLE
Fix Konflux build platform arch (main branch)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ for os_arch in ${BUILDS}; do
     [[ "$GOOS" == "windows" ]] && DOT_EXE=".exe" || DOT_EXE=""
     BINFILE="ec_${GOOS}_${GOARCH}${DOT_EXE}"
     echo "Building ${BINFILE} for ${EC_FULL_VERSION}"
-    go build \
+    GOOS="${GOOS}" GOARCH="${GOARCH}" go build \
         -trimpath \
         --mod=readonly \
         -ldflags="-s -w -X github.com/enterprise-contract/ec-cli/internal/version.Version=${EC_FULL_VERSION}" \


### PR DESCRIPTION
The GOOS and GOARCH env vars need to be set explicitly, otherwise we just build the linux x86 binary over and over. Looks like this regression was introduced in commit b8db99c2.

I think restoring the export on those two vars would also have worked.

Ref: https://issues.redhat.com/browse/SECURESIGN-1054