### PR TITLE
Include term Attribute in Violations and Warnings Output

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -217,9 +217,12 @@ func keepSomeMetadata(results []evaluator.Result) {
 	}
 }
 
+// keepSomeMetadataSingle retains only specific metadata keys in the result.
+// **Updated to include "term" by default as per the acceptance criteria.**
 func keepSomeMetadataSingle(result evaluator.Result) {
 	for key := range result.Metadata {
-		if key == "code" || key == "effective_on" {
+		// Retain "code", "effective_on", and "term" keys
+		if key == "code" || key == "effective_on" || key == "term" {
 			continue
 		}
 		delete(result.Metadata, key)


### PR DESCRIPTION
issue #1668 
## About
This Pull Request modifies the output format of the ec validate image command to include the term attribute in the violations and warnings reported through YAML or JSON formats. This change ensures that users can view important contextual information alongside each violation and warning without needing to provide the --info flag.

### Before:
Violations and warnings were reported without the term attribute by default, making it harder for users to understand the context and significance of each issue.
Users had to remember to use the --info flag to access additional details, which could lead to confusion or oversight.

### After:
Enhances Output: Automatically includes the term attribute in the JSON/YAML output for all violations and warnings, providing users with more context about each issue.
Improves Usability: Eliminates the need for the --info flag to access the term, making the output more user-friendly and informative by default.
Facilitates Filtering: Users can utilize the term for include/exclude causes more effectively, aiding in better decision-making during validation processes.
