### PR TITLE
Use the upstream go-wiremock dependency

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/tektoncd/pipeline v0.60.2
 	github.com/testcontainers/testcontainers-go v0.31.0
 	github.com/transparency-dev/merkle v0.0.2
-	github.com/walkerus/go-wiremock v1.7.0
+	github.com/wiremock/go-wiremock v1.9.0
 	github.com/yudai/gojsondiff v1.0.0
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 	gopkg.in/go-jose/go-jose.v2 v2.6.3

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -902,8 +902,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
-github.com/walkerus/go-wiremock v1.7.0 h1:5J83+bKxR6Pam4+S6VwXPHJk3MC2l3jTgleYpRFsORQ=
-github.com/walkerus/go-wiremock v1.7.0/go.mod h1:gMzQpReT5mG5T/PaW8pSFiPhazrcHb1mnf6JHdKwY5w=
+github.com/wiremock/go-wiremock v1.9.0 h1:9xcU4/IoEfgCaH4TGhQTtiQyBh2eMtu9JB6ppWduK+E=
+github.com/wiremock/go-wiremock v1.9.0/go.mod h1:/uvO0XFheyy8XetvQqm4TbNQRsGPlByeNegzLzvXs0c=
 github.com/xanzy/go-gitlab v0.102.0 h1:ExHuJ1OTQ2yt25zBMMj0G96ChBirGYv8U7HyUiYkZ+4=
 github.com/xanzy/go-gitlab v0.102.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/acceptance/wiremock/wiremock.go
+++ b/acceptance/wiremock/wiremock.go
@@ -33,7 +33,7 @@ import (
 	"github.com/otiai10/copy"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"github.com/walkerus/go-wiremock"
+	"github.com/wiremock/go-wiremock"
 
 	"github.com/enterprise-contract/ec-cli/acceptance/log"
 	"github.com/enterprise-contract/ec-cli/acceptance/testenv"


### PR DESCRIPTION
I guess we used the downstream fork to either get a release or a fix. I don't see a reason why we need to do this, the acceptance tests run fine with the upstream version.