### PR TITLE
Remove GC before capturing memory profile

### DIFF
--- a/cmd/root/root_cmd.go
+++ b/cmd/root/root_cmd.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
 	"sync"
@@ -109,7 +108,6 @@ func NewRootCmd() *cobra.Command {
 						log.Fatal("could not create memory profile: ", err)
 					} else {
 						defer memprofile.Close()
-						runtime.GC()
 						if err := pprof.WriteHeapProfile(memprofile); err != nil {
 							log.Fatal("could not start CPU profile: ", err)
 						}


### PR DESCRIPTION
The call to runtime.GC forces the Go compiler to run. Making this call during `OnExit` of the root command means that pretty much all the memory allocation used during the validate image command, for example, is erased. This makes the memory profile less interesting when trying to understand the memory usage of the command.