### PR TITLE
feat(KONFLUX-4136): add new reduce step

### DIFF
--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -70,6 +70,12 @@ paths can be provided by using the `:` separator.
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
 *Default*: `1`
+*SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
++
+*Default*: `false`
+*PIPELINERUN_ID* (`string`):: Name of current PipelineRun.
++
+*Default*: `unknown`
 
 == Results
 

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -135,6 +135,16 @@ spec:
       description: Number of parallel workers to use for policy evaluation.
       default: "1"
 
+    - name: SINGLE_COMPONENT
+      description: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
+      type: string
+      default: "false"
+
+    - name: PIPELINERUN_ID
+      description: Name of current PipelineRun.
+      type: string
+      default: "unknown"
+
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -168,6 +178,67 @@ spec:
         - name: TUF_MIRROR
           value: "$(params.TUF_MIRROR)"
 
+    - name: reduce
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: SNAPSHOT
+          value: $(params.IMAGES)
+        - name: SINGLE_COMPONENT
+          value: $(params.SINGLE_COMPONENT)
+        - name: PIPELINERUN_ID
+          value: $(params.PIPELINERUN_ID)
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        SNAPSHOT_PATH="$(params.HOMEDIR)/snapshot.json"
+
+        echo "Single Component mode? ${SINGLE_COMPONENT}"
+        if [ "${SINGLE_COMPONENT}" == "true" ]; then
+          SNAPSHOT_CREATION_TYPE=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."test.appstudio.openshift.io/type" // ""')
+          SNAPSHOT_CREATION_COMPONENT=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."appstudio.openshift.io/component" // ""')
+
+          echo "SNAPSHOT_CREATION_TYPE: ${SNAPSHOT_CREATION_TYPE}"
+          echo "SNAPSHOT_CREATION_COMPONENT: ${SNAPSHOT_CREATION_COMPONENT}"
+          if [ "${SNAPSHOT_CREATION_TYPE}" == "component" ] && [ "${SNAPSHOT_CREATION_COMPONENT}" != "" ]; then
+            echo "Single Component mode is ${SINGLE_COMPONENT} and Snapshot type is component"
+            # verify if in json form
+            set +e
+            echo "${SNAPSHOT}" | jq -e > /dev/null 2>&1
+            CHECK_JSON=$?
+            set -e
+            if [ "${CHECK_JSON}" != "0" ]; then
+              # try to load as file first
+              set +e
+              cat "${SNAPSHOT}" | jq -e > /dev/null 2>&1
+              CHECK_JSON_FILE=$?
+              set -e
+              if [ "${CHECK_JSON_FILE}" != "0" ]; then
+                echo "Cannot load snapshot from json string or file"
+                exit 1
+              fi
+              SNAPSHOT=$(cat "${SNAPSHOT}")
+            fi
+            REDUCED_SNAPSHOT=$(echo "${SNAPSHOT}" | jq --arg component "${SNAPSHOT_CREATION_COMPONENT}" \
+            'del(.components[] | select(.name != $component))')
+
+            ## make sure we still have 1 component
+            COMPONENT_COUNT=$(echo "$REDUCED_SNAPSHOT" | jq -r '[ .components[] ] | length')
+            echo "COMPONENT_COUNT: ${COMPONENT_COUNT}"
+            if [ "${COMPONENT_COUNT}" != "1" ] ; then
+              echo "Error: Reduced Snapshot has ${COMPONENT_COUNT} components. It should contain 1"
+              echo "       Verify that the Snapshot contains the built component: ${SNAPSHOT_CREATION_COMPONENT}"
+              exit 1
+            fi
+
+            echo "Reducing Snapshot to:"
+            echo "$REDUCED_SNAPSHOT" | jq .
+            SNAPSHOT=$(echo "$REDUCED_SNAPSHOT" | tr -d ' ' | tr -d '\n')
+          fi
+        fi
+
+        echo "$SNAPSHOT" > "${SNAPSHOT_PATH}"
+
     - name: validate
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue # progress even if the step fails so we can see the debug logs
@@ -177,7 +248,7 @@ spec:
         - image
         - "--verbose"
         - "--images"
