### PR TITLE
Don't produce error output for invalid purl checks

### DIFF
--- a/acceptance/examples/purl.rego
+++ b/acceptance/examples/purl.rego
@@ -18,6 +18,18 @@ deny contains result if {
 
 # METADATA
 # custom:
+#   short_name: parse_fail
+deny contains result if {
+    # This will emit a failure too but this time an error is logged
+    not ec.purl.parse(_bad)
+    result := {
+        "code": "purl.parse_fail",
+        "msg": sprintf("PURL can't be parsed %q", [_bad])
+    }
+}
+
+# METADATA
+# custom:
 #   short_name: is_valid_pass
 deny contains result if {
     # This rule never emits a failure

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -3580,6 +3580,12 @@ Error: 1 error occurred:
           }
         },
         {
+          "msg": "PURL can't be parsed \"this-is-not-a-valid-purl\"",
+          "metadata": {
+            "code": "purl.parse_fail"
+          }
+        },
+        {
           "msg": "PURL parsed as: type: \"rpm\", namespace: \"rhel\", name: \"coreutils-single\", version: \"8.32-34.el9\", qualifiers: \"[{\\\"key\\\": \\\"arch\\\", \\\"value\\\": \\\"x86_64\\\"}, {\\\"key\\\": \\\"distro\\\", \\\"value\\\": \\\"rhel-9.3\\\"}, {\\\"key\\\": \\\"upstream\\\", \\\"value\\\": \\\"coreutils-8.32-34.el9.src.rpm\\\"}]\", subpath: \"\"",
           "metadata": {
             "code": "purl.parsed"
@@ -3652,6 +3658,7 @@ Error: 1 error occurred:
 ---
 
 [PURL functions:stderr - 1]
+time="${TIMESTAMP}" level=error msg="Parsing PURL \"this-is-not-a-valid-purl\" failed: purl scheme is not \"pkg\": \"\""
 Error: success criteria not met
 
 ---

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -3652,7 +3652,6 @@ Error: 1 error occurred:
 ---
 
 [PURL functions:stderr - 1]
-time="${TIMESTAMP}" level=error msg="Parsing PURL \"this-is-not-a-valid-purl\" failed: purl scheme is not \"pkg\": \"\""
 Error: success criteria not met
 
 ---

--- a/internal/rego/purl/purl.go
+++ b/internal/rego/purl/purl.go
@@ -114,7 +114,7 @@ func purlIsValid(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 	}
 	_, err := packageurl.FromString(string(uri))
 	if err != nil {
-		log.Errorf("Parsing PURL %s failed: %s", uri, err)
+		log.Debugf("Parsing PURL %s failed: %s", uri, err)
 		return ast.BooleanTerm(false), nil
 	}
 	return ast.BooleanTerm(true), nil


### PR DESCRIPTION
I noticed the error output in when running the unit test in https://github.com/enterprise-contract/ec-policies/pull/1126

It seems like this should not be an error. Since the purpose of this method is to decide if the purl is valid, quietly returning false if it is invalid would be all that it should do. Logging an error seems unexpected.

(For the parse functon I didn't change it. My reasoning is that if you call parse then you're expecting it to be parseable. If it fails at that point then it's unexpected, so logging an error does seem reasonable in that case.)

Tangentially related to...
Ref: https://issues.redhat.com/browse/EC-847