### PR TITLE
Use source.config instead of configuration

### DIFF
--- a/cmd/validate/__snapshots__/image_test.snap
+++ b/cmd/validate/__snapshots__/image_test.snap
@@ -13,20 +13,20 @@
  "effective-time": "1970-01-01T00:00:00Z",
  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
  "policy": {
-  "configuration": {
-   "exclude": [
-    "not_useful",
-    "test:conftest-clair"
-   ],
-   "include": [
-    "always_checked",
-    "@salsa_one_collection"
-   ]
-  },
   "description": "My custom enterprise contract policy configuration",
   "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
   "sources": [
    {
+    "config": {
+     "exclude": [
+      "not_useful",
+      "test:conftest-clair"
+     ],
+     "include": [
+      "always_checked",
+      "@salsa_one_collection"
+     ]
+    },
     "policy": [
      "quay.io/hacbs-contract/ec-release-policy:latest"
     ]
@@ -51,20 +51,20 @@
  "effective-time": "1970-01-01T00:00:00Z",
  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
  "policy": {
-  "configuration": {
-   "exclude": [
-    "not_useful",
-    "test:conftest-clair"
-   ],
-   "include": [
-    "always_checked",
-    "@salsa_one_collection"
-   ]
-  },
   "description": "My custom enterprise contract policy configuration",
   "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECBtqKHcvxYkGx7ZXqps3nrYS+ZSA\nmh3m1MZfTGlnr2oN0z+sBWEC23s4RkVSXkEydI6SLYatUtJK8OmiBRS+Xw==\n-----END PUBLIC KEY-----\n",
   "sources": [
    {
+    "config": {
+     "exclude": [
+      "not_useful",
+      "test:conftest-clair"
+     ],
+     "include": [
+      "always_checked",
+      "@salsa_one_collection"
+     ]
+    },
     "policy": [
      "quay.io/hacbs-contract/ec-release-policy:latest"
     ]

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -429,7 +429,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		  * Kubernetes reference ([<namespace>/]<name>)
 		  * file (policy.yaml)
 		  * git reference (github.com/user/repo//default?ref=main), or
-		  * inline JSON ('{sources: {...}, configuration: {...}}')")`))
+		  * inline JSON ('{sources: {...}, identity: {...}}')")`))
 
 	cmd.Flags().StringVarP(&data.imageRef, "image", "i", data.imageRef, "OCI image reference")
 

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -557,13 +557,13 @@ description: My custom enterprise contract policy configuration
 sources:
   - policy:
       - quay.io/hacbs-contract/ec-release-policy:latest
-configuration:
-  exclude:
-    - not_useful
-    - test:conftest-clair
-  include:
-    - always_checked
-    - "@salsa_one_collection"
+    config:
+      exclude:
+        - not_useful
+        - test:conftest-clair
+      include:
+        - always_checked
+        - "@salsa_one_collection"
 `,
 		},
 		{
@@ -578,13 +578,13 @@ spec:
   sources:
     - policy:
         - quay.io/hacbs-contract/ec-release-policy:latest
-  configuration:
-    exclude:
-      - not_useful
-      - test:conftest-clair
-    include:
-      - always_checked
-      - "@salsa_one_collection"
+      config:
+        exclude:
+          - not_useful
+          - test:conftest-clair
+        include:
+          - always_checked
+          - "@salsa_one_collection"
 `,
 		},
 	}
@@ -669,12 +669,10 @@ func Test_ValidateImageCommandJSONPolicyFile(t *testing.T) {
       - "registry/policy:latest"
     data:
       - "registry/policy-data:latest"
-configuration:
-  collections:
-    - minimal
-  include:
-    - "*"
-  exclude: []
+    config:
+      include:
+        - '@minimal'
+      exclude: []
 `
 	err := afero.WriteFile(fs, "/policy.json", []byte(testPolicyJSON), 0644)
 	if err != nil {
@@ -754,12 +752,10 @@ func Test_ValidateImageCommandExtraData(t *testing.T) {
       custom_rule_data:
         prefix_data:
           - registry1
-configuration:
-  collections:
-    - minimal
-  include:
-    - "*"
-  exclude: []
+    config:
+      include:
+        - '@minimal'
+      exclude: []
 `
 	err := afero.WriteFile(fs, "/policy.json", []byte(testPolicyJSON), 0644)
 	if err != nil {
@@ -820,6 +816,9 @@ spec:
 			"custom_rule_data":{"prefix_data":["registry1"]},
 			"key": "---\nkind: ReleasePlanAdmission\nspec:\n  application: [some-app]\n  data:\n    mapping:\n      components:\n        - name: some-name\n          repository: quay.io/some-namespace/msd\n",
 			"key2": "value2"
+		},
+		"config": {
+		  "include": ["@minimal"]
 		}
 	  }`, string(sourceSampleMarshaled))
 }
@@ -947,12 +946,10 @@ func Test_ValidateImageErrorLog(t *testing.T) {
       - "registry/policy:latest"
     data:
       - "registry/policy-data:latest"
-configuration:
-  collections:
-    - minimal
-  include:
-    - "*"
-  exclude: []
+    config:
+      include:
+        - '@minimal'
+      exclude: []
 `
 	err := afero.WriteFile(fs, "/policy.yaml", []byte(testPolicyJSON), 0644)
 	if err != nil {

--- a/cmd/validate/input.go
+++ b/cmd/validate/input.go
@@ -198,7 +198,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 		Policy configuration as:
 		* file (policy.yaml)
 		* git reference (github.com/user/repo//default?ref=main), or
-		* inline JSON ('{sources: {...}, configuration: {...}}')")`))
+		* inline JSON ('{sources: {...}}')")`))
 
 	validOutputFormats := applicationsnapshot.OutputFormats
 	cmd.Flags().StringSliceVarP(&data.output, "output", "o", data.output, hd.Doc(`

--- a/cmd/validate/policy.go
+++ b/cmd/validate/policy.go
@@ -78,7 +78,7 @@ func ValidatePolicyCmd(validate policyValidationFunc) *cobra.Command {
 	Policy configuration as:
 	* file (policy.yaml)
 	* git reference (github.com/user/repo//default?ref=main), or
-	* inline JSON ('{sources: {...}, configuration: {...}}')")`))
+	* inline JSON ('{sources: {...}}')")`))
 
 	if err := cmd.MarkFlagRequired("policy"); err != nil {
 		panic(err)

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -352,15 +352,15 @@ YAML::
 +
 [source,yaml]
 ----
-configuration:
-  exclude:
-    - test:get-clair-scan
-    - test:clamav-scan
 sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
       - git::https://github.com/enterprise-contract/ec-policies//example/data
+    config:
+      exclude:
+        - test:get-clair-scan
+        - test:clamav-scan
 ----
 JSON::
 +
@@ -563,7 +563,7 @@ The `policy` and `data` fields in the configuration represent the URI of the pol
 
 === Local File
 
-A local file path scheme, such as the following, may be utilized. 
+A local file path scheme, such as the following, may be utilized.
 
 * `file://<path>`
 
@@ -594,7 +594,7 @@ You may also use the `git::` prefix to specify a Git repository URL. The followi
 
 NOTE: In all git URL forms, the `.git` extension is optional.
 
-NOTE: In all git URL forms, the `?ref=<reference>` is optional and defaults to the repository's default branch. 
+NOTE: In all git URL forms, the `?ref=<reference>` is optional and defaults to the repository's default branch.
 
 NOTE: In all git URL forms, the `//<path>` is optional and defaults to the  root of the repository.
 
@@ -632,9 +632,9 @@ An OCI registry URL may be utilized. The following registry hosts have automatic
 You may also use the `oci::` prefix to specify an OCI registry URL:
 
 * `oci://<registry>/<repository>:<tag>`
-* `oci://<registry>/<repository>@<digest>` 
+* `oci://<registry>/<repository>@<digest>`
 * `oci::<registry>/<repository>:<tag>`
-* `oci::<registry>/<repository>:<tag>@<digest>` 
+* `oci::<registry>/<repository>:<tag>@<digest>`
 
 NOTE: the <tag> is optional and defaults to `latest`.
 NOTE: the <digest> is optional and defaults to the latest digest.

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -144,7 +144,7 @@ mark (?) sign, for example: --output text=output.txt?show-successes=false
   * Kubernetes reference ([<namespace>/]<name>)
   * file (policy.yaml)
   * git reference (github.com/user/repo//default?ref=main), or
-  * inline JSON ('{sources: {...}, configuration: {...}}')")
+  * inline JSON ('{sources: {...}, identity: {...}}')")
 -k, --public-key:: path to the public key. Overrides publicKey from EnterpriseContractPolicy
 -r, --rekor-url:: Rekor URL. Overrides rekorURL from EnterpriseContractPolicy
 --snapshot:: Provide the AppStudio Snapshot as a source of the images to validate, as inline

--- a/docs/modules/ROOT/pages/ec_validate_input.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_input.adoc
@@ -54,7 +54,7 @@ mark (?) sign, for example: --output text=output.txt?show-successes=false
 -p, --policy:: Policy configuration as:
 * file (policy.yaml)
 * git reference (github.com/user/repo//default?ref=main), or
-* inline JSON ('{sources: {...}, configuration: {...}}')")
+* inline JSON ('{sources: {...}}')")
 -s, --strict:: Return non-zero status on non-successful validation (Default: true)
 
 == Options inherited from parent commands

--- a/docs/modules/ROOT/pages/ec_validate_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_policy.adoc
@@ -22,7 +22,7 @@ ec validate policy --policy-configuration github.com/org/repo/policy.yaml
 -p, --policy:: Policy configuration as:
 * file (policy.yaml)
 * git reference (github.com/user/repo//default?ref=main), or
-* inline JSON ('{sources: {...}, configuration: {...}}')")
+* inline JSON ('{sources: {...}}')")
 
 == Options inherited from parent commands
 

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -103,13 +103,13 @@ effective-time: "${TIMESTAMP}"
 key: |
 ${__known_PUBLIC_KEY}
 policy:
-  configuration:
-    include:
-    - test.no_test_warnings
   publicKey: |
 ${____known_PUBLIC_KEY}
   sources:
-  - policy:
+  - config:
+      include:
+      - test.no_test_warnings
+    policy:
     - github.com/enterprise-contract/ec-policies//policy/release
     - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
@@ -170,13 +170,13 @@ effective-time: "${TIMESTAMP}"
 key: |
 ${__known_PUBLIC_KEY}
 policy:
-  configuration:
-    include:
-    - test.no_test_warnings
   publicKey: |
 ${____known_PUBLIC_KEY}
   sources:
-  - policy:
+  - config:
+      include:
+      - test.no_test_warnings
+    policy:
     - github.com/enterprise-contract/ec-policies//policy/release
     - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
@@ -258,16 +258,16 @@ key: |
   zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
   -----END PUBLIC KEY-----
 policy:
-  configuration:
-    include:
-    - slsa_provenance_available
   publicKey: |-
     -----BEGIN PUBLIC KEY-----
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
     zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
     -----END PUBLIC KEY-----
   sources:
-  - policy:
+  - config:
+      include:
+      - slsa_provenance_available
+    policy:
     - github.com/enterprise-contract/ec-policies//policy/release
     - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
@@ -349,16 +349,16 @@ key: |
   zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
   -----END PUBLIC KEY-----
 policy:
-  configuration:
-    include:
-    - slsa_provenance_available
   publicKey: |-
     -----BEGIN PUBLIC KEY-----
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
     zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
     -----END PUBLIC KEY-----
   sources:
-  - policy:
+  - config:
+      include:
+      - slsa_provenance_available
+    policy:
     - github.com/enterprise-contract/ec-policies//policy/release
     - github.com/enterprise-contract/ec-policies//policy/lib
     ruleData:
@@ -454,16 +454,16 @@ key: |
   zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
   -----END PUBLIC KEY-----
 policy:
-  configuration:
-    include:
-    - slsa_provenance_available
   publicKey: |-
     -----BEGIN PUBLIC KEY-----
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp
     zN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==
     -----END PUBLIC KEY-----
   sources:
-  - policy:
+  - config:
+      include:
+      - slsa_provenance_available
+    policy:
     - github.com/enterprise-contract/ec-policies//policy/release
     - github.com/enterprise-contract/ec-policies//policy/lib
 success: true
@@ -731,14 +731,14 @@ true
         "policy": [
           "github.com/enterprise-contract/ec-policies//policy/release",
           "github.com/enterprise-contract/ec-policies//policy/lib"
-        ]
+        ],
+        "config": {
+          "include": [
+            "test.no_skipped_tests"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "include": [
-        "test.no_skipped_tests"
-      ]
-    },
     "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEH5DnqwEI3+1Emku0l2j3Iu1hnxdr\nf3GMYMQxVX2YZnoJPf8uDBCw5Nc8+ieMV8ymoDft0gnhPaycAZF7LMPwLQ==\n-----END PUBLIC KEY-----\n"
   },
   "ec-version": "${EC_VERSION}",
@@ -827,14 +827,14 @@ true
         "policy": [
           "github.com/enterprise-contract/ec-policies//policy/release",
           "github.com/enterprise-contract/ec-policies//policy/lib"
-        ]
+        ],
+        "config": {
+          "include": [
+            "test.no_skipped_tests"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "include": [
-        "test.no_skipped_tests"
-      ]
-    },
     "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER5ajiJOZnGNbPCF0TUHRUXIytPW7\nXWB6BaZOE4N0DDK4ub7K6Qe9Q6W/YfI/vEZVZYUjFMcZOih2cmY5ddQhWg==\n-----END PUBLIC KEY-----\n"
   },
   "ec-version": "${EC_VERSION}",
@@ -945,14 +945,14 @@ true
         "policy": [
           "github.com/enterprise-contract/ec-policies//policy/release",
           "github.com/enterprise-contract/ec-policies//policy/lib"
-        ]
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "include": [
-        "slsa_provenance_available"
-      ]
-    },
     "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
   },
   "ec-version": "${EC_VERSION}",
@@ -1063,14 +1063,14 @@ true
         "policy": [
           "github.com/enterprise-contract/ec-policies//policy/release",
           "github.com/enterprise-contract/ec-policies//policy/lib"
-        ]
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "include": [
-        "slsa_provenance_available"
-      ]
-    },
     "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
   },
   "ec-version": "${EC_VERSION}",
@@ -1181,14 +1181,14 @@ true
         "policy": [
           "github.com/enterprise-contract/ec-policies//policy/release",
           "github.com/enterprise-contract/ec-policies//policy/lib"
-        ]
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "include": [
-        "slsa_provenance_available"
-      ]
-    },
     "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
   },
   "ec-version": "${EC_VERSION}",

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -783,19 +783,19 @@ Error: success criteria not met
       {
         "policy": [
           "git::https://${GITHOST}/git/happy-day-policy.git"
-        ]
+        ],
+        "config": {
+          "exclude": [
+            "filtering.always_fail",
+            "filtering.always_fail_with_collection"
+          ],
+          "include": [
+            "@stamps",
+            "filtering.always_pass"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "exclude": [
-        "filtering.always_fail",
-        "filtering.always_fail_with_collection"
-      ],
-      "include": [
-        "@stamps",
-        "filtering.always_pass"
-      ]
-    },
     "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
@@ -877,6 +877,12 @@ Error: success criteria not met
         "policy": [
           "git::https://${GITHOST}/git/happy-day-policy.git"
         ],
+        "config": {
+          "include": [
+            "@stamps",
+            "filtering.always_pass"
+          ]
+        },
         "volatileConfig": {
           "exclude": [
             {
@@ -891,12 +897,6 @@ Error: success criteria not met
         }
       }
     ],
-    "configuration": {
-      "include": [
-        "@stamps",
-        "filtering.always_pass"
-      ]
-    },
     "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },
@@ -1246,19 +1246,19 @@ Error: success criteria not met
       {
         "policy": [
           "git::https://${GITHOST}/git/happy-day-policy.git"
-        ]
+        ],
+        "config": {
+          "exclude": [
+            "filtering.always_pass_with_collection",
+            "filtering.always_fail_with_collection"
+          ],
+          "include": [
+            "@stamps",
+            "filtering.always_pass"
+          ]
+        }
       }
     ],
-    "configuration": {
-      "exclude": [
-        "filtering.always_pass_with_collection",
-        "filtering.always_fail_with_collection"
-      ],
-      "include": [
-        "@stamps",
-        "filtering.always_pass"
-      ]
-    },
     "rekorUrl": "${REKOR}",
     "publicKey": "${known_PUBLIC_KEY}"
   },

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -17,14 +17,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "slsa_provenance_available"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "slsa_provenance_available"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
@@ -47,14 +47,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "slsa_provenance_available"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "slsa_provenance_available"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
@@ -78,14 +78,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "slsa_provenance_available"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "slsa_provenance_available"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
@@ -110,14 +110,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "slsa_provenance_available"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "slsa_provenance_available"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
@@ -147,14 +147,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "test.no_test_warnings"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "test.no_test_warnings"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
@@ -182,14 +182,14 @@ Feature: Verify Enterprise Contract Tekton Tasks
             "policy": [
               "github.com/enterprise-contract/ec-policies//policy/release",
               "github.com/enterprise-contract/ec-policies//policy/lib"
-            ]
+            ],
+            "config": {
+              "include": [
+                "test.no_test_warnings"
+              ]
+            }
           }