-        - "$(params.IMAGES)"
+        - "$(params.HOMEDIR)/snapshot.json"
         - "--policy"
         - "$(params.POLICY_CONFIGURATION)"
         - "--public-key"

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -179,66 +179,24 @@ spec:
           value: "$(params.TUF_MIRROR)"
 
     - name: reduce
-      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-      env:
-        - name: SNAPSHOT
+      params:
+        - name: IMAGES
           value: $(params.IMAGES)
         - name: SINGLE_COMPONENT
           value: $(params.SINGLE_COMPONENT)
         - name: PIPELINERUN_ID
           value: $(params.PIPELINERUN_ID)
-      script: |
-        #!/usr/bin/env bash
-        set -eu
-
-        SNAPSHOT_PATH="$(params.HOMEDIR)/snapshot.json"
-
-        echo "Single Component mode? ${SINGLE_COMPONENT}"
-        if [ "${SINGLE_COMPONENT}" == "true" ]; then
-          SNAPSHOT_CREATION_TYPE=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."test.appstudio.openshift.io/type" // ""')
-          SNAPSHOT_CREATION_COMPONENT=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."appstudio.openshift.io/component" // ""')
-
-          echo "SNAPSHOT_CREATION_TYPE: ${SNAPSHOT_CREATION_TYPE}"
-          echo "SNAPSHOT_CREATION_COMPONENT: ${SNAPSHOT_CREATION_COMPONENT}"
-          if [ "${SNAPSHOT_CREATION_TYPE}" == "component" ] && [ "${SNAPSHOT_CREATION_COMPONENT}" != "" ]; then
-            echo "Single Component mode is ${SINGLE_COMPONENT} and Snapshot type is component"
-            # verify if in json form
-            set +e
-            echo "${SNAPSHOT}" | jq -e > /dev/null 2>&1
-            CHECK_JSON=$?
-            set -e
-            if [ "${CHECK_JSON}" != "0" ]; then
-              # try to load as file first
-              set +e
-              cat "${SNAPSHOT}" | jq -e > /dev/null 2>&1
-              CHECK_JSON_FILE=$?
-              set -e
-              if [ "${CHECK_JSON_FILE}" != "0" ]; then
-                echo "Cannot load snapshot from json string or file"
-                exit 1
-              fi
-              SNAPSHOT=$(cat "${SNAPSHOT}")
-            fi
-            REDUCED_SNAPSHOT=$(echo "${SNAPSHOT}" | jq --arg component "${SNAPSHOT_CREATION_COMPONENT}" \
-            'del(.components[] | select(.name != $component))')
-
-            ## make sure we still have 1 component
-            COMPONENT_COUNT=$(echo "$REDUCED_SNAPSHOT" | jq -r '[ .components[] ] | length')
-            echo "COMPONENT_COUNT: ${COMPONENT_COUNT}"
-            if [ "${COMPONENT_COUNT}" != "1" ] ; then
-              echo "Error: Reduced Snapshot has ${COMPONENT_COUNT} components. It should contain 1"
-              echo "       Verify that the Snapshot contains the built component: ${SNAPSHOT_CREATION_COMPONENT}"
-              exit 1
-            fi
-
-            echo "Reducing Snapshot to:"
-            echo "$REDUCED_SNAPSHOT" | jq .
-            SNAPSHOT=$(echo "$REDUCED_SNAPSHOT" | tr -d ' ' | tr -d '\n')
-          fi
-        fi
-
-        echo "$SNAPSHOT" > "${SNAPSHOT_PATH}"
-
+        - name: HOMEDIR
+          value: $(params.HOMEDIR)
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/scoheb/release-service-catalog
+          - name: revision
+            value: single-component-mode
+          - name: pathInRepo
+            value: stepactions/reduce-snapshot/reduce-snapshot.yaml
     - name: validate
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue # progress even if the step fails so we can see the debug logs

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -140,8 +140,8 @@ spec:
       type: string
       default: "false"
 
