### PR TITLE
Update forked version of go-containerregistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 
 // use forked version until we can get a fix merged
 // see https://github.com/google/go-containerregistry/pull/1966
-replace github.com/google/go-containerregistry => github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32
+replace github.com/google/go-containerregistry => github.com/zregvart/go-containerregistry v0.0.0-20240726110327-85bb4872bb26
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1334,8 +1334,8 @@ github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
 github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
-github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32 h1:JKVm1/XEri2dBCygARDAE8imzFTUvyAulQoQ43AQCJ4=
-github.com/zregvart/go-containerregistry v0.0.0-20240627132555-cec55a14ea32/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
+github.com/zregvart/go-containerregistry v0.0.0-20240726110327-85bb4872bb26 h1:cX0c9JsDSIMhwef9ZSwkqmb3FaVnpkuoJw9xI7R4pkk=
+github.com/zregvart/go-containerregistry v0.0.0-20240726110327-85bb4872bb26/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=

--- a/internal/utils/oci/client_test.go
+++ b/internal/utils/oci/client_test.go
@@ -109,7 +109,7 @@ func TestImage(t *testing.T) {
 	ref, err := name.ParseReference(fmt.Sprintf("localhost:%s/repository/image:tag", u.Port()))
 	require.NoError(t, err)
 
-	require.NoError(t, remote.Put(ref, img))
+	require.NoError(t, remote.Push(ref, img))
 
 	fetchFully := func() {
 		client := defaultClient{}


### PR DESCRIPTION
The fork has been rebased so this brings in the latest changes to go-containerregistry to make it on par with the changes in acceptance tests in #1784