-        ],
-        "configuration": {
-          "include": [
-            "test.no_test_warnings"
-          ]
-        }
+        ]
       }
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -395,15 +395,15 @@ Feature: evaluate enterprise contract
     Given policy configuration named "ec-policy" with specification
     """
     {
-      "configuration": {
-        "include": ["@stamps", "filtering.always_pass"],
-        "exclude": ["filtering.always_fail", "filtering.always_fail_with_collection"]
-      },
       "sources": [
         {
           "policy": [
             "git::https://${GITHOST}/git/happy-day-policy.git"
-          ]
+          ],
+          "config": {
+            "include": ["@stamps", "filtering.always_pass"],
+            "exclude": ["filtering.always_fail", "filtering.always_fail_with_collection"]
+          }
         }
       ]
     }
@@ -424,9 +424,6 @@ Feature: evaluate enterprise contract
     Given policy configuration named "ec-policy" with specification
     """
     {
-      "configuration": {
-        "include": ["@stamps", "filtering.always_pass"]
-      },
       "sources": [
         {
           "volatileConfig": {
@@ -440,6 +437,9 @@ Feature: evaluate enterprise contract
                 "imageRef": "sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}"
               }
             ]
+          },
+          "config": {
+            "include": ["@stamps", "filtering.always_pass"]
           },
           "policy": [
             "git::https://${GITHOST}/git/happy-day-policy.git"
@@ -464,15 +464,15 @@ Feature: evaluate enterprise contract
     Given policy configuration named "ec-policy" with specification
     """
     {
-      "configuration": {
-        "include": ["@stamps", "filtering.always_pass"],
-        "exclude": ["filtering.always_pass_with_collection", "filtering.always_fail_with_collection"]
-      },
       "sources": [
         {
           "policy": [
             "git::https://${GITHOST}/git/happy-day-policy.git"
-          ]
+          ],
+          "config": {
+            "include": ["@stamps", "filtering.always_pass"],
+            "exclude": ["filtering.always_pass_with_collection", "filtering.always_fail_with_collection"]
+          }
         }
       ]
     }


### PR DESCRIPTION
The "global" `configuration` is deprecated. Instead, the `config` attribute for a certain policy source should be used.

This commit updates acceptance tests and docs to use the new format.

Ref: EC-688