### PR TITLE
Fix description text for multi-term exclude advice

### DIFF
--- a/acceptance/examples/reject.rego
+++ b/acceptance/examples/reject.rego
@@ -47,7 +47,7 @@ deny contains result if {
 		},
 		{
 			"code": "main.reject_with_term",
-			"term": "term2",
+			"term": ["term2", "term3"],
 			"collections": ["A"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Fails always (term2)",

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1622,9 +1622,12 @@ Error: success criteria not met
             "collections": [
               "A"
             ],
-            "description": "This rule will always fail. To exclude this rule add \"main.reject_with_term:term2\" to the `exclude` section of the policy configuration.",
+            "description": "This rule will always fail. To exclude this rule add one or more of \"main.reject_with_term:term2\", \"main.reject_with_term:term3\" to the `exclude` section of the policy configuration.",
             "solution": "None",
-            "term": "term2",
+            "term": [
+              "term2",
+              "term3"
+            ],
             "title": "Reject with term rule"
           }
         },
@@ -1741,8 +1744,8 @@ Results:
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always (term2)
   Title: Reject with term rule
-  Description: This rule will always fail. To exclude this rule add "main.reject_with_term:term2" to the `exclude` section of the
-  policy configuration.
+  Description: This rule will always fail. To exclude this rule add one or more of "main.reject_with_term:term2",
+  "main.reject_with_term:term3" to the `exclude` section of the policy configuration.
   Solution: None
 
 [31m✕[0m [31m[Violation] main.rejector[0m


### PR DESCRIPTION
If there is more than one term provided in a violation's metadata, there will now be a correctly formatted exclude config suggestion for each one.

Ref: https://issues.redhat.com/browse/EC-703