### PR TITLE
fix: allow validate input to handle multiple source groups

### DIFF
--- a/internal/evaluation_target/input/input.go
+++ b/internal/evaluation_target/input/input.go
@@ -30,8 +30,8 @@ var newConftestEvaluator = evaluator.NewConftestEvaluator
 
 // Input represents the structure needed to evaluate a generic file input
 type Input struct {
-	Paths     []string
-	Evaluator evaluator.Evaluator
+	Paths      []string
+	Evaluators []evaluator.Evaluator
 }
 
 // NewInput returns a Input struct with FPath and evaluator ready to use
@@ -59,7 +59,7 @@ func NewInput(ctx context.Context, paths []string, p policy.Policy) (*Input, err
 		}
 
 		log.Debug("Conftest evaluator initialized")
-		i.Evaluator = c
+		i.Evaluators = append(i.Evaluators, c)
 
 	}
 	return i, nil

--- a/internal/input/validate.go
+++ b/internal/input/validate.go
@@ -46,14 +46,28 @@ func ValidateInput(ctx context.Context, fpath string, policy policy.Policy, deta
 		return nil, err
 	}
 
-	results, _, err := p.Evaluator.Evaluate(ctx, evaluator.EvaluationTarget{Inputs: inputFiles})
-	if err != nil {
-		log.Debug("Problem running conftest policy check!")
-		return nil, err
+	var allResults []evaluator.Outcome
+	for _, e := range p.Evaluators {
+		results, _, err := e.Evaluate(ctx, evaluator.EvaluationTarget{Inputs: inputFiles})
+		if err != nil {
+			log.Debug("Problem running conftest policy check!")
+			return nil, err
+		}
+		log.Debug("\n\nRunning conftest policy check\n\n")
+
+		if err != nil {
+			log.Debug("Problem running conftest policy check!")
+			return nil, err
+		}
+		allResults = append(allResults, results...)
 	}
 
 	log.Debug("Conftest policy check complete")
-	return &output.Output{PolicyCheck: results, Detailed: detailed}, nil
+
+	out := output.Output{Detailed: detailed}
+	out.SetPolicyCheck(allResults)
+
+	return &out, nil
 }
 
 // detect if a file or directory was passed. if a directory, gather all files in it

--- a/internal/input/validate_test.go
+++ b/internal/input/validate_test.go
@@ -64,13 +64,13 @@ func (e badMockEvaluator) CapabilitiesPath() string {
 
 func mockNewPipelineDefinitionFile(ctx context.Context, fpath []string, policy policy.Policy) (*input.Input, error) {
 	return &input.Input{
-		Evaluator: mockEvaluator{},
+		Evaluators: []evaluator.Evaluator{mockEvaluator{}},
 	}, nil
 }
 
 func badMockNewPipelineDefinitionFile(ctx context.Context, fpath []string, policy policy.Policy) (*input.Input, error) {
 	return &input.Input{
-		Evaluator: badMockEvaluator{},
+		Evaluators: []evaluator.Evaluator{badMockEvaluator{}},
 	}, nil
 }
 
@@ -91,7 +91,7 @@ func Test_ValidatePipeline(t *testing.T) {
 			name:    "validation succeeds",
 			fpath:   validFile,
 			err:     nil,
-			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome(nil)},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{
@@ -119,14 +119,14 @@ func Test_ValidatePipeline(t *testing.T) {
 			name:    "validation succeeds with json input",
 			fpath:   "{\"json\": 1}",
 			err:     nil,
-			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome(nil)},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{
 			name:    "validation succeeds with yaml input",
 			fpath:   "kind: task",
 			err:     nil,
-			output:  &output.Output{PolicyCheck: []evaluator.Outcome{}},
+			output:  &output.Output{PolicyCheck: []evaluator.Outcome(nil)},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{


### PR DESCRIPTION
Resolves https://github.com/enterprise-contract/ec-cli/issues/1688.

Turns out that the [`NewInput`](https://github.com/enterprise-contract/ec-cli/blob/main/internal/evaluation_target/input/input.go#L38) function only returned the final source group in the policy. This patch makes the function return ALL source groups and changes the caller to evaluate each one, then append all to the output.