### PR TITLE
EC-806 Ensure ec uses go-gather by default

### DIFF
--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -21,7 +21,6 @@ package downloader
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/enterprise-contract/go-gather/metadata"
@@ -46,26 +45,11 @@ func TestDownloader_Download(t *testing.T) {
 		source      string
 		errExpected bool
 		err         error
-		useGoGather bool
 	}{
 		{
 			name:   "Downloads",
 			dest:   "dir",
 			source: "https://example.com/org/repo.git",
-		},
-		{
-			name:        "Downloads with go-gather",
-			dest:        "dir",
-			source:      "https://example.com/org/repo.git",
-			useGoGather: true,
-		},
-		{
-			name:        "Fails to download with go-gather",
-			dest:        "dir",
-			source:      "https://example.com/org/repo.git",
-			errExpected: true,
-			err:         errors.New("expected error with go-gather"),
-			useGoGather: true,
 		},
 		{
 			name:        "Fails to download",
@@ -93,14 +77,8 @@ func TestDownloader_Download(t *testing.T) {
 				gatherFunc = originalGatherFunction
 			}()
 
-			if tt.useGoGather {
-				t.Setenv("USEGOGATHER", "1")
-				gatherFunc = func(_ context.Context, _ string, _ string) (metadata.Metadata, error) {
-					return nil, tt.err
-				}
-			} else {
-				os.Unsetenv("USEGOGATHER")
-				d.On("Download", ctx, tt.dest, []string{tt.source}).Return(tt.err)
+			gatherFunc = func(_ context.Context, _ string, _ string) (metadata.Metadata, error) {
+				return nil, tt.err
 			}
 
 			_, err := Download(ctx, tt.dest, tt.source, false)

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -124,10 +124,6 @@ func Experimental() bool {
 	return os.Getenv("EC_EXPERIMENTAL") == "1"
 }
 
-func UseGoGather() bool {
-	return os.Getenv("USEGOGATHER") == "1"
-}
-
 // detect if the string is json
 func IsJson(data string) bool {
 	var jsMsg json.RawMessage


### PR DESCRIPTION
This commit removes the check for the env var `USEGOGATHER` and instead has ec use the go-gather downloader. As we've previously verified that the data downloaded by go-gather matches the information used via the prior downloader implementation, the corresponding downloader code has been removed in `internal/downloader/downloader.go`. The associated tests in `internal/downloader/downloader_test.go` has been updated. Additionally, since we're no longer using branching logic to determine if we should use go-gather for downloading, the `UseGoGather` function in `internal/utils/helpers.go` has been removed.