### PR TITLE
Use forked version of go-containerregistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,10 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+// use forked version until we can get a fix merged
+// see https://github.com/google/go-containerregistry/pull/1966
+replace github.com/google/go-containerregistry => github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32
+
 require (
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -723,8 +723,6 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-containerregistry v0.19.2 h1:TannFKE1QSajsP6hPWb5oJNgKe1IKjHukIKDUmvsV6w=
-github.com/google/go-containerregistry v0.19.2/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLNb9x9cg=
 github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
 github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
@@ -1304,6 +1302,8 @@ github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
 github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
+github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32 h1:JKVm1/XEri2dBCygARDAE8imzFTUvyAulQoQ43AQCJ4=
+github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=

--- a/internal/utils/oci/__test__/config.json
+++ b/internal/utils/oci/__test__/config.json
@@ -1,0 +1,16 @@
+{
+    "auths": {
+        "registry.io/foo/bar/baz": {
+            "auth": "YmF6OnBhc3N3b3Jk"
+        },
+        "registry.io/foo/bar": {
+            "auth": "YmFyOnBhc3N3b3Jk"
+        },
+        "registry.io/foo": {
+            "auth": "Zm9vOnBhc3N3b3Jk"
+        },
+        "registry.io": {
+            "auth": "cXVheTpwYXNzd29yZA=="
+        }
+    }
+}


### PR DESCRIPTION
This version supports credential lookup according to[1]

Reference: EC-664

[1] https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md#format