### PR TITLE
Remove references to redhat-appstudio org

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -102,11 +102,14 @@
                 "--public-key",
                 "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA\nnaYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==\n-----END PUBLIC KEY-----",
                 "--policy",
-                "{\"configuration\":{\"collections\":[\"minimal\"]},\"sources\":[{\"policy\":[\"oci::quay.io/hacbs-contract/ec-release-policy:git-d995f67@sha256:9d2cffae5ed8a541b4bff1acbaa9bb0b42290214de969e515e78f97b8cf8ff51\"],\"data\":[\"oci::quay.io/hacbs-contract/ec-policy-data:git-d995f67@sha256:eb713f2c0d9c944cbbb298a2c8a0ca1e5a741d149f033b145296d6f550ebd10b\"]}]}",
+                "github.com/enterprise-contract/config//slsa3",
                 "--image",
-                "quay.io/redhat-appstudio/ec-golden-image:latest",
+                "quay.io/konflux-ci/ec-golden-image:latest",
+                "--ignore-rekor",
                 "--output",
-                "data=data.yaml"
+                "data=data.yaml",
+                "--output",
+                "text"
             ]
         },
         {

--- a/hack/pipeline-demo.sh
+++ b/hack/pipeline-demo.sh
@@ -15,6 +15,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BUNDLE="quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:devel"
+BUNDLE="quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
 MAIN_GO=$(git rev-parse --show-toplevel)/main.go
 go run $MAIN_GO validate pipeline --pipeline-file <(tkn bundle list $BUNDLE -o json) | yq -P

--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -29,7 +29,7 @@ HACK_DIR="$(dirname "${BASH_SOURCE[0]}")"
 PIPELINE_SERVICE_ACCOUNT=pipeline
 
 # What pipeline bundle to use
-PIPELINE_BUNDLE=quay.io/redhat-appstudio-tekton-catalog/pipeline-hacbs-docker-build:devel
+PIPELINE_BUNDLE=quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel
 
 # Where to push the image(s)
 IMAGE_REPOSITORY=quay.io/hacbs-contract-demo


### PR DESCRIPTION
This commit removes some more references to the now deprecated redhat-appstudio GitHub and Quay.io organizations. There are some references still in test data which I think is fine to remain.

I also tweaked a bit one of the VSCode launch configurations to use a more recent policy config.