### PR TITLE
Update CLI release policy

### DIFF
--- a/policies/cli/policy.yaml
+++ b/policies/cli/policy.yaml
@@ -36,8 +36,8 @@ sources:
       include:
         - '@redhat'
       exclude:
-        # Not currently doing hermetic builds, see https://issues.redhat.com/browse/EC-360
-        - hermetic_build_task.*
+        # For an upstream release, we don't worry about restricted release dates.
+        - schedule
     ruleData:
       #
       # Make high sev CVEs non-blocking temporarily


### PR DESCRIPTION
This commit updates the EC policy config for the CLI image in two ways.

First, the policy config now enforces hermetic builds since the builds are indeed hermetic 🎉.

Second the policy config no longer enforces the schedule restriction. Those policy rules are usually meant to avoid releases by a vendor on restricted dates, e.g. weekends. Since this is being used for a community release, this is not a concern.

Ref: EC-911