### PR TITLE
Add Konflux release Pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ build-for-test: dist/ec_$(BUILD_IMG_ARCH)
 clean: ## Delete build output
 	@rm -f dist/*
 
+.PHONY: generate-pipelines
+generate-pipelines: ## Generate release pipelines
+	kustomize build ./release/src/cli --output ./release/cli.yaml
+	kustomize build ./release/src/tekton-task --output ./release/tekton-task.yaml
+
 ##@ Testing
 
 # Declutter the output by grepping out the files where there are no

--- a/policies/cli/policy.yaml
+++ b/policies/cli/policy.yaml
@@ -1,3 +1,19 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # If we need to diverge from the "official" policy for pre-merge EC checks,
 # the EC integration test scenario POLICY_CONFIGURATION param can be set to

--- a/policies/tekton-task/policy.yaml
+++ b/policies/tekton-task/policy.yaml
@@ -1,0 +1,32 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# The bundle for the Tekton Task requires a different policy as it is not a traditional container
+# image.
+#
+description: 'Custom pre-merge policy for ec-cli'
+publicKey: 'k8s://openshift-pipelines/public-key'
+sources:
+  - name: Release Policies
+    data:
+      - github.com/release-engineering/rhtap-ec-policy//data
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+    policy:
+      - oci::quay.io/enterprise-contract/ec-release-policy:latest
+    config:
+      include:
+        - '@slsa3'

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,14 @@
+# Release Pipelines
+
+This directory contains the Tekton Pipelines used to release EC from the main branch. These
+Pipelines execute in [Konflux](https://konflux-ci.dev/).
+
+The Pipelines are generated via [kustomize](https://kustomize.io/) from the `src` directory. To
+make changes to the Pipelines, update the corresponding files in that directory and run the
+`make generate-pipelines` command (requires `kustomize`).
+
+## Why are there two Pipelines?
+
+Currently, it is not possible to specify the EC policy in the ReleasePlan, nor any general Pipeline
+parameter. Because the CLI and the Tekton Task require different EC policies, the only way to
+achieve this is by using different Pipelines with different default values for the EC policy.

--- a/release/cli.yaml
+++ b/release/cli.yaml
@@ -1,0 +1,218 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: release-cli
+spec:
+  description: Tekton pipeline to release Snapshots to a registry.
+  finally:
+  - name: cleanup
+    params:
+    - name: subdirectory
+      value: $(context.pipelineRun.uid)
+    - name: delay
+      value: "0"
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: tasks/cleanup-workspace/cleanup-workspace.yaml
+      resolver: git
+    workspaces:
+    - name: input
+      workspace: release-workspace
+  params:
+  - description: The namespaced name (namespace/name) of the Release custom resource
+      initiating this pipeline execution
+    name: release
+    type: string
+  - description: The namespaced name (namespace/name) of the releasePlan
+    name: releasePlan
+    type: string
+  - description: The namespaced name (namespace/name) of the snapshot
+    name: snapshot
+    type: string
+  - default: github.com/enterprise-contract/ec-cli//policies/cli
+    description: JSON representation of the EnterpriseContractPolicy
+    name: enterpriseContractPolicy
+    type: string
+  - default: pipeline_intention=release
+    description: |
+      Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+      "key1=value1,key2=value2..."
+    name: enterpriseContractExtraRuleData
+    type: string
+  - default: 40m0s
+    description: Timeout setting for `ec validate`
+    name: enterpriseContractTimeout
+    type: string
+  tasks:
+  - name: verify-access-to-resources
+    params:
+    - name: release
+      value: $(params.release)
+    - name: releasePlan
+      value: $(params.releasePlan)
+    - name: snapshot
+      value: $(params.snapshot)
+    - name: requireInternalServices
+      value: "false"
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: support-tenant-releases
+      - name: pathInRepo
+        value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
+      resolver: git
+  - name: collect-data
+    params:
+    - name: release
+      value: $(params.release)
+    - name: releasePlan
+      value: $(params.releasePlan)
+    - name: snapshot
+      value: $(params.snapshot)
+    - name: subdirectory
+      value: $(context.pipelineRun.uid)
+    runAfter:
+    - verify-access-to-resources
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: support-tenant-releases
+      - name: pathInRepo
+        value: tasks/collect-data/collect-data.yaml
+      resolver: git
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: reduce-snapshot
+    params:
+    - name: SNAPSHOT
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    - name: SINGLE_COMPONENT
+      value: $(tasks.collect-data.results.singleComponentMode)
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+      value: snapshot/$(tasks.collect-data.results.snapshotName)
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+      value: $(tasks.collect-data.results.snapshotNamespace)
+    - name: SNAPSHOT_PATH
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    runAfter:
+    - collect-data
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: tasks/reduce-snapshot/reduce-snapshot.yaml
+      resolver: git
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: apply-mapping
+    params:
+    - name: failOnEmptyResult
+      value: "true"
+    - name: dataPath
+      value: $(tasks.collect-data.results.data)
+    - name: snapshotPath
+      value: $(tasks.collect-data.results.snapshotSpec)
+    runAfter:
+    - reduce-snapshot
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: development
+      - name: pathInRepo
+        value: tasks/apply-mapping/apply-mapping.yaml
+      resolver: git
+    workspaces:
+    - name: config
+      workspace: release-workspace
+  - name: verify-enterprise-contract
+    params:
+    - name: IMAGES
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    - name: SSL_CERT_DIR
+      value: /var/run/secrets/kubernetes.io/serviceaccount
+    - name: POLICY_CONFIGURATION
+      value: $(params.enterpriseContractPolicy)
+    - name: STRICT
+      value: "1"
+    - name: IGNORE_REKOR
+      value: "true"
+    - name: EXTRA_RULE_DATA
+      value: $(params.enterpriseContractExtraRuleData)
+    - name: TIMEOUT
+      value: $(params.enterpriseContractTimeout)
+    runAfter:
+    - apply-mapping
+    taskRef:
+      params:
+      - name: bundle
+        value: quay.io/enterprise-contract/ec-task-bundle:snapshot
+      - name: kind
+        value: task
+      - name: name
+        value: verify-enterprise-contract
+      resolver: bundles
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: push-snapshot
+    params:
+    - name: snapshotPath
+      value: $(tasks.collect-data.results.snapshotSpec)
+    - name: dataPath
+      value: $(tasks.collect-data.results.data)
+    - name: resultsDirPath
+      value: $(tasks.collect-data.results.resultsDir)
+    retries: 5
+    runAfter:
+    - verify-enterprise-contract
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: KFLUXBUGS-1741
+      - name: pathInRepo
+        value: tasks/push-snapshot/push-snapshot.yaml
+      resolver: git
+    when:
+    - input: $(tasks.apply-mapping.results.mapped)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  workspaces:
+  - name: release-workspace

--- a/release/src/base/kustomization.yaml
+++ b/release/src/base/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml
+patches:
+  - path: tasks/verify-access-to-resources.yaml
+    target:
+      kind: Pipeline
+  - path: tasks/collect-data.yaml
+    target:
+      kind: Pipeline
+  - path: tasks/apply-mapping.yaml
+    target:
+      kind: Pipeline
+  - path: tasks/push-snapshot.yaml
+    target:
+      kind: Pipeline

--- a/release/src/base/release.yaml
+++ b/release/src/base/release.yaml
@@ -1,0 +1,222 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This Pipeline is a variation of:
+# https://github.com/konflux-ci/release-service-catalog/blob/development/pipelines/push-to-external-registry/push-to-external-registry.yaml
+# It has been modified from its original version. It has been formatted to fit Tenant Release Pipelines.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: release
+spec:
+  description: >-
+    Tekton pipeline to release Snapshots to a registry.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+      default: UPDATE_ME
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: enterpriseContractTimeout
+      type: string
+      description: Timeout setting for `ec validate`
+      default: 40m0s
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: verify-access-to-resources
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
+    - name: collect-data
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/collect-data/collect-data.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-access-to-resources
+    - name: reduce-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/reduce-snapshot/reduce-snapshot.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: SINGLE_COMPONENT
+          value: $(tasks.collect-data.results.singleComponentMode)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/$(tasks.collect-data.results.snapshotName)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: $(tasks.collect-data.results.snapshotNamespace)
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: apply-mapping
+      params:
+        - name: failOnEmptyResult
+          value: "true"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - reduce-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/apply-mapping/apply-mapping.yaml
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: TIMEOUT
+          value: $(params.enterpriseContractTimeout)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      retries: 5
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/push-snapshot/push-snapshot.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/cleanup-workspace/cleanup-workspace.yaml
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+        - name: delay
+          value: "0"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/release/src/base/tasks/apply-mapping.yaml
+++ b/release/src/base/tasks/apply-mapping.yaml
@@ -1,0 +1,22 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Need changes from https://github.com/konflux-ci/release-service-catalog/pull/631 to be in the
+# production branch
+- op: replace
+  path: /spec/tasks/3/taskRef/params/1/value
+  value: development

--- a/release/src/base/tasks/collect-data.yaml
+++ b/release/src/base/tasks/collect-data.yaml
@@ -1,0 +1,27 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Need these changes: https://github.com/konflux-ci/release-service-catalog/pull/672
+- op: replace
+  path: /spec/tasks/1/taskRef/params
+  value:
+    - name: url
+      value: https://github.com/lcarva/release-service-bundles.git
+    - name: revision
+      value: support-tenant-releases
+    - name: pathInRepo
+      value: tasks/collect-data/collect-data.yaml

--- a/release/src/base/tasks/push-snapshot.yaml
+++ b/release/src/base/tasks/push-snapshot.yaml
@@ -1,0 +1,28 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Need these changes to be merged and made available in the production branch:
+# https://github.com/konflux-ci/release-service-catalog/pull/671
+- op: replace
+  path: /spec/tasks/5/taskRef/params
+  value:
+    - name: url
+      value: https://github.com/lcarva/release-service-bundles.git
+    - name: revision
+      value: KFLUXBUGS-1741
+    - name: pathInRepo
+      value: tasks/push-snapshot/push-snapshot.yaml

--- a/release/src/base/tasks/verify-access-to-resources.yaml
+++ b/release/src/base/tasks/verify-access-to-resources.yaml
@@ -1,0 +1,27 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Need these changes: https://github.com/konflux-ci/release-service-catalog/pull/672
+- op: replace
+  path: /spec/tasks/0/taskRef/params
+  value:
+    - name: url
+      value: https://github.com/lcarva/release-service-bundles.git
+    - name: revision
+      value: support-tenant-releases
+    - name: pathInRepo
+      value: tasks/verify-access-to-resources/verify-access-to-resources.yaml

--- a/release/src/cli/kustomization.yaml
+++ b/release/src/cli/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: patch.yaml
+    target:
+      kind: Pipeline

--- a/release/src/cli/patch.yaml
+++ b/release/src/cli/patch.yaml
@@ -1,0 +1,23 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- op: replace
+  path: /metadata/name
+  value: release-cli
+- op: replace
+  path: /spec/params/3/default  # enterpriseContractPolicy
+  value: github.com/enterprise-contract/ec-cli//policies/cli

--- a/release/src/tekton-task/kustomization.yaml
+++ b/release/src/tekton-task/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: patch.yaml
+    target:
+      kind: Pipeline

--- a/release/src/tekton-task/patch.yaml
+++ b/release/src/tekton-task/patch.yaml
@@ -1,0 +1,23 @@
+---
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- op: replace
+  path: /metadata/name
+  value: release-cli
+- op: replace
+  path: /spec/params/3/default  # enterpriseContractPolicy
+  value: github.com/enterprise-contract/ec-cli//policies/tekton-task

--- a/release/tekton-task.yaml
+++ b/release/tekton-task.yaml
@@ -1,0 +1,218 @@
+# Copyright The Enterprise Contract Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: release-cli
+spec:
+  description: Tekton pipeline to release Snapshots to a registry.
+  finally:
+  - name: cleanup
+    params:
+    - name: subdirectory
+      value: $(context.pipelineRun.uid)
+    - name: delay
+      value: "0"
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: tasks/cleanup-workspace/cleanup-workspace.yaml
+      resolver: git
+    workspaces:
+    - name: input
+      workspace: release-workspace
+  params:
+  - description: The namespaced name (namespace/name) of the Release custom resource
+      initiating this pipeline execution
+    name: release
+    type: string
+  - description: The namespaced name (namespace/name) of the releasePlan
+    name: releasePlan
+    type: string
+  - description: The namespaced name (namespace/name) of the snapshot
+    name: snapshot
+    type: string
+  - default: github.com/enterprise-contract/ec-cli//policies/tekton-task
+    description: JSON representation of the EnterpriseContractPolicy
+    name: enterpriseContractPolicy
+    type: string
+  - default: pipeline_intention=release
+    description: |
+      Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+      "key1=value1,key2=value2..."
+    name: enterpriseContractExtraRuleData
+    type: string
+  - default: 40m0s
+    description: Timeout setting for `ec validate`
+    name: enterpriseContractTimeout
+    type: string
+  tasks:
+  - name: verify-access-to-resources
+    params:
+    - name: release
+      value: $(params.release)
+    - name: releasePlan
+      value: $(params.releasePlan)
+    - name: snapshot
+      value: $(params.snapshot)
+    - name: requireInternalServices
+      value: "false"
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: support-tenant-releases
+      - name: pathInRepo
+        value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
+      resolver: git
+  - name: collect-data
+    params:
+    - name: release
+      value: $(params.release)
+    - name: releasePlan
+      value: $(params.releasePlan)
+    - name: snapshot
+      value: $(params.snapshot)
+    - name: subdirectory
+      value: $(context.pipelineRun.uid)
+    runAfter:
+    - verify-access-to-resources
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: support-tenant-releases
+      - name: pathInRepo
+        value: tasks/collect-data/collect-data.yaml
+      resolver: git
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: reduce-snapshot
+    params:
+    - name: SNAPSHOT
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    - name: SINGLE_COMPONENT
+      value: $(tasks.collect-data.results.singleComponentMode)
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+      value: snapshot/$(tasks.collect-data.results.snapshotName)
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+      value: $(tasks.collect-data.results.snapshotNamespace)
+    - name: SNAPSHOT_PATH
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    runAfter:
+    - collect-data
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: tasks/reduce-snapshot/reduce-snapshot.yaml
+      resolver: git
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: apply-mapping
+    params:
+    - name: failOnEmptyResult
+      value: "true"
+    - name: dataPath
+      value: $(tasks.collect-data.results.data)
+    - name: snapshotPath
+      value: $(tasks.collect-data.results.snapshotSpec)
+    runAfter:
+    - reduce-snapshot
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/release-service-catalog.git
+      - name: revision
+        value: development
+      - name: pathInRepo
+        value: tasks/apply-mapping/apply-mapping.yaml
+      resolver: git
+    workspaces:
+    - name: config
+      workspace: release-workspace
+  - name: verify-enterprise-contract
+    params:
+    - name: IMAGES
+      value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+    - name: SSL_CERT_DIR
+      value: /var/run/secrets/kubernetes.io/serviceaccount
+    - name: POLICY_CONFIGURATION
+      value: $(params.enterpriseContractPolicy)
+    - name: STRICT
+      value: "1"
+    - name: IGNORE_REKOR
+      value: "true"
+    - name: EXTRA_RULE_DATA
+      value: $(params.enterpriseContractExtraRuleData)
+    - name: TIMEOUT
+      value: $(params.enterpriseContractTimeout)
+    runAfter:
+    - apply-mapping
+    taskRef:
+      params:
+      - name: bundle
+        value: quay.io/enterprise-contract/ec-task-bundle:snapshot
+      - name: kind
+        value: task
+      - name: name
+        value: verify-enterprise-contract
+      resolver: bundles
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  - name: push-snapshot
+    params:
+    - name: snapshotPath
+      value: $(tasks.collect-data.results.snapshotSpec)
+    - name: dataPath
+      value: $(tasks.collect-data.results.data)
+    - name: resultsDirPath
+      value: $(tasks.collect-data.results.resultsDir)
+    retries: 5
+    runAfter:
+    - verify-enterprise-contract
+    taskRef:
+      params:
+      - name: url
+        value: https://github.com/lcarva/release-service-bundles.git
+      - name: revision
+        value: KFLUXBUGS-1741
+      - name: pathInRepo
+        value: tasks/push-snapshot/push-snapshot.yaml
+      resolver: git
+    when:
+    - input: $(tasks.apply-mapping.results.mapped)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: data
+      workspace: release-workspace
+  workspaces:
+  - name: release-workspace


### PR DESCRIPTION
This commit adds two Tekton Pipelines. One is meant to be used to release the CLI image via Konflux, the other for releasing the Tekton Task bundle.

Ideally, a single Pipeline would be used. However, due to limitations in Konflux release, this would force us to use the same EC policy config for both images which is currently not supported by EC.

The Pipelines are based on the push-to-external-registry Pipeline provided by Konflux release (link in code). Some of the Tasks require changes for a couple of reasons:

1. Some Tasks require ReleasePlanAdmission and ReleaseConfig resource references. Neither one of those are used/available during tenant releases.

2. Some Tasks assume the image is an OCI image (good thing). However, the `tekton bundle push` command creates an Image Manifest with the docker media type (kind of deprecated).

To make this saner to maintain, `kustomize` is used to compose the release Pipelines. `make generate-pipelines` is added to facilitate running the command.

Additionally, because two EC policies are used, the `.ec` directory didn't make sense anymore. As such, a new top-level `policies` directory is used.

Ref: EC-910