### PR TITLE
feat(RHTAPWATCH-1039): mount custom certificate

### DIFF
--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -45,6 +45,12 @@ certificates issued by a not-commonly trusted root CA. In such cases,
 `/var/run/secrets/kubernetes.io/serviceaccount` is a good value. Multiple
 paths can be provided by using the `:` separator.
 
+*CA_TRUST_CONFIGMAP_NAME* (`string`):: The name of the ConfigMap to read CA bundle data from.
++
+*Default*: `trusted-ca`
+*CA_TRUST_CONFIG_MAP_KEY* (`string`):: The name of the key in the ConfigMap that contains the CA bundle data.
++
+*Default*: `ca-bundle.crt`
 *INFO* (`string`):: Include rule titles and descriptions in the output. Set to `"false"` to disable it.
 +
 *Default*: `true`

--- a/tasks/verify-enterprise-contract/0.1/README.md
+++ b/tasks/verify-enterprise-contract/0.1/README.md
@@ -17,6 +17,8 @@ kubectl apply -f https://raw.githubusercontent.com/enterprise-contract/ec-cli/ma
 * **REKOR_HOST**: Rekor host for transparency log lookups
 * **SSL_CERT_DIR**: Path to a directory containing SSL certs to be used when communicating
         with external services.
+* **CA_TRUST_CONFIGMAP_NAME**: The name of the ConfigMap to read CA bundle data from.
+* **CA_TRUST_CONFIG_MAP_KEY**: The name of the key in the ConfigMap that contains the CA bundle data.
 * **STRICT**: Fail the task if policy fails. Set to "false" to disable it.
 * **HOMEDIR**: Value for the HOME environment variable.
 * **EFFECTIVE_TIME**: Run policy checks with the provided time.

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -91,6 +91,16 @@ spec:
         paths can be provided by using the `:` separator.
       default: ""
 
+    - name: CA_TRUST_CONFIGMAP_NAME
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+
+    - name: CA_TRUST_CONFIG_MAP_KEY
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+
     - name: INFO
       type: string
       description: Include rule titles and descriptions in the output. Set to `"false"` to disable it.
@@ -207,6 +217,11 @@ spec:
           memory: 2Gi
         limits:
           memory: 2Gi
+      volumeMounts:
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
 
     - name: report
       image: quay.io/enterprise-contract/ec-cli:snapshot
@@ -259,3 +274,12 @@ spec:
         - >
           .result == "SUCCESS" or .result == "WARNING" or ($strict | not)
         - "$(results.TEST_OUTPUT.path)"
+
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.CA_TRUST_CONFIGMAP_NAME)
+        items:
+          - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        optional: true


### PR DESCRIPTION
Introducing optional parameters for referencing a config map containing CA bundle. The certificate is mounted to a location within the path the OS is taking certificates from.