### PR TITLE
Use errors in place of hashicorp/go-multierror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ TEST_OUTPUT_FILTER=grep -vE '0.0% of statements|\[no test files\]'
 .PHONY: test
 test: ## Run all unit tests
 	@echo "Unit tests:"
-	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
 	@echo "Integration tests:"
 	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | $(TEST_OUTPUT_FILTER)
 # Given the nature of generative tests the test timeout is increased from 500ms

--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/cucumber/godog"
 	c "github.com/doiit/picocolors"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/diff"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
@@ -740,7 +739,7 @@ func matchSnapshot(ctx context.Context) error {
 		return nil
 	}
 
-	return multierror.Append(stdout, stderr)
+	return errors.Join(stdout, stderr)
 }
 
 func matchFileSnapshot(ctx context.Context, file string) error {

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/go-containerregistry v0.20.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.9.1-0.20240317085821-8e2966059a09
 	github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409
 	github.com/otiai10/copy v1.14.0
@@ -126,6 +125,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.4 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/enterprise-contract/ec-cli/acceptance/testenv"
 )
@@ -74,8 +73,7 @@ func (e errCapture) Name() string {
 
 func (e *errCapture) Error(args ...interface{}) {
 	err := errors.New(fmt.Sprint(args...))
-	var merr error = multierror.Append(e.err, err)
-	e.err = merr
+	e.err = errors.Join(e.err, err)
 }
 
 func (e errCapture) Log(args ...interface{}) {

--- a/cmd/validate/definition.go
+++ b/cmd/validate/definition.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
 	"github.com/enterprise-contract/ec-cli/internal/definition"
@@ -97,7 +96,7 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 				}
 				ctx := cmd.Context()
 				if out, err := validate(ctx, fpath, sources, data.namespaces); err != nil {
-					allErrors = multierror.Append(allErrors, err)
+					allErrors = errors.Join(allErrors, err)
 				} else {
 					if !showSuccesses {
 						for i := range out.PolicyCheck {
@@ -110,7 +109,7 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 			p := format.NewTargetParser(definition.JSONReport, format.Options{ShowSuccesses: showSuccesses}, cmd.OutOrStdout(), utils.FS(cmd.Context()))
 			for _, target := range data.output {
 				if err := report.Write(target, p); err != nil {
-					allErrors = multierror.Append(allErrors, err)
+					allErrors = errors.Join(allErrors, err)
 				}
 			}
 			if allErrors != nil {

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -216,7 +216,7 @@ func TestValidateDefinitionFileCommandErrors(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-	assert.Error(t, err, "2 errors occurred:\n\t* /path/file1.yaml\n\t* /path/file2.yaml\n")
+	assert.Error(t, err, "/path/file1.yaml\n/path/file2.yaml\n")
 	assert.Equal(t, "Command \"definition\" is deprecated, please use \"ec validate input\" instead.\n", out.String())
 }
 

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/hashicorp/go-multierror"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	log "github.com/sirupsen/logrus"
@@ -197,14 +196,14 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				Snapshot: data.snapshot,
 				Images:   data.images,
 			}); err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 			} else {
 				data.spec = s
 			}
 
 			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)
 			if err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 				return
 			}
 			data.policyConfiguration = policyConfiguration
