### PR TITLE
Add support for setting severity dynamically

### DIFF
--- a/acceptance/examples/dynamic_severity.rego
+++ b/acceptance/examples/dynamic_severity.rego
@@ -1,0 +1,31 @@
+package main
+
+import rego.v1
+
+deny contains result if {
+    result := {
+        "msg": "Failure to warning",
+        "severity": "warning"
+    }
+}
+
+deny contains result if {
+    result := {
+        "msg": "Failure to failure",
+        "severity": "failure"
+    }
+}
+
+warn contains result if {
+    result := {
+        "msg": "Warning to failure",
+        "severity": "failure"
+    }
+}
+
+warn contains result if {
+    result := {
+        "msg": "Warning to warning",
+        "severity": "warning"
+    }
+}

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -4882,3 +4882,109 @@ Error: success criteria not met
 [fetch OCI image files:stderr - 1]
 
 ---
+
+[severity is dynamically adjusted:stdout - 1]
+{
+  "success": false,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
+      "source": {},
+      "violations": [
+        {
+          "msg": "Failure to failure",
+          "metadata": {
+            "severity": "failure"
+          }
+        },
+        {
+          "msg": "Warning to failure",
+          "metadata": {
+            "severity": "failure"
+          }
+        }
+      ],
+      "warnings": [
+        {
+          "msg": "Failure to warning",
+          "metadata": {
+            "severity": "warning"
+          }
+        },
+        {
+          "msg": "Warning to warning",
+          "metadata": {
+            "severity": "warning"
+          }
+        }
+      ],
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check",
+            "description": "The attestation signature matches available signing materials.",
+            "title": "Attestation signature check passed"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check",
+            "description": "The attestation has correct syntax.",
+            "title": "Attestation syntax check passed"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check",
+            "description": "The image signature matches available signing materials.",
+            "title": "Image signature check passed"
+          }
+        }
+      ],
+      "success": false,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/ec-happy-day}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/ec-happy-day}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::https://${GITHOST}/git/dynamic-severity-policy.git?ref=${LATEST_COMMIT}"
+        ]
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[severity is dynamically adjusted:stderr - 1]
+Error: success criteria not met
+
+---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -209,6 +209,19 @@ Feature: evaluate enterprise contract
     Then the exit status should be 1
     Then the output should match the snapshot
 
+  Scenario: severity is dynamically adjusted
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "dynamic-severity-policy" with
+      | main.rego | examples/dynamic_severity.rego |
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy {"sources":[{"policy":["git::https://${GITHOST}/git/dynamic-severity-policy.git"]}]} --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json --info"
+    Then the exit status should be 1
+    Then the output should match the snapshot
+
   Scenario: multiple policy sources with multiple source groups
     Given a key pair named "known"
     Given an image named "acceptance/ec-multiple-sources"

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -502,7 +502,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, target EvaluationTarget
 		result.Skipped = skipped
 
 		// Replace the placeholder successes slice with the actual successes.
-		result.Successes = c.computeSuccesses(result, rules, effectiveTime, target.Target)
+		result.Successes = c.computeSuccesses(result, rules, target.Target)
 
 		totalRules += len(result.Warnings) + len(result.Failures) + len(result.Successes)
 
