### PR TITLE
update-rpm-lock: use volumes instead of mounts

### DIFF
--- a/hack/update-rpm-lock.sh
+++ b/hack/update-rpm-lock.sh
@@ -95,9 +95,9 @@ fi
 echo Running RPM lock tooling...
 podman run \
     --rm \
-    --mount type=bind,source="${root_dir}/Dockerfile.dist",destination=/opt/app-root/src/Dockerfile \
-    --mount type=bind,source="${root_dir}/rpms.in.yaml",destination=/opt/app-root/src/rpms.in.yaml \
-    --mount type=bind,source="${root_dir}/rpms.lock.yaml",destination=/opt/app-root/src/rpms.lock.yaml \
+    --volume "${root_dir}/Dockerfile.dist:/opt/app-root/src/Dockerfile:Z" \
+    --volume "${root_dir}/rpms.in.yaml:/opt/app-root/src/rpms.in.yaml:Z" \
+    --volume "${root_dir}/rpms.lock.yaml:/opt/app-root/src/rpms.lock.yaml:Z" \
     "${image}" \
     bash -c "${script}"
 


### PR DESCRIPTION
On systems where SELinux is enabled, it is not possible to modify file on the host's filesystem unless explicitly enabled by SELinux. The `--mount` flag does not allow specifying SELinux labels. This commit changes the podman run command to use `--volume` instead so the labels can be set as expected.