@@ -222,7 +221,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				PublicKey:   data.publicKey,
 				RekorURL:    data.rekorURL,
 			}); err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 			} else {
 				// inject extra variables into rule data per source
 				if len(data.extraRuleData) > 0 {
@@ -385,7 +384,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				r := <-results
 				if r.err != nil {
 					e := fmt.Errorf("error validating image %s of component %s: %w", r.component.ContainerImage, r.component.Name, r.err)
-					allErrors = multierror.Append(allErrors, e)
+					allErrors = errors.Join(allErrors, e)
 				} else {
 					components = append(components, r.component)
 					manyData = append(manyData, r.data)

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -727,7 +727,7 @@ func Test_ValidateImageCommandEmptyPolicyFile(t *testing.T) {
 	utils.SetTestRekorPublicKey(t)
 
 	err = cmd.Execute()
-	assert.EqualError(t, err, "1 error occurred:\n\t* file /policy.yaml is empty\n\n")
+	assert.EqualError(t, err, "file /policy.yaml is empty")
 }
 
 func Test_ValidateImageErrorLog(t *testing.T) {
@@ -814,10 +814,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 				"--policy",
 				fmt.Sprintf(`{"publicKey": %s}`, utils.TestPublicKeyJSON),
 			},
-			expected: `1 error occurred:
-	* error validating image registry/image:tag of component Unnamed: expected
-
-`,
+			expected: `error validating image registry/image:tag of component Unnamed: expected`,
 		},
 		{
 			name: "invalid policy JSON",
@@ -827,10 +824,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 				"--policy",
 				`{"invalid": "json""}`,
 			},
-			expected: `1 error occurred:
-	* unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream
-
-`,
+			expected: `unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream`,
 		},
 		{
 			name: "invalid input JSON",
@@ -840,10 +834,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 				"--policy",
 				fmt.Sprintf(`{"publicKey": %s}`, utils.TestPublicKeyJSON),
 			},
-			expected: `1 error occurred:
-	* unable to parse Snapshot specification from {"invalid": "json""}: error converting YAML to JSON: yaml: found unexpected end of stream
-
-`,
+			expected: `unable to parse Snapshot specification from {"invalid": "json""}: error converting YAML to JSON: yaml: found unexpected end of stream`,
 		},
 		{
 			name: "invalid input and policy JSON",
@@ -853,11 +844,8 @@ func Test_ValidateErrorCommand(t *testing.T) {
 				"--policy",
 				`{"invalid": "json""}`,
 			},
-			expected: `2 errors occurred:
-	* unable to parse Snapshot specification from {"invalid": "json""}: error converting YAML to JSON: yaml: found unexpected end of stream
-	* unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream
-
-`,
+			expected: `unable to parse Snapshot specification from {"invalid": "json""}: error converting YAML to JSON: yaml: found unexpected end of stream
+unable to parse EnterpriseContractPolicySpec: error converting YAML to JSON: yaml: found unexpected end of stream`,
 		},
 	}
 	for _, c := range cases {

--- a/cmd/validate/input.go
+++ b/cmd/validate/input.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
 	"github.com/enterprise-contract/ec-cli/internal/applicationsnapshot"
@@ -90,13 +89,13 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 
 			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)
 			if err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 				return
 			}
 			data.policyConfiguration = policyConfiguration
 
 			if p, err := policy.NewInputPolicy(cmd.Context(), data.policyConfiguration, data.effectiveTime); err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 			} else {
 				data.policy = p
 			}
