### PR TITLE
Use v2 of softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,7 +163,7 @@ jobs:
           git push -f --tags
 
       - name: Rolling release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
         with:
           make_latest: true
           name: Rolling release
@@ -173,7 +173,7 @@ jobs:
           files: dist/*
 
       - name: Versioned release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
         with:
           make_latest: false
           name: ${{ steps.add_tags.outputs.tag_name }}


### PR DESCRIPTION
The v2.2.0 release of the action introduced a bug: https://github.com/softprops/action-gh-release/issues/555

This commit changes the version used to v2, instead of the more specific v2.2.0 as suggested in another issue:
https://github.com/softprops/action-gh-release/issues/556