### PR TITLE
Switch to "unversioned" in the antora config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 
 
 [pol]: https://github.com/enterprise-contract/ec-policies/
-[docs]: https://enterprisecontract.dev/docs/ec-cli/main/ec.html
+[docs]: https://enterprisecontract.dev/docs/ec-cli/ec.html

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -17,6 +17,6 @@
 ---
 name: ec-cli
 title: Enterprise Contract CLI
-version: main
+version: ~
 nav:
   - modules/ROOT/nav.adoc

--- a/tasks/verify-enterprise-contract/0.1/README.md
+++ b/tasks/verify-enterprise-contract/0.1/README.md
@@ -10,7 +10,7 @@ kubectl apply -f https://raw.githubusercontent.com/enterprise-contract/ec-cli/ma
 * **IMAGES**: A JSON formatted list of images.
 ### Optional
 * **POLICY_CONFIGURATION**: Name or inline policy in JSON configuration to use. For name `namespace/name` or `name` syntax supported. If
-        namespace is omitted the namespace where the task runs is used. For inline policy provide the [specification](https://enterprise-contract.github.io/ecc/main/reference.html#k8s-api-github-com-enterprise-contract-enterprise-contract-controller-api-v1alpha1-enterprisecontractpolicyspec) as JSON.
+        namespace is omitted the namespace where the task runs is used. For inline policy provide the [specification](https://enterprisecontract.dev/docs/ecc/reference.html#k8s-api-github-com-enterprise-contract-enterprise-contract-controller-api-v1alpha1-enterprisecontractpolicyspec) as JSON.
 * **PUBLIC_KEY**: Public key used to verify signatures. Must be a valid k8s cosign
         reference, e.g. k8s://my-space/my-secret where my-secret contains
         the expected cosign.pub attribute.
@@ -27,7 +27,7 @@ kubectl apply -f https://raw.githubusercontent.com/enterprise-contract/ec-cli/ma
 
 ## Usage
 
-This TaskRun runs the Task to verify an image. This assumes a policy is created and stored on the cluster with hte namespaced name of `enterprise-contract-service/default`. For more information on creating a policy, refer to the Enterprise Contract [documentation](https://enterprise-contract.github.io/ecc/main/index.html).
+This TaskRun runs the Task to verify an image. This assumes a policy is created and stored on the cluster with hte namespaced name of `enterprise-contract-service/default`. For more information on creating a policy, refer to the Enterprise Contract [documentation](https://enterprisecontract.dev/docs/ecc/index.html).
 
 ```yaml
 apiVersion: tekton.dev/v1


### PR DESCRIPTION
There will be an impact on the urls. I'll aim to check for broken links later and maybe try to set up a redirect.

See also
https://docs.antora.org/antora/latest/component-with-no-version/

Ref: https://issues.redhat.com/browse/EC-903