### PR TITLE
Resolve ImageManifests concurrently

### DIFF
--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -173,7 +173,7 @@ func Test_determineInputSpec(t *testing.T) {
 					  {
 						"name": "single-container-app",
 						"containerImage": "quay.io/hacbs-contract-demo/single-container-app:62c06bf"
-					  }
+					  },
 					]
 				  }`,
 			},
@@ -181,16 +181,16 @@ func Test_determineInputSpec(t *testing.T) {
 				Application: "app1",
 				Components: []app.SnapshotComponent{
 					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+					{
 						Name:           "nodejs",
 						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
 					},
 					{
 						Name:           "petclinic",
 						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
-					},
-					{
-						Name:           "single-container-app",
-						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
 					},
 				},
 			},
@@ -214,16 +214,16 @@ func Test_determineInputSpec(t *testing.T) {
 				Application: "app1",
 				Components: []app.SnapshotComponent{
 					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+					{
 						Name:           "nodejs",
 						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
 					},
 					{
 						Name:           "petclinic",
 						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
-					},
-					{
-						Name:           "single-container-app",
-						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
 					},
 				},
 			},
@@ -237,16 +237,16 @@ func Test_determineInputSpec(t *testing.T) {
 				Application: "app1",
 				Components: []app.SnapshotComponent{
 					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+					{
 						Name:           "nodejs",
 						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
 					},
 					{
 						Name:           "petclinic",
 						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
-					},
-					{
-						Name:           "single-container-app",
-						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
 					},
 				},
 			},
@@ -260,16 +260,16 @@ func Test_determineInputSpec(t *testing.T) {
 				Application: "app1",
 				Components: []app.SnapshotComponent{
 					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+					{
 						Name:           "nodejs",
 						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
 					},
 					{
 						Name:           "petclinic",
 						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
-					},
-					{
-						Name:           "single-container-app",
-						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
 					},
 				},
 			},
@@ -291,6 +291,7 @@ func Test_determineInputSpec(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+
 			assert.Equal(t, c.spec, s)
 		})
 	}

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -119,15 +119,15 @@ func Test_DetermineInputSpec(t *testing.T) {
 			},
 			want: &app.SnapshotSpec{
 				Components: []app.SnapshotComponent{
-					snapshot.Components[0],
-					{
-						Name:           "Named",
-						ContainerImage: "registry.io/repository/image:different",
-					},
 					{
 						Name:           "Unnamed",
 						ContainerImage: "registry.io/repository/image:another",
 					},
+					{
+						Name:           "Named",
+						ContainerImage: "registry.io/repository/image:different",
+					},
+					snapshot.Components[0],
 				},
 			},
 		},
@@ -141,12 +141,12 @@ func Test_DetermineInputSpec(t *testing.T) {
 			want: &app.SnapshotSpec{
 				Components: []app.SnapshotComponent{
 					{
-						Name:           "Named",
-						ContainerImage: imageRef,
-					},
-					{
 						Name:           "Set name",
 						ContainerImage: "registry.io/repository/image:another",
+					},
+					{
+						Name:           "Named",
+						ContainerImage: imageRef,
 					},
 				},
 			},


### PR DESCRIPTION
This should speed up resolving manifests when there's a greater number of components.

https://issues.redhat.com/browse/EC-975