@@ -158,7 +157,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 			for r := range ch {
 				if r.err != nil {
 					e := fmt.Errorf("error validating file %s: %w", r.input.FilePath, r.err)
-					allErrors = multierror.Append(allErrors, e)
+					allErrors = errors.Join(allErrors, e)
 				} else {
 					inputs = append(inputs, r.input)
 					manyData = append(manyData, r.data)

--- a/cmd/validate/policy.go
+++ b/cmd/validate/policy.go
@@ -18,10 +18,10 @@ package validate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	hd "github.com/MakeNowJust/heredoc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
 	validate_utils "github.com/enterprise-contract/ec-cli/internal/validate"
@@ -55,7 +55,7 @@ func ValidatePolicyCmd(validate policyValidationFunc) *cobra.Command {
 
 			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)
 			if err != nil {
-				allErrors = multierror.Append(allErrors, err)
+				allErrors = errors.Join(allErrors, err)
 				return
 			}
 			data.policyConfiguration = policyConfiguration

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1276,10 +1276,7 @@ Error: success criteria not met
 ---
 
 [happy day with missing git config:stderr - 1]
-Error: 1 error occurred:
-    * no suitable config file found at git::https://${GITHOST}/git/happy-config.git
-
-
+Error: no suitable config file found at git::https://${GITHOST}/git/happy-config.git
 
 ---
 
@@ -2042,13 +2039,10 @@ Error: success criteria not met
 ---
 
 [Dropping rego capabilities:stderr - 1]
-Error: 1 error occurred:
-    * error validating image ${REGISTRY}/acceptance/ec-happy-day of component Unnamed: load: loading policies: get compiler: 3 errors occurred:
+Error: error validating image ${REGISTRY}/acceptance/ec-happy-day of component Unnamed: load: loading policies: get compiler: 3 errors occurred:
 ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:15: rego_type_error: undefined function opa.runtime
 ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:23: rego_type_error: undefined function http.send
 ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:34: rego_type_error: undefined function net.lookup_ip_addr
-
-
 
 ---
 
@@ -3112,10 +3106,7 @@ Error: success criteria not met
 ---
 
 [Unsupported policies:stderr - 1]
-Error: 1 error occurred:
-    * error validating image ${REGISTRY}/acceptance/image of component Unnamed: the rule "deny = true { true }" returns an unsupported value, at main.rego:3
-
-
+Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed: the rule "deny = true { true }" returns an unsupported value, at main.rego:3
 
 ---
 

--- a/features/__snapshots__/validate_input.snap
+++ b/features/__snapshots__/validate_input.snap
@@ -34,10 +34,7 @@
 ---
 
 [policy URL with no rego files:stderr - 1]
-Error: 1 error occurred:
-    * error validating file pipeline_definition.yaml: evaluating policy: no rego files found in policy subdirectory
-
-
+Error: error validating file pipeline_definition.yaml: evaluating policy: no rego files found in policy subdirectory
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/google/go-containerregistry v0.20.2
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hashicorp/go-getter v1.7.6
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
@@ -222,6 +221,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/hashicorp/go-multierror"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -193,13 +192,13 @@ func expandImageIndex(ctx context.Context, snap *app.SnapshotSpec) {
 		components = append(components, component)
 		ref, err := name.ParseReference(component.ContainerImage)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, fmt.Errorf("unable to parse container image %s: %w", component.ContainerImage, err))
+			allErrors = errors.Join(allErrors, fmt.Errorf("unable to parse container image %s: %w", component.ContainerImage, err))
 			continue
 		}
 
 		desc, err := client.Head(ref)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, fmt.Errorf("unable to fetch descriptior for container image %s: %w", ref, err))
+			allErrors = errors.Join(allErrors, fmt.Errorf("unable to fetch descriptior for container image %s: %w", ref, err))
 			continue
 		}
 
@@ -209,13 +208,13 @@ func expandImageIndex(ctx context.Context, snap *app.SnapshotSpec) {
 
 		index, err := client.Index(ref)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, fmt.Errorf("unable to fetch index for container image %s: %w", component.ContainerImage, err))
+			allErrors = errors.Join(allErrors, fmt.Errorf("unable to fetch index for container image %s: %w", component.ContainerImage, err))
 			continue
 		}
 
 		indexManifest, err := index.IndexManifest()
 		if err != nil {
-			allErrors = multierror.Append(allErrors, fmt.Errorf("unable to fetch index manifest for container image %s: %w", component.ContainerImage, err))
+			allErrors = errors.Join(allErrors, fmt.Errorf("unable to fetch index manifest for container image %s: %w", component.ContainerImage, err))
 			continue
 		}
 

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -21,11 +21,11 @@ import (
 	"embed"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"time"
 
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	"github.com/hashicorp/go-multierror"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"sigs.k8s.io/yaml"
 
@@ -171,14 +171,14 @@ func (r Report) WriteAll(targets []string, p format.TargetParser) (allErrors err
 	for _, targetName := range targets {
 		target, err := p.Parse(targetName)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 			continue
 		}
 		r.applyOptions(target.Options)
 
 		data, err := r.toFormat(target.Format)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 			continue
 		}
 
@@ -187,7 +187,7 @@ func (r Report) WriteAll(targets []string, p format.TargetParser) (allErrors err
 		}
 
 		if _, err := target.Write(data); err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 		}
 	}
 	return

--- a/internal/image/process.go
+++ b/internal/image/process.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/hashicorp/go-multierror"
 )
 
 type key string
