### PR TITLE
Group all commands when running make acceptance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,21 +100,21 @@ ACCEPTANCE_TIMEOUT:=20m
 .ONESHELL:
 .SHELLFLAGS=-e -c
 .PHONY: acceptance
+
 acceptance: ## Run all acceptance tests
-	@ACCEPTANCE_WORKDIR="$$(mktemp -d)"
-	@function cleanup() {
-	  cp "$${ACCEPTANCE_WORKDIR}"/features/__snapshots__/* "$(ROOT_DIR)"/features/__snapshots__/
-	  #rm -rf "$${ACCEPTANCE_WORKDIR}"
-	}
-	@trap cleanup EXIT
-	@cp -R . "$${ACCEPTANCE_WORKDIR}"
-	@cd "$${ACCEPTANCE_WORKDIR}"
-	@go run acceptance/coverage/coverage.go
-	@$(MAKE) build
-	@export COVERAGE_FILEPATH="$${ACCEPTANCE_WORKDIR}"
-	@export COVERAGE_FILENAME="-acceptance"
-	@cd acceptance && go test -timeout $(ACCEPTANCE_TIMEOUT) ./...
-	@go run -modfile "$${ACCEPTANCE_WORKDIR}/tools/go.mod" github.com/wadey/gocovmerge "$${ACCEPTANCE_WORKDIR}"/coverage-acceptance*.out > "$(ROOT_DIR)/coverage-acceptance.out"
+	@ACCEPTANCE_WORKDIR="$$(mktemp -d)"; \
+	cleanup() { \
+		cp "$${ACCEPTANCE_WORKDIR}"/features/__snapshots__/* "$(ROOT_DIR)"/features/__snapshots__/; \
+	}; \
+	trap cleanup EXIT; \
+	cp -R . "$$ACCEPTANCE_WORKDIR"; \
+	cd "$$ACCEPTANCE_WORKDIR" && \
+	go run acceptance/coverage/coverage.go && \
+	$(MAKE) build && \
+	export COVERAGE_FILEPATH="$$ACCEPTANCE_WORKDIR"; \
+	export COVERAGE_FILENAME="-acceptance"; \
+	cd acceptance && go test -coverprofile "$$ACCEPTANCE_WORKDIR/coverage-acceptance.out" -timeout $(ACCEPTANCE_TIMEOUT) ./... && \
+	go run -modfile "$$ACCEPTANCE_WORKDIR/tools/go.mod" github.com/wadey/gocovmerge "$$ACCEPTANCE_WORKDIR/coverage-acceptance.out" > "$(ROOT_DIR)/coverage-acceptance.out"
 
 # Add @focus above the feature you're hacking on to use this
 # (Mainly for use with the feature-% target below)


### PR DESCRIPTION
For whatever reason the trap command on MacOS causes issues when running make acceptance.