### PR TITLE
Inherit Konflux renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "timezone": "America/New_York",
   "schedule": ["before 10pm"],
-  "enabledManagers": ["asdf"]
+  "enabledManagers": ["asdf", "tekton"]
 }


### PR DESCRIPTION
This commit updates the renovate.json config to extend the renovate config provided by Konflux via mintmaker:
https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json

This feature is described here:
https://docs.renovatebot.com/config-presets/#github-hosted-presets

It also adds `tekton` to the list of enabled managers because the config in this repo overwrites that key in order to enable the `asdf` manager.