### PR TITLE
Track the policy data by source group

### DIFF
--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -223,7 +223,7 @@ func setupKeys(ctx context.Context, vars map[string]string, environment []string
 
 		vars[name+"_PUBLIC_KEY"] = key.Name()
 		// Handle some variations in indentation
-		vars[fmt.Sprintf("__________%s_PUBLIC_KEY", name)] = snaps.Indent(publicKey, 10)
+		vars[fmt.Sprintf("________%s_PUBLIC_KEY", name)] = snaps.Indent(publicKey, 10)
 
 		vars[name+"_PUBLIC_KEY_JSON"] = strings.ReplaceAll(publicKey, "\n", "\\n")
 

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -2383,34 +2383,34 @@ Error: success criteria not met
 ---
 
 [Custom rule data:${TMPDIR}/custom-rule-data.yaml - 1]
-- - config:
-      default_sigstore_opts:
-        certificate_identity: ""
-        certificate_identity_regexp: ""
-        certificate_oidc_issuer: ""
-        certificate_oidc_issuer_regexp: ""
-        ignore_rekor: false
-        public_key: |
-${__________known_PUBLIC_KEY}
-        rekor_url: ${REKOR}
-      policy:
-        when_ns: 1401494400000000000
-    rule_data__configuration__:
-      custom: data1
-  - config:
-      default_sigstore_opts:
-        certificate_identity: ""
-        certificate_identity_regexp: ""
-        certificate_oidc_issuer: ""
-        certificate_oidc_issuer_regexp: ""
-        ignore_rekor: false
-        public_key: |
-${__________known_PUBLIC_KEY}
-        rekor_url: ${REKOR}
-      policy:
-        when_ns: 1401494400000000000
-    rule_data__configuration__:
-      other: data2
+- config:
+    default_sigstore_opts:
+      certificate_identity: ""
+      certificate_identity_regexp: ""
+      certificate_oidc_issuer: ""
+      certificate_oidc_issuer_regexp: ""
+      ignore_rekor: false
+      public_key: |
+${________known_PUBLIC_KEY}
+      rekor_url: ${REKOR}
+    policy:
+      when_ns: 1401494400000000000
+  rule_data__configuration__:
+    custom: data1
+- config:
+    default_sigstore_opts:
+      certificate_identity: ""
+      certificate_identity_regexp: ""
+      certificate_oidc_issuer: ""
+      certificate_oidc_issuer_regexp: ""
+      ignore_rekor: false
+      public_key: |
+${________known_PUBLIC_KEY}
+      rekor_url: ${REKOR}
+    policy:
+      when_ns: 1401494400000000000
+  rule_data__configuration__:
+    other: data2
 
 ---
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -85,7 +85,7 @@ type Output struct {
 	Attestations              []attestation.Attestation   `json:"attestations,omitempty"`
 	ImageURL                  string                      `json:"-"`
 	Detailed                  bool                        `json:"-"`
-	Data                      []evaluator.Data            `json:"-"`
+	Data                      map[string]evaluator.Data   `json:"-"`
 	Policy                    policy.Policy               `json:"-"`
 	PolicyInput               []byte                      `json:"-"`
 }


### PR DESCRIPTION
Only collect the policy data once for each source group. Before this the data was duplicated for each component.

https://issues.redhat.com/browse/EC-1027