### PR TITLE
Add support for JSON and YAML files in --extra-rule-data

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -227,12 +227,12 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 					policySpec := p.Spec()
 					sources := policySpec.Sources
 					for i := range sources {
-						source := sources[i]
+						src := sources[i]
 						var rule_data_raw []byte
 						unmarshaled := make(map[string]interface{})
 
-						if source.RuleData != nil {
-							rule_data_raw, err = source.RuleData.MarshalJSON()
+						if src.RuleData != nil {
+							rule_data_raw, err = src.RuleData.MarshalJSON()
 							if err != nil {
 								log.Errorf("Unable to parse ruledata to raw data")
 							}
@@ -249,7 +249,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 							if len(parts) < 2 {
 								log.Errorf("Incorrect syntax for --extra-rule-data")
 							}
-							unmarshaled[parts[0]] = parts[1]
+							extraRuleDataPolicyConfig, err := validate_utils.GetPolicyConfig(ctx, parts[1])
+							if err != nil {
+								log.Errorf("Unable to load data from extraRuleData: %s", err.Error())
+							}
+							unmarshaled[parts[0]] = extraRuleDataPolicyConfig
 						}
 						rule_data_raw, err = json.Marshal(unmarshaled)
 						if err != nil {

--- a/internal/validate/helpers.go
+++ b/internal/validate/helpers.go
@@ -50,11 +50,13 @@ func GetPolicyConfig(ctx context.Context, policyConfiguration string) (string, e
 		if err != nil {
 			return "", err
 		}
-		return readPolicyConfigurationFile(ctx, configFile)
+		log.Debugf("Loading %s as policy configuration", configFile)
+		return ReadFile(ctx, configFile)
 	} else if source.SourceIsFile(policyConfiguration) && utils.HasJsonOrYamlExt(policyConfiguration) {
 		// If policyConfiguration is detected as a file and it has a json or yaml extension,
 		// we read its contents and return it.
-		return readPolicyConfigurationFile(ctx, policyConfiguration)
+		log.Debugf("Loading %s as policy configuration", policyConfiguration)
+		return ReadFile(ctx, policyConfiguration)
 	}
 
 	// If policyConfiguration is not a file path, git url, or https url,
@@ -62,20 +64,18 @@ func GetPolicyConfig(ctx context.Context, policyConfiguration string) (string, e
 	return policyConfiguration, nil
 }
 
-// Read policyConfiguration file and return its contents.
-func readPolicyConfigurationFile(ctx context.Context, policyConfiguration string) (string, error) {
-	// Check if policyConfig is a file path. If so, try to read it.
-	// If successful we write that into the data.policyConfiguration var.
+// Read file from the workspace and return its contents.
+func ReadFile(ctx context.Context, fileName string) (string, error) {
 	fs := utils.FS(ctx)
-	policyBytes, err := afero.ReadFile(fs, policyConfiguration)
+	fileBytes, err := afero.ReadFile(fs, fileName)
 	if err != nil {
 		return "", err
 	}
 	// Check for empty file as that would cause a false "success"
-	if len(policyBytes) == 0 {
-		err := fmt.Errorf("file %s is empty", policyConfiguration)
+	if len(fileBytes) == 0 {
+		err := fmt.Errorf("file %s is empty", fileName)
 		return "", err
 	}
-	log.Debugf("Loaded %s as policyConfiguration", policyConfiguration)
-	return string(policyBytes), nil
+	log.Debugf("Loaded %s", fileName)
+	return string(fileBytes), nil
 }


### PR DESCRIPTION
This commit adds support for specifying filename as value of a key in --extra-rule-data which can be later used in policy checks.

resolves: CVP-4147