### PR TITLE
Remnant methods of PolicySource implementations

### DIFF
--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	"github.com/enterprise-contract/go-gather/metadata"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/spf13/afero"
@@ -70,10 +69,6 @@ type testPolicySource struct{}
 
 func (t testPolicySource) GetPolicy(ctx context.Context, dest string, showMsg bool) (string, error) {
 	return "/policy", nil
-}
-
-func (t testPolicySource) GetPolicyWithMetadata(ctx context.Context, dest string, showMsg bool) (string, metadata.Metadata, error) {
-	return "/policy", nil, nil
 }
 
 func (t testPolicySource) PolicyUrl() string {

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -234,27 +234,6 @@ func (s inlineData) GetPolicy(ctx context.Context, workDir string, showMsg bool)
 	return dest, err
 }
 
-func (s inlineData) GetPolicyWithMetadata(ctx context.Context, workDir string, showMsg bool) (string, metadata.Metadata, error) {
-	dl := func(source string, dest string) (metadata.Metadata, error) {
-		fs := utils.FS(ctx)
-
-		if err := fs.MkdirAll(dest, 0755); err != nil {
-			return nil, err
-		}
-
-		f := path.Join(dest, "rule_data.json")
-		m := &fileMetadata.FileMetadata{
-			Path: dest,
-			Size: int64(len(dest)),
-			SHA:  "",
-		}
-
-		return m, afero.WriteFile(fs, f, s.source, 0400)
-	}
-
-	return getPolicyThroughCache(ctx, s, workDir, dl)
-}
-
 func (s inlineData) PolicyUrl() string {
 	return "data:application/json;base64," + base64.StdEncoding.EncodeToString(s.source)
 }

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -187,10 +187,6 @@ func (mockPolicySource) GetPolicy(_ context.Context, _ string, _ bool) (string, 
 	return "", nil
 }
 
-func (mockPolicySource) GetPolicyWithMetadata(_ context.Context, _ string, _ bool) (string, metadata.Metadata, error) {
-	return "", nil, nil
-}
-
 func (mockPolicySource) PolicyUrl() string {
 	return ""
 }


### PR DESCRIPTION
The `GetPolicyWithMetadata` was removed from the `PolicySource` interface, these methods are unused.