### PR TITLE
Tracing support

### DIFF
--- a/docs/modules/ROOT/pages/ec.adoc
+++ b/docs/modules/ROOT/pages/ec.adoc
@@ -18,7 +18,7 @@ ec [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == Options inherited from parent commands

--- a/docs/modules/ROOT/pages/ec_fetch.adoc
+++ b/docs/modules/ROOT/pages/ec_fetch.adoc
@@ -12,7 +12,7 @@ Fetch remote resources
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_fetch_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_fetch_policy.adoc
@@ -74,7 +74,7 @@ Notes:
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_init.adoc
+++ b/docs/modules/ROOT/pages/ec_init.adoc
@@ -12,7 +12,7 @@ Initialize a directory for use
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_init_policies.adoc
+++ b/docs/modules/ROOT/pages/ec_init_policies.adoc
@@ -30,7 +30,7 @@ Initialize the "my-policy" directory with minimal EC policy scaffolding:
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_inspect.adoc
+++ b/docs/modules/ROOT/pages/ec_inspect.adoc
@@ -12,7 +12,7 @@ Inspect policy rules
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_inspect_policy-data.adoc
+++ b/docs/modules/ROOT/pages/ec_inspect_policy-data.adoc
@@ -35,7 +35,7 @@ ec inspect policy-data --source git::https://github.com/enterprise-contract/ec-p
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_inspect_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_inspect_policy.adoc
@@ -47,7 +47,7 @@ Display details about the latest Enterprise Contract release policy in json form
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa.adoc
+++ b/docs/modules/ROOT/pages/ec_opa.adoc
@@ -18,7 +18,7 @@ ec opa [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_bench.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_bench.adoc
@@ -55,7 +55,7 @@ ec opa bench <query> [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_build.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_build.adoc
@@ -193,7 +193,7 @@ ec opa build <path> [<path> [...]] [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_capabilities.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_capabilities.adoc
@@ -63,7 +63,7 @@ ec opa capabilities [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_check.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_check.adoc
@@ -32,7 +32,7 @@ ec opa check <path> [path [...]] [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_deps.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_deps.adoc
@@ -54,7 +54,7 @@ ec opa deps <query> [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_eval.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_eval.adoc
@@ -157,7 +157,7 @@ ec opa eval <query> [flags]
 --kubeconfig:: path to the Kubernetes config file to use
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_exec.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_exec.adoc
@@ -56,7 +56,7 @@ ec opa exec <path> [<path> [...]] [flags]
 --kubeconfig:: path to the Kubernetes config file to use
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_fmt.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_fmt.adoc
@@ -44,7 +44,7 @@ ec opa fmt [path [...]] [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_inspect.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_inspect.adoc
@@ -44,7 +44,7 @@ ec opa inspect <path> [<path> [...]] [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_parse.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_parse.adoc
@@ -21,7 +21,7 @@ ec opa parse <path> [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_run.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_run.adoc
@@ -182,7 +182,7 @@ ec opa run [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_sign.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_sign.adoc
@@ -105,7 +105,7 @@ ec opa sign <path> [<path> [...]] [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_opa_test.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_test.adoc
@@ -110,7 +110,7 @@ ec opa test <path> [path [...]] [flags]
 --kubeconfig:: path to the Kubernetes config file to use
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 
 == See also
 

--- a/docs/modules/ROOT/pages/ec_opa_version.adoc
+++ b/docs/modules/ROOT/pages/ec_opa_version.adoc
@@ -19,7 +19,7 @@ ec opa version [flags]
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_sigstore.adoc
+++ b/docs/modules/ROOT/pages/ec_sigstore.adoc
@@ -12,7 +12,7 @@ Perform certain sigstore operations
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_sigstore_initialize.adoc
+++ b/docs/modules/ROOT/pages/ec_sigstore_initialize.adoc
@@ -48,7 +48,7 @@ ec initialize -mirror <url> -root <url>
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_track.adoc
+++ b/docs/modules/ROOT/pages/ec_track.adoc
@@ -12,7 +12,7 @@ Record resource references for tracking purposes
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_track_bundle.adoc
+++ b/docs/modules/ROOT/pages/ec_track_bundle.adoc
@@ -76,7 +76,7 @@ Update existing acceptable bundles:
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_validate.adoc
+++ b/docs/modules/ROOT/pages/ec_validate.adoc
@@ -13,7 +13,7 @@ Validate conformance with the Enterprise Contract
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -160,7 +160,7 @@ JSON of the "spec" or a reference to a Kubernetes object [<namespace>/]<name>
 --quiet:: less verbose output (Default: false)
 --show-successes::  (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_validate_input.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_input.adoc
@@ -65,7 +65,7 @@ mark (?) sign, for example: --output text=output.txt?show-successes=false
 --quiet:: less verbose output (Default: false)
 --show-successes::  (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_validate_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_policy.adoc
@@ -32,7 +32,7 @@ ec validate policy --policy-configuration github.com/org/repo/policy.yaml
 --quiet:: less verbose output (Default: false)
 --show-successes::  (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/ec_version.adoc
+++ b/docs/modules/ROOT/pages/ec_version.adoc
@@ -14,7 +14,7 @@ Print version information
 --logfile:: file to write the logging output. If not specified logging output will be written to stderr
 --quiet:: less verbose output (Default: false)
 --timeout:: max overall execution duration (Default: 5m0s)
---trace:: enable trace logging (Default: false)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)
 
 == See also

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -1,0 +1,39 @@
+= Troubleshooting
+
+To identify the root cause of an issue encountered when running the `ec` command
+line tool re-running the tool while gathering more information about its
+execution can be useful. In the order of increasing verbosity the command line
+options `--verbose`, `--debug`, and `--trace` emit additional log lines that can
+be written to standard error or a file with the `--logfile` option.
+
+The `--trace` option supports enabling multiple tracing subsystems, one or more
+can be combined using the comma (`,`) as a separator, defaulting to `log` to
+enable only the trace log level if none were given. For example, specifying
+`--trace=opa,log` will output both `ec` trace and the Open Policy Engine trace
+logs.
+
+Policy execution can be traced to show any debug `print` statements in the Rego
+files and the full engine execution trace by enabling the `opa` trace with
+`--trace=opa`.
+
+TIP: The trace output can be quite verbose, filtering to include only the lines
+containing the `<filename>.rego` is helpful to look at only the debug messages
+printed by from a particular file.
+
+When using the `--trace`, memory (`mem`), CPU (`cpu`), or comprehensive
+performance (`perf`) tracing metrics are written to files in the temporary
+directory, and the path to these files is provided in the last lines of the
+logging output. These files can be loaded into Golang tooling for further
+analysis.
+
+For example, performance tracing can be captured and later analyzed using
+workflow similar to:
+
+[source,sh]
+----
+$ ec validate image --trace=perf ...
+...
+Wrote performance trace to: /tmp/perf.3645083324
+$ go tool trace -http=:6060 /tmp/perf.3645083324
+# open browser at http://localhost:6060
+----

--- a/docs/modules/ROOT/partials/main_nav.adoc
+++ b/docs/modules/ROOT/partials/main_nav.adoc
@@ -2,3 +2,4 @@
 * xref:configuration.adoc[Configuration]
 * xref:policy_input.adoc[Policy Input]
 * xref:signing.adoc[Signing]
+* xref:troubleshooting.adoc[Troubleshooting]

--- a/features/__snapshots__/opa.snap
+++ b/features/__snapshots__/opa.snap
@@ -25,13 +25,13 @@ Flags:
   -h, --help   help for opa
 
 Global Flags:
-      --debug               same as verbose but also show function names and line numbers
-      --kubeconfig string   path to the Kubernetes config file to use
-      --logfile string      file to write the logging output. If not specified logging output will be written to stderr
-      --quiet               less verbose output
-      --timeout duration    max overall execution duration (default 5m0s)
-      --trace               enable trace logging
-      --verbose             more verbose output
+      --debug                  same as verbose but also show function names and line numbers
+      --kubeconfig string      path to the Kubernetes config file to use
+      --logfile string         file to write the logging output. If not specified logging output will be written to stderr
+      --quiet                  less verbose output
+      --timeout duration       max overall execution duration (default 5m0s)
+      --trace string[="log"]   enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (default "none")
+      --verbose                more verbose output
 
 Use "ec opa [command] --help" for more information about a command.
 

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1059,7 +1059,7 @@ Feature: evaluate enterprise contract
         ]
       }
       """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/trace-debug --policy acceptance/ec-policy --public-key ${trace_debug_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json --trace"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/trace-debug --policy acceptance/ec-policy --public-key ${trace_debug_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json --trace=opa"
     Then the exit status should be 0
      And the standard error should contain
       """

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/trace"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -181,6 +182,11 @@ func readSnapshotSource(input []byte) (app.SnapshotSpec, error) {
 }
 
 func expandImageIndex(ctx context.Context, snap *app.SnapshotSpec) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:expand-image-index")
+		defer region.End()
+	}
+
 	client := oci.NewClient(ctx)
 	// For an image index, remove the original component and replace it with an expanded component with all its image manifests
 	var components []app.SnapshotComponent

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -52,8 +52,8 @@ var gatherFunc = func(ctx context.Context, source, destination string) (metadata
 
 var _initialize = func() {
 	if log.IsLevelEnabled(logrus.TraceLevel) {
-		goci.Transport = http.NewTracingRoundTripperWithLogger(goci.Transport, log)
-		ghttp.Transport = http.NewTracingRoundTripperWithLogger(ghttp.Transport, log)
+		goci.Transport = http.NewTracingRoundTripperWithLogger(goci.Transport)
+		ghttp.Transport = http.NewTracingRoundTripperWithLogger(ghttp.Transport)
 	}
 
 	backoff := retry.ExponentialBackoff(http.DefaultBackoff.Duration, http.DefaultBackoff.Factor, http.DefaultBackoff.Jitter)

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime/trace"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -87,6 +88,11 @@ func NewApplicationSnapshotImage(ctx context.Context, component app.SnapshotComp
 
 // ValidateImageAccess executes the remote.Head method on the ApplicationSnapshotImage image ref
 func (a *ApplicationSnapshotImage) ValidateImageAccess(ctx context.Context) error {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:validate-image-access")
+		defer region.End()
+	}
+
 	resp, err := oci.NewClient(ctx).Head(a.reference)
 	if err != nil {
 		return err
@@ -211,6 +217,11 @@ func (a *ApplicationSnapshotImage) ValidateAttestationSignature(ctx context.Cont
 // successful syntax check of no inputs, must invoke
 // [ValidateAttestationSignature] to prefill the attestations.
 func (a ApplicationSnapshotImage) ValidateAttestationSyntax(ctx context.Context) error {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:validate-attestation-syntax")
+		defer region.End()
+	}
+
 	if len(a.attestations) == 0 {
 		log.Debug("No attestation data found, possibly due to attestation image signature not being validated beforehand")
 		return errors.New("no attestation data")

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -290,6 +291,11 @@ func NewConftestEvaluator(ctx context.Context, policySources []source.PolicySour
 
 // set the policy namespace
 func NewConftestEvaluatorWithNamespace(ctx context.Context, policySources []source.PolicySource, p ConfigProvider, source ecc.Source, namespace []string) (Evaluator, error) {
+	if trace.IsEnabled() {
+		r := trace.StartRegion(ctx, "ec:conftest-create-evaluator")
+		defer r.End()
+	}
+
 	fs := utils.FS(ctx)
 	c := conftestEvaluator{
 		policySources: policySources,
@@ -361,6 +367,11 @@ func (r *policyRules) collect(a *ast.AnnotationsRef) error {
 
 func (c conftestEvaluator) Evaluate(ctx context.Context, target EvaluationTarget) ([]Outcome, Data, error) {
 	var results []Outcome
+
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:conftest-evaluate")
+		defer region.End()
+	}
 
 	// hold all rule annotations from all policy sources
 	// NOTE: emphasis on _all rules from all sources_; meaning that if two rules

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -42,6 +42,7 @@ import (
 	"github.com/enterprise-contract/ec-cli/internal/opa/rule"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
 	"github.com/enterprise-contract/ec-cli/internal/policy/source"
+	"github.com/enterprise-contract/ec-cli/internal/tracing"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
 
@@ -211,9 +212,7 @@ type conftestRunner struct {
 }
 
 func (r conftestRunner) Run(ctx context.Context, fileList []string) (result []Outcome, data Data, err error) {
-	if log.IsLevelEnabled(log.TraceLevel) {
-		r.Trace = true
-	}
+	r.Trace = tracing.FromContext(ctx).Enabled(tracing.Opa)
 
 	var conftestResult []output.CheckResult
 	conftestResult, err = r.TestRunner.Run(ctx, fileList)

--- a/internal/fetchers/oci/config/config.go
+++ b/internal/fetchers/oci/config/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/trace"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,6 +30,12 @@ import (
 
 // FetchImageConfig retrieves the config for an image from its OCI registry.
 func FetchImageConfig(ctx context.Context, ref name.Reference) (json.RawMessage, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:image-fetch-config")
+		defer region.End()
+		trace.Logf(ctx, "", "image=%q", ref)
+	}
+
 	image, err := oci.NewClient(ctx).Image(ref)
 	if err != nil {
 		return nil, err
@@ -48,6 +55,12 @@ func FetchImageConfig(ctx context.Context, ref name.Reference) (json.RawMessage,
 
 // FetchParentImage retrieves the reference to an image's parent image from its OCI registry.
 func FetchParentImage(ctx context.Context, ref name.Reference) (name.Reference, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:image-fetch-parent-image")
+		defer region.End()
+		trace.Logf(ctx, "", "image=%q", ref)
+	}
+
 	image, err := oci.NewClient(ctx).Image(ref)
 	if err != nil {
 		return nil, err

--- a/internal/fetchers/oci/files/files.go
+++ b/internal/fetchers/oci/files/files.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"io"
 	"path"
+	"runtime/trace"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -42,6 +43,12 @@ type Matcher func(*tar.Header) bool
 var supportedExtensions = []string{".yaml", ".yml", ".json"}
 
 func ImageFiles(ctx context.Context, ref name.Reference, extractors []Extractor) (map[string]json.RawMessage, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:image-fetch-image-files")
+		defer region.End()
+		trace.Logf(ctx, "", "image=%q", ref)
+	}
+
 	img, err := oci.NewClient(ctx).Image(ref)
 	if err != nil {
 		return nil, err

--- a/internal/http/tracing_test.go
+++ b/internal/http/tracing_test.go
@@ -18,10 +18,12 @@ package http
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type transport struct {
@@ -37,8 +39,16 @@ func TestDelegation(t *testing.T) {
 	delegate := &transport{}
 	tracing := NewTracingRoundTripper(delegate)
 
-	req := &http.Request{}
-	res := &http.Response{}
+	u, err := url.Parse("http://example.com")
+	require.NoError(t, err)
+
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+	}
+	res := &http.Response{
+		ContentLength: 42,
+	}
 	delegate.On("RoundTrip", req).Return(res, nil)
 	r, err := tracing.RoundTrip(req)
 	assert.Same(t, res, r)

--- a/internal/image/process.go
+++ b/internal/image/process.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/trace"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -35,6 +36,12 @@ const RemoteHead key = "ec.image.remoteHead"
 // ParseAndResolve parses the url into an ImageReference object. The digest is
 // resolved if needed.
 func ParseAndResolve(ctx context.Context, url string, opts ...name.Option) (*ImageReference, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:image-resolve")
+		defer region.End()
+		trace.Logf(ctx, "", "image=%q", url)
+	}
+
 	ref, err := NewImageReference(url, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -19,6 +19,7 @@ package image
 import (
 	"context"
 	"encoding/json"
+	"runtime/trace"
 	"sort"
 	"time"
 
@@ -36,6 +37,12 @@ import (
 // ValidateImage executes the required method calls to evaluate a given policy
 // against a given image url.
 func ValidateImage(ctx context.Context, comp app.SnapshotComponent, snap *app.SnapshotSpec, p policy.Policy, evaluators []evaluator.Evaluator, detailed bool) (*output.Output, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:validate-image")
+		defer region.End()
+		trace.Logf(ctx, "", "image=%q", comp.ContainerImage)
+	}
+
 	log.Debugf("Validating image %s", comp.ContainerImage)
 
 	out := &output.Output{ImageURL: comp.ContainerImage, Detailed: detailed, Policy: p}

--- a/internal/input/validate.go
+++ b/internal/input/validate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime/trace"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -34,6 +35,12 @@ import (
 var inputFile = input.NewInput
 
 func ValidateInput(ctx context.Context, fpath string, policy policy.Policy, detailed bool) (*output.Output, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:validate-input")
+		defer region.End()
+		trace.Logf(ctx, "", "file=%q", fpath)
+	}
+
 	log.Debugf("Current input filePath: %q", fpath)
 	inputFiles, err := detectInput(ctx, fpath)
 	if err != nil {

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"runtime/trace"
 	"strings"
 	"sync"
 	"time"
@@ -139,6 +140,12 @@ func getPolicyThroughCache(ctx context.Context, s PolicySource, workDir string, 
 
 // GetPolicies clones the repository for a given PolicyUrl
 func (p *PolicyUrl) GetPolicy(ctx context.Context, workDir string, showMsg bool) (string, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(ctx, "ec:get-policy")
+		defer region.End()
+		trace.Logf(ctx, "", "policy=%q", p.Url)
+	}
+
 	dl := func(source string, dest string) (metadata.Metadata, error) {
 		x := ctx.Value(DownloaderFuncKey)
 		if dl, ok := x.(downloaderFunc); ok {

--- a/internal/tracing/flag.go
+++ b/internal/tracing/flag.go
@@ -1,0 +1,27 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+func (t *Trace) Set(s string) error {
+	*t = ParseTrace(s)
+
+	return nil
+}
+
+func (Trace) Type() string {
+	return "string"
+}

--- a/internal/tracing/flag_test.go
+++ b/internal/tracing/flag_test.go
@@ -1,0 +1,35 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	for _, c := range parse_cases {
+		t.Run(fmt.Sprintf("%s => %d", c.given, c.expected), func(t *testing.T) {
+			v := None
+			if err := v.Set(c.given); err != nil {
+				t.Fatal(err)
+			} else if v != c.expected {
+				t.Errorf(`ParseTrace("%s") = %d, expected %d`, c.given, v, c.expected)
+			}
+		})
+	}
+}

--- a/internal/tracing/type.go
+++ b/internal/tracing/type.go
@@ -1,0 +1,129 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"strconv"
+	"strings"
+)
+
+type Trace uint8
+
+const (
+	None   Trace = 0
+	Perf   Trace = 1 << 0
+	CPU    Trace = 1 << 1
+	Memory Trace = 1 << 2
+	Opa    Trace = 1 << 3
+	Log    Trace = 1 << 4
+	All    Trace = Perf | CPU | Memory | Opa | Log
+
+	contextKey Trace = 0xff
+)
+
+var Default = Log
+
+// ParseTrace returns a Trace for the given comma separated string value
+func ParseTrace(s string) Trace {
+	// backward compatibility, the flag used to be a boolean on/off, we no longer
+	// advertise this
+	if v, err := strconv.ParseBool(s); err == nil {
+		if v {
+			return Default
+		} else {
+			return None
+		}
+	}
+
+	trace := None
+	for _, t := range strings.Split(s, ",") {
+		v := strings.ToLower(strings.TrimSpace(t))
+		switch v {
+		case "":
+			trace |= Default
+		case "none":
+			return None
+		case "perf":
+			trace |= Perf
+		case "cpu":
+			trace |= CPU
+		case "mem":
+			trace |= Memory
+		case "opa":
+			trace |= Opa
+		case "log":
+			trace |= Log
+		case "all":
+			return All
+		}
+
+	}
+
+	return trace
+}
+
+// Enabled returns true if one of the provided tracing categories is enabled
+func (t Trace) Enabled(categories ...Trace) bool {
+	for _, c := range categories {
+		if t&c == c {
+			return true
+		}
+	}
+
+	return false
+}
+
+// String returns a comma separated list of enabled categories
+func (t Trace) String() string {
+	if t == None {
+		return "none"
+	}
+
+	s := ""
+	if t.Enabled(Perf) {
+		s += "perf,"
+	}
+	if t.Enabled(CPU) {
+		s += "cpu,"
+	}
+	if t.Enabled(Memory) {
+		s += "mem,"
+	}
+	if t.Enabled(Opa) {
+		s += "opa,"
+	}
+	if t.Enabled(Log) {
+		s += "log,"
+	}
+
+	return strings.TrimRight(s, ",")
+}
+
+// WithTrace returns the context with the given Trace
+func WithTrace(ctx context.Context, t Trace) context.Context {
+	return context.WithValue(ctx, contextKey, t)
+}
+
+// FromContext returns the stored Trace in context or Default
+func FromContext(ctx context.Context) Trace {
+	if t := ctx.Value(contextKey); t == nil {
+		return Default
+	} else {
+		return t.(Trace)
+	}
+}

--- a/internal/tracing/type_test.go
+++ b/internal/tracing/type_test.go
@@ -1,0 +1,122 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+var parse_cases = []struct {
+	given    string
+	expected Trace
+}{
+	{"0", None},
+	{"1", Default},
+	{"false", None},
+	{"true", Default},
+	{"False", None},
+	{"True", Default},
+	{"F", None},
+	{"T", Default},
+	{"FALSE", None},
+	{"TRUE", Default},
+	{"none", None},
+	{"None", None},
+	{"perf", Perf},
+	{"cpu", CPU},
+	{"mem", Memory},
+	{"opa", Opa},
+	{"log", Log},
+	{"all", All},
+	{"none,opa", None},
+	{"all, perf", All},
+	{"perf, Opa", Perf | Opa},
+	{"", Default},
+	{",Opa", Default | Opa},
+	{"perf,", Default | Perf},
+}
+
+func TestParseTrace(t *testing.T) {
+	for _, c := range parse_cases {
+		t.Run(fmt.Sprintf("%s => %d", c.given, c.expected), func(t *testing.T) {
+			if got := ParseTrace(c.given); got != c.expected {
+				t.Errorf(`ParseTrace("%s") = %d, expected %d`, c.given, got, c.expected)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	cases := []struct {
+		value    Trace
+		expected string
+	}{
+		{None, "none"},
+		{Default, "log"},
+		{Perf, "perf"},
+		{CPU, "cpu"},
+		{Memory, "mem"},
+		{Opa, "opa"},
+		{Log, "log"},
+		{All, "perf,cpu,mem,opa,log"},
+		{Perf | Opa, "perf,opa"},
+		{Log | Opa, "opa,log"},
+		{Perf | CPU | Memory | Opa | Log, "perf,cpu,mem,opa,log"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%d => %s", c.value, c.expected), func(t *testing.T) {
+			if got := c.value.String(); got != c.expected {
+				t.Errorf(`string("%d") = %s, expected %s`, c.value, got, c.expected)
+			}
+		})
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	cases := []struct {
+		value      Trace
+		categories []Trace
+		expected   bool
+	}{
+		{None, []Trace{None}, true},
+		{All, []Trace{Opa, Perf, CPU}, true},
+		{Opa | Memory, []Trace{CPU, Opa, Perf}, true},
+		{Opa | Perf | CPU, []Trace{Memory, Log}, false},
+		{Opa | Perf | CPU, []Trace{Opa | Perf, Log}, true},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%v enabled in %d => %v", c.categories, c.value, c.expected), func(t *testing.T) {
+			if got := c.value.Enabled(c.categories...); got != c.expected {
+				t.Errorf(`%d.Enabled(%v) = %v, expected %v`, c.value, c.categories, got, c.expected)
+			}
+		})
+	}
+}
+
+func TestContextStorage(t *testing.T) {
+	if FromContext(context.TODO()) != Default {
+		t.Error("did not recive the default value from context when unset")
+	}
+
+	if FromContext(WithTrace(context.TODO(), Opa)) != Opa {
+		t.Error("did not restore the value from context")
+	}
+}

--- a/internal/utils/oci/client.go
+++ b/internal/utils/oci/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime/trace"
 	"strconv"
 	"sync"
 
@@ -125,21 +126,45 @@ type defaultClient struct {
 }
 
 func (c *defaultClient) VerifyImageSignatures(ref name.Reference, opts *cosign.CheckOpts) ([]oci.Signature, bool, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:validate-image-signatures")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	opts.RegistryClientOpts = append(opts.RegistryClientOpts, ociremote.WithRemoteOptions(c.opts...))
 	return cosign.VerifyImageSignatures(c.ctx, ref, opts)
 }
 
 func (c *defaultClient) VerifyImageAttestations(ref name.Reference, opts *cosign.CheckOpts) ([]oci.Signature, bool, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:validate-image-attestations")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	opts.RegistryClientOpts = append(opts.RegistryClientOpts, ociremote.WithRemoteOptions(c.opts...))
 	return cosign.VerifyImageAttestations(c.ctx, ref, opts)
 }
 
 func (c *defaultClient) Head(ref name.Reference) (*v1.Descriptor, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-head")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	return remote.Head(ref, c.opts...)
 }
 
 // gather all attestation uris and digests associated with an image
 func (c *defaultClient) AttestationUri(img string) (string, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-attestation-uri")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", img)
+	}
+
 	imgRef, err := name.ParseReference(img)
 	if err != nil {
 		return "", err
@@ -159,6 +184,12 @@ func (c *defaultClient) AttestationUri(img string) (string, error) {
 }
 
 func (c *defaultClient) ResolveDigest(ref name.Reference) (string, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-resolve-digest")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	digest, err := ociremote.ResolveDigest(ref, ociremote.WithRemoteOptions(c.opts...))
 	if err != nil {
 		return "", err
@@ -171,6 +202,12 @@ func (c *defaultClient) ResolveDigest(ref name.Reference) (string, error) {
 }
 
 func (c *defaultClient) Image(ref name.Reference) (v1.Image, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-fetch-image")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	img, err := remote.Image(ref, c.opts...)
 	if err != nil {
 		return nil, err
@@ -184,6 +221,12 @@ func (c *defaultClient) Image(ref name.Reference) (v1.Image, error) {
 }
 
 func (c *defaultClient) Layer(ref name.Digest) (v1.Layer, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-fetch-layer")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	// TODO: Caching a layer directly is difficult and may not be possible, see:
 	//   https://github.com/google/go-containerregistry/issues/1821
 	layer, err := remote.Layer(ref, c.opts...)
@@ -194,6 +237,12 @@ func (c *defaultClient) Layer(ref name.Digest) (v1.Layer, error) {
 }
 
 func (c *defaultClient) Index(ref name.Reference) (v1.ImageIndex, error) {
+	if trace.IsEnabled() {
+		region := trace.StartRegion(c.ctx, "ec:oci-fetch-index")
+		defer region.End()
+		trace.Logf(c.ctx, "", "image=%q", ref)
+	}
+
 	index, err := remote.Index(ref, c.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("fetching index: %w", err)


### PR DESCRIPTION
When run with `--trace` in addition to the CPU and memory trace, the execution trace will be generated. The trace can be loaded and analyzed using the `go trace` tool.

Reference: https://issues.redhat.com/browse/EC-801

In addition to that, I'm lazy to create a separate PR, a small refactor I encountered.

There is no need to return an error from `FetchPolicySources`, and since `FetchPolicySources` is not fetching the policy sources, only constructing a slice of `PolicySource`s let's call it
`PolicySourcesFrom` instead.