### PR TITLE
Rollback update to softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,7 +163,7 @@ jobs:
           git push -f --tags
 
       - name: Rolling release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
         with:
           make_latest: true
           name: Rolling release
@@ -173,7 +173,7 @@ jobs:
           files: dist/*
 
       - name: Versioned release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
         with:
           make_latest: false
           name: ${{ steps.add_tags.outputs.tag_name }}


### PR DESCRIPTION
We're seeing a similar issue to
https://github.com/enterprise-contract/ec-cli/commit/2378fc68fcc0880c267c0d280bb33ac9a6941b2a during a release.

Let's roll back the version to unblock the release.