@@ -537,7 +537,7 @@ func toRules(results []output.Result) []Result {
 // computeSuccesses generates success results, these are not provided in the
 // Conftest results, so we reconstruct these from the parsed rules, any rule
 // that hasn't been touched by adding metadata must have succeeded
-func (c conftestEvaluator) computeSuccesses(result Outcome, rules policyRules, effectiveTime time.Time, target string) []Result {
+func (c conftestEvaluator) computeSuccesses(result Outcome, rules policyRules, target string) []Result {
 	// what rules, by code, have we seen in the Conftest results, use map to
 	// take advantage of hashing for quicker lookup
 	seenRules := map[string]bool{}

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -98,7 +98,7 @@ func (m *mockDownloader) Download(ctx context.Context, dest string, urls []strin
 	return args.Error(0)
 }
 
-func TestConftestEvaluatorEvaluateTimeBased(t *testing.T) {
+func TestConftestEvaluatorEvaluateSeverity(t *testing.T) {
 	results := []Outcome{
 		{
 			Failures: []Result{
@@ -130,12 +130,60 @@ func TestConftestEvaluatorEvaluateTimeBased(t *testing.T) {
 						"effective_on": "3021-01-01T00:00:00Z",
 					},
 				},
+				{
+					Message: "failure to warning",
+					Metadata: map[string]any{
+						"severity": "warning",
+					},
+				},
+				{
+					Message: "failure to failure",
+					Metadata: map[string]any{
+						"severity": "failure",
+					},
+				},
+				{
+					Message: "unexpected severity value on failure",
+					Metadata: map[string]any{
+						"severity": "spam",
+					},
+				},
+				{
+					Message: "unexpected severity type on failure",
+					Metadata: map[string]any{
+						"severity": 42,
+					},
+				},
 			},
 			Warnings: []Result{
 				{
 					Message: "existing warning",
 					Metadata: map[string]any{
 						"effective_on": "2021-01-01T00:00:00Z",
+					},
+				},
+				{
+					Message: "warning to failure",
+					Metadata: map[string]any{
+						"severity": "failure",
+					},
+				},
+				{
+					Message: "warning to warning",
+					Metadata: map[string]any{
+						"severity": "warning",
+					},
+				},
+				{
+					Message: "unexpected severity value on warning",
+					Metadata: map[string]any{
+						"severity": "spam",
+					},
+				},
+				{
+					Message: "unexpected severity type on warning",
+					Metadata: map[string]any{
+						"severity": 42,
 					},
 				},
 			},
@@ -145,6 +193,12 @@ func TestConftestEvaluatorEvaluateTimeBased(t *testing.T) {
 	expectedResults := []Outcome{
 		{
 			Failures: []Result{
+				{
+					Message: "warning to failure",
+					Metadata: map[string]any{
+						"severity": "failure",
+					},
+				},
 				{
 					Message:  "missing effective date",
 					Metadata: map[string]any{},
@@ -167,6 +221,24 @@ func TestConftestEvaluatorEvaluateTimeBased(t *testing.T) {
 						"effective_on": true,
 					},
 				},
+				{
+					Message: "failure to failure",
+					Metadata: map[string]any{
+						"severity": "failure",
+					},
+				},
+				{
+					Message: "unexpected severity value on failure",
+					Metadata: map[string]any{
+						"severity": "spam",
+					},
+				},
+				{
+					Message: "unexpected severity type on failure",
+					Metadata: map[string]any{
+						"severity": 42,
+					},
+				},
 			},
 			Warnings: []Result{
 				{
@@ -176,9 +248,34 @@ func TestConftestEvaluatorEvaluateTimeBased(t *testing.T) {
 					},
 				},
 				{
+					Message: "warning to warning",
+					Metadata: map[string]any{
+						"severity": "warning",
+					},
+				},
+				{
+					Message: "unexpected severity value on warning",
+					Metadata: map[string]any{
+						"severity": "spam",
+					},
+				},
+				{
+					Message: "unexpected severity type on warning",
+					Metadata: map[string]any{
+						"severity": 42,
+					},
+				},
+
+				{
 					Message: "not yet effective",
 					Metadata: map[string]any{
 						"effective_on": "3021-01-01T00:00:00Z",
+					},
+				},
+				{
+					Message: "failure to warning",
+					Metadata: map[string]any{
+						"severity": "warning",
 					},
 				},
 			},

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -266,6 +266,7 @@ type Info struct {
 	DependsOn        []string
 	Description      string
 	DocumentationUrl string
+	Severity         string
 	EffectiveOn      string
 	Kind             RuleKind
 	Package          string


### PR DESCRIPTION
This commit adds support for a new custom rego annotation, called `severity`. When emitted, this can turn a warning into a violation, and a violation to a warning.

(It also includes a commit about removing an unused parameter of the internal function `computeSuccesses`.)

Fixes: #2025
Ref: EC-894