### PR TITLE
Support `imageRef` field in `volatileConfig`

### DIFF
--- a/cmd/validate/common_test.go
+++ b/cmd/validate/common_test.go
@@ -40,8 +40,8 @@ type mockEvaluator struct {
 	mock.Mock
 }
 
-func (e *mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
-	args := e.Called(ctx, inputs)
+func (e *mockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
+	args := e.Called(ctx, target.Inputs)
 
 	return args.Get(0).([]evaluator.Outcome), args.Get(1).(evaluator.Data), args.Error(2)
 }

--- a/cmd/validate/image_integration_test.go
+++ b/cmd/validate/image_integration_test.go
@@ -78,7 +78,7 @@ func TestEvaluatorLifecycle(t *testing.T) {
 
 	validate := func(_ context.Context, component app.SnapshotComponent, _ policy.Policy, evaluators []evaluator.Evaluator, _ bool) (*output.Output, error) {
 		for _, e := range evaluators {
-			_, _, err := e.Evaluate(ctx, []string{})
+			_, _, err := e.Evaluate(ctx, evaluator.EvaluationTarget{Inputs: []string{}})
 			require.NoError(t, err)
 		}
 

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -808,6 +808,107 @@ Error: success criteria not met
 
 ---
 
+[policy rule filtering on imageRef:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass_with_collection"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/ec-happy-day}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/ec-happy-day}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/happy-day-policy.git"
+        ],
+        "volatileConfig": {
+          "exclude": [
+            {
+              "value": "filtering.always_fail",
+              "imageRef": "sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}"
+            },
+            {
+              "value": "filtering.always_fail_with_collection",
+              "imageRef": "sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}"
+            }
+          ]
+        }
+      }
+    ],
+    "configuration": {
+      "include": [
+        "@stamps",
+        "filtering.always_pass"
+      ]
+    },
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[policy rule filtering on imageRef:stderr - 1]
+
+---
+
 [application snapshot reference:stdout - 1]
 {
   "success": true,

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -411,6 +411,46 @@ Feature: evaluate enterprise contract
     When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR}  --show-successes"
     Then the exit status should be 0
     Then the output should match the snapshot
+  
+  Scenario: policy rule filtering on imageRef
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | filtering.rego | examples/filtering.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "configuration": {
+        "include": ["@stamps", "filtering.always_pass"]
+      },
+      "sources": [
+        {
+          "volatileConfig": {
+            "exclude": [
+              {
+                "value": "filtering.always_fail",
+                "imageRef": "sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}"
+              },
+              {
+                "value": "filtering.always_fail_with_collection",
+                "imageRef": "sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}"
+              }
+            ]
+          },
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR}  --show-successes"
+    Then the exit status should be 0
+    Then the output should match the snapshot
 
   Scenario: policy rule filtering for successes
     Given a key pair named "known"

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v25.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v25.0.5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 h1:lxmTCgmHE1G
 github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v25.0.3+incompatible h1:KLeNs7zws74oFuVhgZQ5ONGZiXUUdgsdy6/EsX/6284=
 github.com/docker/cli v25.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/internal/definition/validate.go
+++ b/internal/definition/validate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/enterprise-contract/ec-cli/internal/evaluation_target/definition"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/policy/source"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
@@ -45,7 +46,7 @@ func ValidateDefinition(ctx context.Context, fpath string, sources []source.Poli
 		return nil, err
 	}
 
-	results, _, err := p.Evaluator.Evaluate(ctx, defFiles)
+	results, _, err := p.Evaluator.Evaluate(ctx, evaluator.EvaluationTarget{Inputs: defFiles})
 	if err != nil {
 		log.Debug("Problem running conftest policy check!")
 		return nil, err

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -40,7 +40,7 @@ type (
 	badMockEvaluator struct{}
 )
 
-func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+func (e mockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
 	return []evaluator.Outcome{}, nil, nil
 }
 
@@ -51,7 +51,7 @@ func (e mockEvaluator) CapabilitiesPath() string {
 	return ""
 }
 
-func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+func (b badMockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
 	return nil, nil, errors.New("Evaluator error")
 }
 

--- a/internal/evaluator/criteria.go
+++ b/internal/evaluator/criteria.go
@@ -1,0 +1,132 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"fmt"
+	"time"
+
+	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	log "github.com/sirupsen/logrus"
+)
+
+// contains include/exclude items
+// digestItems stores include/exclude items that are specific with an imageRef
+// - the imageRef is the key, value is the policy to include/exclude.
+// defaultItems are include/exclude items without an imageRef
+type Criteria struct {
+	digestItems  map[string][]string
+	defaultItems []string
+}
+
+func (c *Criteria) len() int {
+	totalLength := len(c.defaultItems)
+	for _, items := range c.digestItems {
+		totalLength += len(items)
+	}
+	return totalLength
+}
+
+func (c *Criteria) addItem(key, value string) {
+	if key == "" {
+		c.defaultItems = append(c.defaultItems, value)
+	} else {
+		if c.digestItems == nil {
+			c.digestItems = make(map[string][]string)
+		}
+		c.digestItems[key] = append(c.digestItems[key], value)
+	}
+}
+
+func (c *Criteria) addArray(key string, values []string) {
+	if key == "" {
+		c.defaultItems = append(c.defaultItems, values...)
+	} else {
+		if c.digestItems == nil {
+			c.digestItems = make(map[string][]string)
+		}
+		c.digestItems[key] = append(c.digestItems[key], values...)
+	}
+}
+
+func (c *Criteria) get(key string) []string {
+	if items, ok := c.digestItems[key]; ok {
+		items = append(items, c.defaultItems...)
+		return items
+	}
+	return c.defaultItems
+}
+
+func computeIncludeExclude(src ecc.Source, p ConfigProvider) (*Criteria, *Criteria) {
+	include := &Criteria{}
+	exclude := &Criteria{}
+
+	sc := src.Config
+
+	// The lines below take care to make a copy of the includes/excludes slices in order
+	// to ensure mutations are not unexpectedly propagated.
+	if sc != nil && (len(sc.Include) != 0 || len(sc.Exclude) != 0) {
+		include.addArray("", sc.Include)
+		exclude.addArray("", sc.Exclude)
+	}
+
+	vc := src.VolatileConfig
+	if vc != nil {
+		at := p.EffectiveTime()
+		filter := func(items *Criteria, volatileCriteria []ecc.VolatileCriteria) *Criteria {
+			for _, c := range volatileCriteria {
+				from, err := time.Parse(time.RFC3339, c.EffectiveOn)
+				if err != nil {
+					if c.EffectiveOn != "" {
+						log.Warnf("unable to parse time for criteria %q, was given %q: %v", c.Value, c.EffectiveOn, err)
+					}
+					from = at
+				}
+				until, err := time.Parse(time.RFC3339, c.EffectiveUntil)
+				if err != nil {
+					if c.EffectiveUntil != "" {
+						log.Warnf("unable to parse time for criteria %q, was given %q: %v", c.Value, c.EffectiveUntil, err)
+					}
+					until = at
+				}
+				if until.Compare(at) >= 0 && from.Compare(at) <= 0 {
+					items.addItem(c.ImageRef, c.Value)
+				}
+			}
+
+			return items
+		}
+
+		include = filter(include, vc.Include)
+		exclude = filter(exclude, vc.Exclude)
+	}
+
+	if policyConfig := p.Spec().Configuration; include.len() == 0 && exclude.len() == 0 && policyConfig != nil {
+		include.addArray("", policyConfig.Include)
+		exclude.addArray("", policyConfig.Exclude)
+		// If the old way of specifying collections are used, convert them.
+		for _, collection := range policyConfig.Collections {
+			include.addItem("", fmt.Sprintf("@%s", collection))
+		}
+	}
+
+	if include.len() == 0 {
+		include.addItem("", "*")
+	}
+
+	return include, exclude
+}

--- a/internal/evaluator/criteria_test.go
+++ b/internal/evaluator/criteria_test.go
@@ -1,0 +1,225 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLen(t *testing.T) {
+	tests := []struct {
+		name        string
+		criteria    *Criteria
+		expectedLen int
+	}{
+		{
+			name: "Empty Criteria",
+			criteria: &Criteria{
+				digestItems:  map[string][]string{},
+				defaultItems: []string{},
+			},
+			expectedLen: 0,
+		},
+		{
+			name: "Only Default Items",
+			criteria: &Criteria{
+				digestItems:  map[string][]string{},
+				defaultItems: []string{"default1", "default2"},
+			},
+			expectedLen: 2,
+		},
+		{
+			name: "Only Digest Items",
+			criteria: &Criteria{
+				digestItems: map[string][]string{
+					"key1": {"value1", "value2"},
+					"key2": {"value3"},
+				},
+				defaultItems: []string{},
+			},
+			expectedLen: 3,
+		},
+		{
+			name: "Both Default and Digest Items",
+			criteria: &Criteria{
+				digestItems: map[string][]string{
+					"key1": {"value1", "value2"},
+					"key2": {"value3"},
+				},
+				defaultItems: []string{"default1", "default2"},
+			},
+			expectedLen: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.criteria.len(); got != tt.expectedLen {
+				t.Errorf("Criteria.len() = %d, want %d", got, tt.expectedLen)
+			}
+		})
+	}
+}
+
+func TestAddItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		initial  *Criteria
+		expected *Criteria
+	}{
+		{
+			name:  "Add to defaultItems",
+			key:   "",
+			value: "defaultValue",
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems:  make(map[string][]string),
+			},
+			expected: &Criteria{
+				defaultItems: []string{"defaultValue"},
+				digestItems:  make(map[string][]string),
+			},
+		},
+		{
+			name:  "Add to digestItems",
+			key:   "key1",
+			value: "digestValue1",
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems:  make(map[string][]string),
+			},
+			expected: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1"},
+				},
+			},
+		},
+		{
+			name:  "Add to existing digestItems",
+			key:   "key1",
+			value: "digestValue2",
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1"},
+				},
+			},
+			expected: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1", "digestValue2"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initial.addItem(tt.key, tt.value)
+			require.Equal(t, tt.initial, tt.expected)
+		})
+	}
+}
+
+func TestAddArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		values   []string
+		initial  *Criteria
+		expected *Criteria
+	}{
+		{
+			name:   "Add to defaultItems",
+			key:    "",
+			values: []string{"defaultValue1", "defaultValue2"},
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems:  make(map[string][]string),
+			},
+			expected: &Criteria{
+				defaultItems: []string{"defaultValue1", "defaultValue2"},
+				digestItems:  make(map[string][]string),
+			},
+		},
+		{
+			name:   "Add to digestItems",
+			key:    "key1",
+			values: []string{"digestValue1", "digestValue2"},
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems:  make(map[string][]string),
+			},
+			expected: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1", "digestValue2"},
+				},
+			},
+		},
+		{
+			name:   "Add to existing digestItems",
+			key:    "key1",
+			values: []string{"digestValue2", "digestValue3"},
+			initial: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1"},
+				},
+			},
+			expected: &Criteria{
+				defaultItems: []string{},
+				digestItems: map[string][]string{
+					"key1": {"digestValue1", "digestValue2", "digestValue3"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initial.addArray(tt.key, tt.values)
+			require.Equal(t, tt.initial, tt.expected)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	c := &Criteria{
+		digestItems: map[string][]string{
+			"key1": {"item1", "item2"},
+		},
+		defaultItems: []string{"default1", "default2"},
+	}
+
+	// Test getting items for a key that exists
+	expectedItems := []string{"item1", "item2", "default1", "default2"}
+	assert.ElementsMatch(t, expectedItems, c.get("key1"))
+
+	// Test getting items for a key that does not exist
+	expectedDefaultItems := []string{"default1", "default2"}
+	assert.ElementsMatch(t, expectedDefaultItems, c.get("key2"))
+
+}

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -20,8 +20,13 @@ import (
 	"context"
 )
 
+type EvaluationTarget struct {
+	Inputs []string
+	Target string
+}
+
 type Evaluator interface {
-	Evaluate(ctx context.Context, inputs []string) ([]Outcome, Data, error)
+	Evaluate(ctx context.Context, target EvaluationTarget) ([]Outcome, Data, error)
 
 	// Destroy performs any cleanup needed
 	Destroy()

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -109,7 +109,13 @@ func ValidateImage(ctx context.Context, comp app.SnapshotComponent, p policy.Pol
 
 	for _, e := range evaluators {
 		// Todo maybe: Handle each one concurrently
-		results, data, err := e.Evaluate(ctx, []string{inputPath})
+		target := evaluator.EvaluationTarget{Inputs: []string{inputPath}}
+		if digest, err := a.ResolveDigest(ctx); err != nil {
+			log.Debugf("Problem parsing digest from image")
+		} else {
+			target.Target = digest
+		}
+		results, data, err := e.Evaluate(ctx, target)
 		log.Debug("\n\nRunning conftest policy check\n\n")
 
 		if err != nil {

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -275,8 +275,8 @@ type mockEvaluator struct {
 	mock.Mock
 }
 
-func (e *mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
-	args := e.Called(ctx, inputs)
+func (e *mockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
+	args := e.Called(ctx, target.Inputs)
 
 	return args.Get(0).([]evaluator.Outcome), args.Get(1).(evaluator.Data), args.Error(2)
 }
@@ -300,6 +300,7 @@ func TestEvaluatorLifecycle(t *testing.T) {
 	client.On("Head", ref).Return(&gcr.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
 	client.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 	client.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
+	client.On("ResolveDigest", refNoTag).Return("@sha256:"+imageDigest, nil)
 	ctx = ecoci.WithClient(ctx, &client)
 
 	component := app.SnapshotComponent{

--- a/internal/input/validate.go
+++ b/internal/input/validate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/enterprise-contract/ec-cli/internal/evaluation_target/input"
+	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/output"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
@@ -45,7 +46,7 @@ func ValidateInput(ctx context.Context, fpath string, policy policy.Policy, deta
 		return nil, err
 	}
 
-	results, _, err := p.Evaluator.Evaluate(ctx, inputFiles)
+	results, _, err := p.Evaluator.Evaluate(ctx, evaluator.EvaluationTarget{Inputs: inputFiles})
 	if err != nil {
 		log.Debug("Problem running conftest policy check!")
 		return nil, err

--- a/internal/input/validate_test.go
+++ b/internal/input/validate_test.go
@@ -40,7 +40,7 @@ type (
 	badMockEvaluator struct{}
 )
 
-func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+func (e mockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
 	return []evaluator.Outcome{}, nil, nil
 }
 
@@ -51,7 +51,7 @@ func (e mockEvaluator) CapabilitiesPath() string {
 	return ""
 }
 
-func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]evaluator.Outcome, evaluator.Data, error) {
+func (b badMockEvaluator) Evaluate(ctx context.Context, target evaluator.EvaluationTarget) ([]evaluator.Outcome, evaluator.Data, error) {
 	return nil, nil, errors.New("Evaluator error")
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -722,7 +722,6 @@ func TestJsonSchemaFromPolicySpec(t *testing.T) {
 		PublicKey: "testPublicKey",
 		RekorUrl:  "testRekorUrl",
 	}
-
 	schemaJson, err := jsonSchemaFromPolicySpec(ecp)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Allows restricting the include/exclude configuration to particular image via `imageRef` field in `volatileConfig`.

Reference: EC-631