@@ -58,7 +58,7 @@ func ParseAndResolveAll(ctx context.Context, urls []string, opts ...name.Option)
 	for _, url := range urls {
 		ref, err := ParseAndResolve(ctx, url, opts...)
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 

--- a/internal/image/process_test.go
+++ b/internal/image/process_test.go
@@ -96,7 +96,9 @@ func TestParseAndResolveAll(t *testing.T) {
 				"registry.com/repo:good@" + testHash.String(),
 			},
 			opts: []name.Option{name.StrictValidation},
-			err:  "3 errors occurred",
+			err: `could not parse reference: registry.com/one@sha256:123
+could not parse reference: registry/two@` + testHash.String() + `
+could not parse reference: three.com@` + testHash.String(),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/input/report.go
+++ b/internal/input/report.go
@@ -19,11 +19,11 @@ package input
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	"github.com/hashicorp/go-multierror"
 	"sigs.k8s.io/yaml"
 
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
@@ -125,13 +125,13 @@ func (r Report) WriteAll(targets []string, p format.TargetParser) (allErrors err
 	for _, targetName := range targets {
 		target, err := p.Parse(targetName)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 			continue
 		}
 
 		data, err := r.toFormat(target.Format)
 		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 			continue
 		}
 
@@ -140,7 +140,7 @@ func (r Report) WriteAll(targets []string, p format.TargetParser) (allErrors err
 		}
 
 		if _, err := target.Write(data); err != nil {
-			allErrors = multierror.Append(allErrors, err)
+			allErrors = errors.Join(allErrors, err)
 		}
 	}
 	return

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	"github.com/hashicorp/go-multierror"
 	schemaExporter "github.com/invopop/jsonschema"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
@@ -405,7 +404,7 @@ func parseEffectiveTime(choosenTime string) (*time.Time, error) {
 		}
 
 		log.Debugf("Unable to parse provided effective time `%s` using RFC3339", choosenTime)
-		errs := multierror.Append(err)
+		errs := err
 
 		if when, err := time.Parse(DateFormat, choosenTime); err == nil {
 			log.Debugf("Using provided effective time %s", when.Format(time.RFC3339))
@@ -413,7 +412,7 @@ func parseEffectiveTime(choosenTime string) (*time.Time, error) {
 			return &whenUTC, nil
 		}
 		log.Debugf("Unable to parse provided effective time string `%s` using %s format", choosenTime, DateFormat)
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 
 		return nil, fmt.Errorf("invalid policy time argument: %s", errs)
 	}
@@ -530,12 +529,12 @@ func validateIdentity(identity cosign.Identity) error {
 	var errs error
 
 	if identity.Issuer == "" && identity.IssuerRegExp == "" {
-		errs = multierror.Append(errs, errors.New(
+		errs = errors.Join(errs, errors.New(
 			"certificate OIDC issuer must be provided for keyless workflow"))
 	}
 
 	if identity.Subject == "" && identity.SubjectRegExp == "" {
-		errs = multierror.Append(errs, errors.New(
+		errs = errors.Join(errs, errors.New(
 			"certificate identity must be provided for keyless workflow"))
 	}
 

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -134,7 +134,7 @@ func TestSigstoreVerifyImage(t *testing.T) {
 			name:    "insufficient options",
 			success: ast.BooleanTerm(false),
 			errors: ast.ArrayTerm(
-				ast.StringTerm("opts parameter: new policy: 2 errors occurred:\n\t* certificate OIDC issuer must be provided for keyless workflow\n\t* certificate identity must be provided for keyless workflow\n\n"),
+				ast.StringTerm("opts parameter: new policy: certificate OIDC issuer must be provided for keyless workflow\ncertificate identity must be provided for keyless workflow"),
 			),
 			uri: ast.StringTerm(goodImage.String()),
 		},
@@ -305,7 +305,7 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 			name:    "insufficient options",
 			success: ast.BooleanTerm(false),
 			errors: ast.ArrayTerm(
-				ast.StringTerm("opts parameter: new policy: 2 errors occurred:\n\t* certificate OIDC issuer must be provided for keyless workflow\n\t* certificate identity must be provided for keyless workflow\n\n"),
+				ast.StringTerm("opts parameter: new policy: certificate OIDC issuer must be provided for keyless workflow\ncertificate identity must be provided for keyless workflow"),
 			),
 			uri: ast.StringTerm(goodImage.String()),
 		},


### PR DESCRIPTION
Replaces the use of hashicorp/go-multierror with errors.Join. The formatting changes aside it is very straightforward change.

Fixes #1971