### PR TITLE
Increase Dockerfile consistency between upstream and downstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ FROM docker.io/library/golang:1.21 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILD_SUFFIX=""
+ARG BUILD_LIST="${TARGETOS}_${TARGETARCH}"
 
 WORKDIR /build
 
@@ -30,7 +32,7 @@ RUN go mod download
 # Now copy everything including .git
 COPY . .
 
-RUN /build/build.sh "${TARGETOS}_${TARGETARCH}"
+RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && micr
 COPY --from=build /build/dist/* /usr/local/bin/
 
 # Gzip them because that's what the cli downloader image expects, see
-# https://github.com/securesign/sigstore-ocp/blob/main/images/Dockerfile-clientserver
+# https://github.com/securesign/cosign/blob/main/Dockerfile.client-server-re.rh
 RUN gzip /usr/local/bin/ec_*
 
 # Copy the one ec binary that can run in this container

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ad
 ARG TARGETOS
 ARG TARGETARCH
 
+LABEL \
+  name="ec-cli" \
+  description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
+  io.k8s.description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
+  summary="Provides the binaries for downloading the EC CLI. Also used as a Tekton task runner image for EC tasks. Upstream build." \
+  io.k8s.display-name="Enterprise Contract" \
+  io.openshift.tags="enterprise-contract ec opa cosign sigstore"
+
 RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
 
 # Copy the one ec binary that can run in this container

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -65,7 +65,7 @@ RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && micr
 COPY --from=build /build/dist/* /usr/local/bin/
 
 # Gzip them because that's what the cli downloader image expects, see
-# https://github.com/securesign/sigstore-ocp/blob/main/images/Dockerfile-clientserver
+# https://github.com/securesign/cosign/blob/main/Dockerfile.client-server-re.rh
 RUN gzip /usr/local/bin/ec_*
 
 # Copy the one ec binary that can run in this container

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -51,7 +51,7 @@ LABEL \
   name="ec-cli" \
   description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Enterprise Contract verifies and checks supply chain artifacts to ensure they meet security and business policies." \
-  summary="Provides the binaries for downloading the EC CLI. Also used as a Tekton task runner image for EC tasks." \
+  summary="Provides the binaries for downloading the EC CLI. Also used as a Tekton task runner image for EC tasks. Red Hat build." \
   io.k8s.display-name="Enterprise Contract for Red Hat Trusted Artifact Signer" \
   io.openshift.tags="rhtas rhtap trusted-artifact-signer trusted-application-pipeline enterprise-contract ec opa cosign sigstore" \
   com.redhat.component="ec-cli"

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -21,10 +21,10 @@
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:ae17d73e70a966f39ef4dfca74241e3ca4374cd1198b02c30ea0748b8dcc83a6 AS build
 
-ARG BUILD_SUFFIX="redhat"
-ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILD_SUFFIX="redhat"
+ARG BUILD_LIST="darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 linux_ppc64le linux_s390x windows_amd64"
 
 # Avoid safe directory git failures building with default user from go-toolset
 USER root


### PR DESCRIPTION
I'm not brave enough to try to unify the Dockerfiles in this PR, but this is a step towards doing that, and it should make it easier when/if we do unify them.

It does mean there are some non-useful things happening in the upstream build for the sake of consistency with the downstream build. I feel like that's okay, wdyt?