### PR TITLE
Declutter make test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,20 @@ clean: ## Delete build output
 
 ##@ Testing
 
+# Declutter the output by grepping out the files where there are no
+# tests at all, or no tests matching the specified tag
+TEST_OUTPUT_FILTER=grep -vE '0.0% of statements|\[no test files\]'
+
 .PHONY: test
 test: ## Run all unit tests
 	@echo "Unit tests:"
-	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./...
+	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
 	@echo "Integration tests:"
-	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | grep -v '\[no test files\]'
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | $(TEST_OUTPUT_FILTER)
 # Given the nature of generative tests the test timeout is increased from 500ms
 # to 30s to accommodate many samples being generated and test cases being run.
 	@echo "Generative tests:"
-	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-generative.out -timeout 30s -tags=generative ./... | grep -v '\[no test files\]'
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-generative.out -timeout 30s -tags=generative ./... | $(TEST_OUTPUT_FILTER)
 
 ACCEPTANCE_TIMEOUT:=20m
 .ONESHELL:


### PR DESCRIPTION
Particularly for the integration and generative test output, this reduces the clutter by filtering out the files that don't have tests.