### PR TITLE
Add custom ECP for pre-merge integration tests

### DIFF
--- a/.ec/policy.yaml
+++ b/.ec/policy.yaml
@@ -1,3 +1,4 @@
+# Use `make sync-custom-ecp` to update this file
 description: 'Custom pre-merge policy for ec-cli'
 publicKey: 'k8s://openshift-pipelines/public-key'
 sources:

--- a/.ec/policy.yaml
+++ b/.ec/policy.yaml
@@ -1,0 +1,21 @@
+description: 'Custom pre-merge policy for ec-cli'
+publicKey: 'k8s://openshift-pipelines/public-key'
+sources:
+  - name: Release Policies
+    data:
+      - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+    policy:
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-75c36c3@sha256:5ab1e5a7314bb5a782fea919369a324e0f288bb3b1a9e39172f5204392c34dc0
+    config:
+      include:
+        - '@redhat'
+      exclude:
+        # Not currently doing hermetic builds, see https://issues.redhat.com/browse/EC-360
+        - hermetic_build_task.*
+    ruleData:
+      # Make high sev CVEs non-blocking temporarily
+      # (The default here is [critical,high])
+      restrict_cve_security_levels: [critical]
+      # (The default here is [])
+      warn_cve_security_levels: [high]

--- a/.ec/policy.yaml
+++ b/.ec/policy.yaml
@@ -6,7 +6,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     policy:
-      - oci::quay.io/enterprise-contract/ec-release-policy:git-75c36c3@sha256:5ab1e5a7314bb5a782fea919369a324e0f288bb3b1a9e39172f5204392c34dc0
+      - oci::quay.io/enterprise-contract/ec-release-policy:latest
     config:
       include:
         - '@redhat'

--- a/.ec/tweaks/cve-blockers.yaml
+++ b/.ec/tweaks/cve-blockers.yaml
@@ -1,0 +1,7 @@
+---
+ruleData:
+  # Make high sev CVEs non-blocking temporarily
+  # (The default here is [critical,high])
+  restrict_cve_security_levels: [critical]
+  # (The default here is [])
+  warn_cve_security_levels: [high]

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,7 @@ ECP=curl -s --header "PRIVATE-TOKEN: $(GITLAB_TOKEN)" "$(END_POINT)$(ECP_PATH)/r
 sync-custom-ecp:
 	@$(ECP) | \
 	  yq '.spec' |
+	  yq '. head_comment = "Use `make sync-custom-ecp` to update this file"' |
 	  yq '.description = "Custom pre-merge policy for ec-cli"' |
 	  yq '.sources[0] |= . + load(".ec/tweaks/cve-blockers.yaml")' |
 	  yq '.sources[0].policy = ["oci::quay.io/enterprise-contract/ec-release-policy:latest"]' |

--- a/Makefile
+++ b/Makefile
@@ -333,4 +333,5 @@ sync-custom-ecp:
 	  yq '.spec' |
 	  yq '.description = "Custom pre-merge policy for ec-cli"' |
 	  yq '.sources[0] |= . + load(".ec/tweaks/cve-blockers.yaml")' |
+	  yq '.sources[0].policy = ["oci::quay.io/enterprise-contract/ec-release-policy:latest"]' |
 	  tee .ec/policy.yaml


### PR DESCRIPTION
The motivation is because we have a high severity CVE in main branch currently that we can't fix easily. Customizing the ECP used by the integration test means we can unblock merges.

The CVE was discovered via https://issues.redhat.com/browse/EC-908

Ref: [EC-926](https://issues.redhat.com/browse/EC-926)