### PR TITLE
v-e-c: print debug logging at bottom of output

### DIFF
--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -187,6 +187,8 @@ spec:
         - "appstudio=$(results.TEST_OUTPUT.path)"
         - "--output"
         - "json=$(params.HOMEDIR)/report-json.json"
+        - "2>"
+        - "debug.log"
       env:
         - name: SSL_CERT_DIR
           # The Tekton Operator automatically sets the SSL_CERT_DIR env to the value below but,
@@ -239,3 +241,9 @@ spec:
         - >
           .result == "SUCCESS" or .result == "WARNING" or ($strict | not)
         - "$(results.TEST_OUTPUT.path)"
+
+    - name: debug
+      image: quay.io/enterprise-contract/ec-cli:snapshot
+      command: [cat]
+      args:
+        - "debug.log"


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/EC-565

Simple change to the `verify-enterprise-contract` Task that should capture debug output in a file, then print it at the bottom of the output.

This hasn't been tested, so I'm submitting it as a draft.

cc @zregvart 