### PR TITLE
Refactor PolicySource from ECP creation

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -298,11 +298,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			for _, sourceGroup := range data.policy.Spec().Sources {
 				// Todo: Make each fetch run concurrently
 				log.Debugf("Fetching policy source group '%s'", sourceGroup.Name)
-				policySources, err := source.FetchPolicySources(sourceGroup)
-				if err != nil {
-					log.Debugf("Failed to fetch policy source group '%s'!", sourceGroup.Name)
-					return err
-				}
+				policySources := source.PolicySourcesFrom(sourceGroup)
 
 				for _, policySource := range policySources {
 					log.Debugf("policySource: %#v", policySource)

--- a/internal/evaluation_target/input/input.go
+++ b/internal/evaluation_target/input/input.go
@@ -42,11 +42,7 @@ func NewInput(ctx context.Context, paths []string, p policy.Policy) (*Input, err
 
 	for _, sourceGroup := range p.Spec().Sources {
 		// Todo: Make each fetch run concurrently
-		policySources, err := source.FetchPolicySources(sourceGroup)
-		if err != nil {
-			log.Debugf("Failed to fetch policy source group '%s'!", sourceGroup.Name)
-			return nil, err
-		}
+		policySources := source.PolicySourcesFrom(sourceGroup)
 
 		for _, policySource := range policySources {
 			log.Debugf("policySource: %#v", policySource)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -56,7 +56,7 @@ const (
 var now = time.Now
 
 var (
-	FetchPolicySources     = source.FetchPolicySources
+	PolicySourcesFrom      = source.PolicySourcesFrom
 	CreateWorkDir          = utils.CreateWorkDir
 	PolicyCacheFromContext = cache.PolicyCacheFromContext
 )
@@ -600,11 +600,7 @@ func PreProcessPolicy(ctx context.Context, policyOptions Options) (Policy, *cach
 	sources := p.Spec().Sources
 	for i, sourceGroup := range sources {
 		log.Debugf("Fetching policy source group '%+v'\n", sourceGroup.Name)
-		policySources, err := FetchPolicySources(sourceGroup)
-		if err != nil {
-			log.Debugf("Failed to fetch policy source group '%s'!\n", sourceGroup.Name)
-			return nil, nil, err
-		}
+		policySources := PolicySourcesFrom(sourceGroup)
 
 		fs := utils.FS(ctx)
 		dir, err := utils.CreateWorkDir(fs)

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -298,8 +298,8 @@ func (inlineData) Type() PolicyType {
 	return InlineDataKind
 }
 
-// FetchPolicySources returns an array of policy sources
-func FetchPolicySources(s ecc.Source) ([]PolicySource, error) {
+// PolicySourcesFrom returns an array of policy sources
+func PolicySourcesFrom(s ecc.Source) []PolicySource {
 	policySources := make([]PolicySource, 0, len(s.Policy)+len(s.Data))
 
 	for _, policySourceUrl := range s.Policy {
@@ -317,5 +317,5 @@ func FetchPolicySources(s ecc.Source) ([]PolicySource, error) {
 		policySources = append(policySources, InlineData(data))
 	}
 
-	return policySources, nil
+	return policySources
 }

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -138,13 +138,12 @@ func TestInlineDataSource(t *testing.T) {
 	require.Equal(t, "data:application/json;base64,c29tZSBkYXRh", s.PolicyUrl())
 }
 
-func TestFetchPolicySources(t *testing.T) {
+func TestPolicySourcesFrom(t *testing.T) {
 	// var ruleData = &extv1.JSON{Raw: []byte("foo")}
 	tests := []struct {
 		name     string
 		source   ecc.Source
 		expected []PolicySource
-		err      error
 	}{
 		{
 			name: "fetches policy configs",
@@ -161,7 +160,6 @@ func TestFetchPolicySources(t *testing.T) {
 				&PolicyUrl{Url: "github.com/org/repo2//data/", Kind: DataKind},
 				&PolicyUrl{Url: "github.com/org/repo3//data/", Kind: DataKind},
 			},
-			err: nil,
 		},
 		{
 			name: "handles rule data",
@@ -176,17 +174,11 @@ func TestFetchPolicySources(t *testing.T) {
 				&PolicyUrl{Url: "github.com/org/repo1//data/", Kind: DataKind},
 				inlineData{source: []byte("{\"rule_data__configuration__\":\"foo\":\"bar\"}")},
 			},
-			err: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sources, err := FetchPolicySources(tt.source)
-			if tt.err == nil {
-				assert.NoError(t, err, "FetchPolicySources returned an error")
-			} else {
-				assert.EqualError(t, err, tt.err.Error())
-			}
+			sources := PolicySourcesFrom(tt.source)
 			assert.Equal(t, sources, tt.expected)
 		})
 	}


### PR DESCRIPTION
There is no need to return an error from `FetchPolicySources`, and since `FetchPolicySources` is not fetching the policy sources, only constructing a slice of `PolicySource`s let's call it `PolicySourcesFrom` instead.