-    - name: PIPELINERUN_ID
-      description: Name of current PipelineRun.
+    - name: CR_TO_QUERY
+      description: Name of CR to query for labels. for example, pr/somepipeline
       type: string
       default: "unknown"
 
@@ -154,10 +154,17 @@ spec:
     - name: TEST_OUTPUT
       description: Short summary of the policy evaluation for each image
 
-  stepTemplate:
-    env:
-      - name: HOME
-        value: "$(params.HOMEDIR)"
+# due to https://github.com/tektoncd/pipeline/pull/7982 being fixed
+# in a later release of openshift pipelines, we cannot use the following.
+# we must replicate the `env` section to each step.
+# Otherwise, we see the error:
+# "validation.webhook.pipeline.tekton.dev" denied the request: validation failed:
+#   env cannot be used with Ref: spec.steps[1].env
+
+#  stepTemplate:
+#    env:
+#      - name: HOME
+#        value: "$(params.HOMEDIR)"
 
   steps:
 
@@ -177,6 +184,8 @@ spec:
       env:
         - name: TUF_MIRROR
           value: "$(params.TUF_MIRROR)"
+        - name: HOME
+          value: "$(params.HOMEDIR)"
 
     - name: reduce
       params:
@@ -184,10 +193,10 @@ spec:
           value: $(params.IMAGES)
         - name: SINGLE_COMPONENT
           value: $(params.SINGLE_COMPONENT)
-        - name: PIPELINERUN_ID
-          value: $(params.PIPELINERUN_ID)
-        - name: HOMEDIR
-          value: $(params.HOMEDIR)
+        - name: CR_TO_QUERY
+          value: $(params.CR_TO_QUERY)
+#        - name: HOMEDIR
+#          value: $(params.HOMEDIR)
       ref:
         resolver: git
         params:
@@ -247,6 +256,8 @@ spec:
         # files from an image, see https://github.com/enterprise-contract/ec-cli/issues/1109
         - name: EC_CACHE
           value: "false"
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       computeResources:
         requests:
           cpu: 250m
@@ -263,6 +274,9 @@ spec:
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [cat]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - "$(params.HOMEDIR)/report.yaml"
 
@@ -270,6 +284,9 @@ spec:
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [cat]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - "$(params.HOMEDIR)/report-json.json"
 
@@ -277,6 +294,9 @@ spec:
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [jq]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - "."
         - "$(results.TEST_OUTPUT.path)"
@@ -284,12 +304,18 @@ spec:
     - name: info
       image: quay.io/enterprise-contract/ec-cli:snapshot
       command: [printf]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - "----- DEBUG OUTPUT -----\n"
 
     - name: version
       image: quay.io/enterprise-contract/ec-cli:snapshot
       command: [ec]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - version
 
@@ -302,6 +328,9 @@ spec:
     - name: assert
       image: quay.io/enterprise-contract/ec-cli:snapshot
       command: [jq]
+      env:
+        - name: HOME
+          value: "$(params.HOMEDIR)"
       args:
         - "--argjson"
         - "strict"


### PR DESCRIPTION
- Introducing **Single Component Mode**
  - See KONFLUX-4059

- This step, if activated by the SINGLE_COMPONENT parameter and a valid pipelinerun name, will attempt to reduce the incoming snapshot to contain a single component. That component being the one that caused the snapshot to create for.
- This is determined by examining the labels of the currently running pipelinerun:

```
appstudio.openshift.io/component: acb-service
test.appstudio.openshift.io/type: component
```

- This tells you that the underlying snapshot for this Test was created by a `component` that was recently built called `abc-service`

NOTE: This requires https://github.com/redhat-appstudio/infra-deployments/pull/4413