### PR TITLE
Format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/cli-build.yaml
+++ b/.tekton/cli-build.yaml
@@ -306,8 +306,12 @@ spec:
       params:
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       runAfter:
-        - clone-repository
+        - build-container
       taskRef:
         params:
           - name: name

--- a/.tekton/task-build.yaml
+++ b/.tekton/task-build.yaml
@@ -218,7 +218,7 @@ spec:
     #- Skipping ecosystem-cert-preflight-checks
     - name: sast-snyk-check
       runAfter:
-        - clone-repository
+        - build-container
       taskRef:
         params:
           - name: name
@@ -236,6 +236,11 @@ spec:
       workspaces:
         - name: workspace
           workspace: workspace
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
         - name: image-digest


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263