### PR TITLE
Only store attestation data that is needed

### DIFF
--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -1322,7 +1322,30 @@ func TestContainsData(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := containsData(test.input)
+		result := containsOutput(test.input, "data")
+		assert.Equal(t, test.expected, result, test.name)
+	}
+}
+
+func TestContainsAttestation(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected bool
+		name     string
+	}{
+		{[]string{"attestation"}, true, "Match single attestation"},
+		{[]string{"attestation=some-file.att"}, true, "Match attestation=some-file.att"},
+		{[]string{"meta=attestation.json"}, false, "Do not match meta=attestation.json"},
+		{[]string{"config", "attestation=custom-attestation.yaml"}, true, "Match attestation in slice with multiple values"},
+		{[]string{"attestation text"}, false, "Do not match attestation text"},
+		{[]string{"attest"}, false, "Do not match attest"},
+		{[]string{"attestation123"}, false, "Do not match attestation123"},
+		{[]string{"attestation="}, true, "Match attestation="},
+		{[]string{""}, false, "Do not match empty string"},
+	}
+
+	for _, test := range tests {
+		result := containsOutput(test.input, "attestation")
 		assert.Equal(t, test.expected, result, test.name)
 	}
 }

--- a/cmd/validate/input.go
+++ b/cmd/validate/input.go
@@ -177,7 +177,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 				} else {
 					inputs = append(inputs, r.input)
 					// evaluator data is duplicated per component, so only collect it once.
-					if len(evaluatorData) == 0 && containsData(data.output) {
+					if len(evaluatorData) == 0 && containsOutput(data.output, "data") {
 						evaluatorData = append(evaluatorData, r.data)
 					}
 					manyPolicyInput = append(manyPolicyInput, r.policyInput)

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -29,7 +29,6 @@ import (
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/format"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
@@ -46,7 +45,7 @@ type Component struct {
 	Success      bool                        `json:"success"`
 	SuccessCount int                         `json:"-"`
 	Signatures   []signature.EntitySignature `json:"signatures,omitempty"`
-	Attestations []attestation.Attestation   `json:"attestations,omitempty"`
+	Attestations []AttestationResult         `json:"attestations,omitempty"`
 }
 
 type Report struct {

--- a/internal/applicationsnapshot/vsa_test.go
+++ b/internal/applicationsnapshot/vsa_test.go
@@ -29,37 +29,10 @@ import (
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/enterprise-contract/ec-cli/internal/attestation"
 	"github.com/enterprise-contract/ec-cli/internal/evaluator"
 	"github.com/enterprise-contract/ec-cli/internal/policy"
-	"github.com/enterprise-contract/ec-cli/internal/signature"
 	"github.com/enterprise-contract/ec-cli/internal/utils"
 )
-
-type provenance struct {
-	statement in_toto.Statement
-	data      []byte
-}
-
-func (p provenance) Type() string {
-	return in_toto.StatementInTotoV01
-}
-
-func (p provenance) PredicateType() string {
-	return p.statement.StatementHeader.PredicateType
-}
-
-func (p provenance) Statement() []byte {
-	return p.data
-}
-
-func (p provenance) Signatures() []signature.EntitySignature {
-	return []signature.EntitySignature{}
-}
-
-func (p provenance) Subject() []in_toto.Subject {
-	return p.statement.Subject
-}
 
 func TestNewVSA(t *testing.T) {
 	components := []Component{
@@ -70,9 +43,9 @@ func TestNewVSA(t *testing.T) {
 					Message: "violation1",
 				},
 			},
-			Attestations: []attestation.Attestation{
-				provenance{
-					statement: in_toto.Statement{},
+			Attestations: []AttestationResult{
+				{
+					Statement: []byte{},
 				},
 			},
 		},
@@ -110,6 +83,7 @@ func TestSubjects(t *testing.T) {
 			Digest: nil,
 		},
 	}
+
 	statement := in_toto.Statement{
 		StatementHeader: in_toto.StatementHeader{
 			Subject: expected,
@@ -126,10 +100,9 @@ func TestSubjects(t *testing.T) {
 					Message: "violation1",
 				},
 			},
-			Attestations: []attestation.Attestation{
-				provenance{
-					statement: statement,
-					data:      data,
+			Attestations: []AttestationResult{
+				{
+					Statement: data,
 				},
 			},
 		},

--- a/internal/attestation/slsa_provenance_02.go
+++ b/internal/attestation/slsa_provenance_02.go
@@ -86,6 +86,10 @@ func (a slsaProvenance) Statement() []byte {
 	return a.data
 }
 
+func (a slsaProvenance) PredicateBuildType() string {
+	return a.statement.Predicate.BuildType
+}
+
 func (a slsaProvenance) Signatures() []signature.EntitySignature {
 	return a.signatures
 }


### PR DESCRIPTION
The whole attestation is being stored for each component that is evaluated, but in most cases only a subset of the attestation is printed. This change captures only the needed attestation data based on the output selected at runtime.

https://issues.redhat.com/browse/EC-1026