### PR TITLE
Use consistent rego syntax in prep for opa 1.0

### DIFF
--- a/acceptance/examples/allow_all.rego
+++ b/acceptance/examples/allow_all.rego
@@ -1,4 +1,6 @@
 # Simplest never-failing policy
 package main
 
+import rego.v1
+
 allow := []

--- a/acceptance/examples/disallowed_functions.rego
+++ b/acceptance/examples/disallowed_functions.rego
@@ -6,8 +6,7 @@
 #   test that certain rego functions are not allowed.
 package policy.capabilities
 
-import future.keywords.contains
-import future.keywords.if
+import rego.v1
 
 # METADATA
 # title: use env var

--- a/acceptance/examples/fail_with_data.rego
+++ b/acceptance/examples/fail_with_data.rego
@@ -1,5 +1,7 @@
 package main
 
-deny[result] {
+import rego.v1
+
+deny contains result if {
     result := sprintf("Failure due to %s", [data.rule_data.banana_fail_reason])
 }

--- a/acceptance/examples/fetch_blob.rego
+++ b/acceptance/examples/fetch_blob.rego
@@ -1,8 +1,6 @@
 package blobby
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # custom:
@@ -27,7 +25,7 @@ deny contains result if {
     }
 }
 
-uri := value {
+uri := value if {
     # Assume the blob is on the same repo as the image
     repo := split(input.image.ref, "@")[0]
     # The digest of the word "spam"

--- a/acceptance/examples/filtering.rego
+++ b/acceptance/examples/filtering.rego
@@ -6,9 +6,7 @@
 #   showcase the filtering logic with include/exclude/collection.
 package policy.filtering
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # title: always pass

--- a/acceptance/examples/future_deny.rego
+++ b/acceptance/examples/future_deny.rego
@@ -1,6 +1,8 @@
 package main
 
-deny[{"msg": result, "effective_on": effective_on}] {
-    result := "Fails in 2099"
+import rego.v1
+
+deny contains {"msg": result, "effective_on": effective_on} if {
+  result := "Fails in 2099"
 	effective_on := "2099-01-01T00:00:00Z"
 }

--- a/acceptance/examples/gloomy_day.rego
+++ b/acceptance/examples/gloomy_day.rego
@@ -1,13 +1,15 @@
 # Provide one always passing rule and one always failing rule
 package gloomy
 
+import rego.v1
+
 # METADATA
 # title: Allow gloomy rule
 # description: This rule will never fail
 # custom:
 #   short_name: happy
 #   failure_msg: Always succeeds
-deny[result] {
+deny contains result if {
     false
     result := "Never fails"
 }
@@ -18,7 +20,7 @@ deny[result] {
 # custom:
 #   short_name: sad
 #   failure_msg: Always fails
-deny[result] {
+deny contains result if {
 	result := {
 		"code": "gloomy.sad",
 		"effective_on": "2022-01-01T00:00:00Z",

--- a/acceptance/examples/happy_day.rego
+++ b/acceptance/examples/happy_day.rego
@@ -1,6 +1,8 @@
 # Simplest never-failing policy
 package main
 
+import rego.v1
+
 # METADATA
 # title: Allow rule
 # description: This rule will never fail
@@ -10,7 +12,7 @@ package main
 #   solution: Easy
 #   collections:
 #   - A
-deny[result] {
+deny contains result if {
     false
     result := "Never denies"
 }

--- a/acceptance/examples/image_config.rego
+++ b/acceptance/examples/image_config.rego
@@ -1,9 +1,7 @@
 # Verify image config data from input.
 package image_config
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # title: Image Title Label
@@ -11,7 +9,7 @@ import future.keywords.in
 # custom:
 #   short_name: image_title_set
 #   failure_msg: Missing image title label
-deny contains err(rego.metadata.rule()) {
+deny contains err(rego.metadata.rule()) if {
     not input.image.config.Labels["org.opencontainers.image.title"]
 }
 
@@ -21,7 +19,7 @@ deny contains err(rego.metadata.rule()) {
 # custom:
 #   short_name: parent_image_title_set
 #   failure_msg: Missing parent image title label
-deny contains err(rego.metadata.rule()) {
+deny contains err(rego.metadata.rule()) if {
     not input.image.parent.config.Labels["org.opencontainers.image.title"]
 }
 
@@ -33,7 +31,7 @@ deny contains err(rego.metadata.rule()) {
 # custom:
 #   short_name: image_distinct_title_set
 #   failure_msg: Image does not have a distinct title
-deny contains err(rego.metadata.rule()) {
+deny contains err(rego.metadata.rule()) if {
     l1 := input.image.config.Labels["org.opencontainers.image.title"]
     l2 := input.image.parent.config.Labels["org.opencontainers.image.title"]
     l1 == l2

--- a/acceptance/examples/keyless.rego
+++ b/acceptance/examples/keyless.rego
@@ -1,8 +1,6 @@
 package keyless
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # custom:

--- a/acceptance/examples/oci_image_files.rego
+++ b/acceptance/examples/oci_image_files.rego
@@ -2,7 +2,6 @@ package files
 
 import rego.v1
 
-
 # METADATA
 # custom:
 #   short_name: match

--- a/acceptance/examples/olm_manifests.rego
+++ b/acceptance/examples/olm_manifests.rego
@@ -1,8 +1,6 @@
 package olm_manifests
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # title: Manifests are there

--- a/acceptance/examples/pipeline_basic.rego
+++ b/acceptance/examples/pipeline_basic.rego
@@ -1,5 +1,7 @@
 package pipeline.main
 
+import rego.v1
+
 expected_kind := "Pipeline"
 
 # METADATA
@@ -7,7 +9,7 @@ expected_kind := "Pipeline"
 # description: Check that the pipeline is a kind of "Pipeline"
 # custom:
 #   short_name: expected_kind
-deny[result] {
+deny contains result if {
 	expected_kind != input.kind
 	result := "invalid kind"
 }

--- a/acceptance/examples/purl.rego
+++ b/acceptance/examples/purl.rego
@@ -1,8 +1,6 @@
 package purl
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # custom:

--- a/acceptance/examples/reject.rego
+++ b/acceptance/examples/reject.rego
@@ -1,9 +1,7 @@
 # Simplest always-failing policy
 package main
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # METADATA
 # title: Reject rule

--- a/acceptance/examples/rules_with_dependencies.rego
+++ b/acceptance/examples/rules_with_dependencies.rego
@@ -1,7 +1,6 @@
 package pkg
 
-import future.keywords.contains
-import future.keywords.if
+import rego.v1
 
 # METADATA
 # custom:

--- a/acceptance/examples/trace_debug.rego
+++ b/acceptance/examples/trace_debug.rego
@@ -1,7 +1,6 @@
 package main
 
-import future.keywords.contains
-import future.keywords.if
+import rego.v1
 
 # METADATA
 # title: Debug

--- a/acceptance/examples/unsupported.rego
+++ b/acceptance/examples/unsupported.rego
@@ -1,5 +1,7 @@
 package unsupported
 
-deny {
+import rego.v1
+
+deny if {
     true
 }

--- a/acceptance/examples/warn.rego
+++ b/acceptance/examples/warn.rego
@@ -1,6 +1,8 @@
 # Simplest always-warning policy
 package main
 
-warn[result] {
+import rego.v1
+
+warn contains result if {
     result := "Has a warning"
 }

--- a/acceptance/examples/with_annotations.rego
+++ b/acceptance/examples/with_annotations.rego
@@ -1,11 +1,13 @@
 package policy.release.kitty
 
+import rego.v1
+
 # METADATA
 # title: Kittens
 # description: Fluffy
 # custom:
 #   short_name: purr
 #
-deny[result] {
+deny contains result if {
     result := "Meow"
 }

--- a/docs/policy/release/attestation.rego
+++ b/docs/policy/release/attestation.rego
@@ -8,6 +8,8 @@
 #
 package policy.release.builtin.attestation
 
+import rego.v1
+
 # METADATA
 # title: Attestation signature
 # description: >-
@@ -23,7 +25,7 @@ package policy.release.builtin.attestation
 #   collections:
 #   - builtin
 #
-deny {
+deny if {
 	false # Here just to provide documentation
 }
 
@@ -40,6 +42,6 @@ deny {
 #   collections:
 #   - builtin
 #
-deny {
+deny if {
 	false # Here just to provide documentation
 }

--- a/docs/policy/release/image.rego
+++ b/docs/policy/release/image.rego
@@ -8,6 +8,8 @@
 #
 package policy.release.builtin.image
 
+import rego.v1
+
 # METADATA
 # title: Image signature
 # description: >-
@@ -23,6 +25,6 @@ package policy.release.builtin.image
 #   collections:
 #   - builtin
 #
-deny {
+deny if {
 	false # Here just to provide documentation
 }

--- a/features/__snapshots__/inspect_policy.snap
+++ b/features/__snapshots__/inspect_policy.snap
@@ -22,7 +22,7 @@ Error: Merge error. The 'rule_data' key was found more than once!
       },
       "location": {
         "file": "main.rego",
-        "row": 9,
+        "row": 11,
         "col": 1
       },
       "path": [
@@ -94,7 +94,7 @@ kitty.purr
 ---
 
 [sources from ECP:stdout - 1]
-# Source: git::${GITHOST}/git/policy1.git?ref=8288b21ca5e7d8863efffb47c2bc3eac1274d1ff
+# Source: git::${GITHOST}/git/policy1.git?ref=5c216ecae44c9bd76cca3e6cce95892289a07db0
 
 policy.release.kitty.purr (deny)
 https://enterprisecontract.dev/docs/ec-policies/release_policy.html#kitty__purr

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -59,7 +59,7 @@
     "sources": [
       {
         "policy": [
-          "git::${GITHOST}/git/happy-day-policy.git?ref=95175b6ea9bb28c645186c6624ff904812ebbca7"
+          "git::${GITHOST}/git/happy-day-policy.git?ref=adeaf76384dd4391e18e8ce5fadef1a5c7414f06"
         ]
       }
     ],
@@ -161,7 +161,7 @@ Error: success criteria not met
     "sources": [
       {
         "policy": [
-          "git::${GITHOST}/git/banana_check.git?ref=c6cafb797f5afa8b9c7b1c54ea7bf0ca35368e21"
+          "git::${GITHOST}/git/banana_check.git?ref=bdb9057ca7da961fe4a753993017ab9e97798fd4"
         ],
         "data": [
           "git::${GITHOST}/git/banana_data_1.git?ref=62e50acbb1a230a3f11ca1858fc053b21fe5cc82"
@@ -169,7 +169,7 @@ Error: success criteria not met
       },
       {
         "policy": [
-          "git::${GITHOST}/git/banana_check.git?ref=c6cafb797f5afa8b9c7b1c54ea7bf0ca35368e21"
+          "git::${GITHOST}/git/banana_check.git?ref=bdb9057ca7da961fe4a753993017ab9e97798fd4"
         ],
         "data": [
           "git::${GITHOST}/git/banana_data_2.git?ref=${LATEST_COMMIT}"
@@ -327,7 +327,7 @@ Error: success criteria not met
     "sources": [
       {
         "policy": [
-          "git::${GITHOST}/git/happy-day-policy.git?ref=95175b6ea9bb28c645186c6624ff904812ebbca7"
+          "git::${GITHOST}/git/happy-day-policy.git?ref=adeaf76384dd4391e18e8ce5fadef1a5c7414f06"
         ]
       }
     ],
@@ -614,12 +614,12 @@ Error: success criteria not met
     "sources": [
       {
         "policy": [
-          "git::${GITHOST}/git/repository1.git?ref=95175b6ea9bb28c645186c6624ff904812ebbca7"
+          "git::${GITHOST}/git/repository1.git?ref=adeaf76384dd4391e18e8ce5fadef1a5c7414f06"
         ]
       },
       {
         "policy": [
-          "git::${GITHOST}/git/repository2.git?ref=9998384962ba66481defc409b0f821d222ba3366"
+          "git::${GITHOST}/git/repository2.git?ref=7e2406bbafba94a4ecf1b5e59f9211c6597f58f7"
         ]
       },
       {
@@ -1176,8 +1176,8 @@ Error: success criteria not met
     "sources": [
       {
         "policy": [
-          "git::${GITHOST}/git/repository1.git?ref=95175b6ea9bb28c645186c6624ff904812ebbca7",
-          "git::${GITHOST}/git/repository2.git?ref=9998384962ba66481defc409b0f821d222ba3366",
+          "git::${GITHOST}/git/repository1.git?ref=adeaf76384dd4391e18e8ce5fadef1a5c7414f06",
+          "git::${GITHOST}/git/repository2.git?ref=7e2406bbafba94a4ecf1b5e59f9211c6597f58f7",
           "git::${GITHOST}/git/repository3.git?ref=${LATEST_COMMIT}"
         ]
       }
@@ -2143,9 +2143,9 @@ Error: success criteria not met
 
 [Dropping rego capabilities:stderr - 1]
 Error: error validating image ${REGISTRY}/acceptance/ec-happy-day of component Unnamed: load: loading policies: get compiler: 3 errors occurred:
-${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:15: rego_type_error: undefined function opa.runtime
-${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:23: rego_type_error: undefined function http.send
-${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:34: rego_type_error: undefined function net.lookup_ip_addr
+${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:14: rego_type_error: undefined function opa.runtime
+${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:22: rego_type_error: undefined function http.send
+${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:33: rego_type_error: undefined function net.lookup_ip_addr
 
 ---
 
@@ -3209,7 +3209,7 @@ Error: success criteria not met
 ---
 
 [Unsupported policies:stderr - 1]
-Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed: the rule "deny = true { true }" returns an unsupported value, at main.rego:3
+Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed: the rule "deny = true { true }" returns an unsupported value, at main.rego:5
 
 ---
 

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1106,7 +1106,7 @@ Feature: evaluate enterprise contract
       """
      And the standard error should contain
       """
-      level=debug msg="\[data.main.deny\] .*/main.rego:13: here we are
+      level=debug msg="\[data.main.deny\] .*/main.rego:12: here we are
       """
 
   Scenario: PURL functions

--- a/internal/evaluator/__testdir__/simple/a.rego
+++ b/internal/evaluator/__testdir__/simple/a.rego
@@ -1,12 +1,14 @@
 # A set of policies
 package a
 
+import rego.v1
+
 # METADATA
 # title: Failure
 # description: Failure description.
 # custom:
 #   short_name: failure
-deny[result] {
+deny contains result if {
 	result := {
 		"code": "a.failure",
 		"msg": "Failure!",
@@ -17,7 +19,7 @@ deny[result] {
 # description: Warning description.
 # custom:
 #   short_name: warning
-warn[result] {
+warn contains result if {
 	result := {
 		"code": "a.warning",
 		"msg": "Warning!",
@@ -28,7 +30,7 @@ warn[result] {
 # description: Success description.
 # custom:
 #   short_name: success
-deny[result] {
+deny contains result if {
 	false
 	result := "Success!"
 }

--- a/internal/evaluator/__testdir__/simple/b.rego
+++ b/internal/evaluator/__testdir__/simple/b.rego
@@ -1,10 +1,12 @@
 # B set of policies
 package b
 
+import rego.v1
+
 # METADATA
 # custom:
 #   short_name: failure
-deny[result] {
+deny contains result if {
 	result := {
 		"code": "b.failure",
 		"msg": "Failure!",
@@ -13,7 +15,7 @@ deny[result] {
 # METADATA
 # custom:
 #   short_name: warning
-warn[result] {
+warn contains result if {
 	result := {
 		"code": "b.warning",
 		"msg": "Warning!",
@@ -22,7 +24,7 @@ warn[result] {
 # METADATA
 # custom:
 #   short_name: success
-deny[result] {
+deny contains result if {
 	false
 	result := "Success!"
 }

--- a/internal/evaluator/__testdir__/unconforming/no_msg.rego
+++ b/internal/evaluator/__testdir__/unconforming/no_msg.rego
@@ -1,5 +1,7 @@
 package no_msg
 
-deny {
+import rego.v1
+
+deny if {
     true
 }

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -316,11 +316,12 @@ func setupTestContext(r *mockTestRunner, dl *mockDownloader) context.Context {
 
 	if err := afero.WriteFile(fs, "/policy/example.rego", []byte(heredoc.Doc(`# Simplest always-failing policy
 	package main
+	import rego.v1
 
 	# METADATA
 	# title: Reject rule
 	# description: This rule will always fail
-	deny[result] {
+	deny contains result if {
 		result := "Fails always"
 	}`)), 0644); err != nil {
 		panic(err)
@@ -1364,6 +1365,8 @@ func TestMakeMatchers(t *testing.T) {
 func TestCollectAnnotationData(t *testing.T) {
 	module := ast.MustParseModuleWithOpts(heredoc.Doc(`
 		package a.b.c
+		import rego.v1
+
 		# METADATA
 		# title: Title
 		# description: Description
@@ -1372,7 +1375,7 @@ func TestCollectAnnotationData(t *testing.T) {
 		#   collections: [A, B, C]
 		#   effective_on: 2022-01-01T00:00:00Z
 		#   depends_on: a.b.c
-		deny[msg] {
+		deny contains msg if {
 			msg := "hi"
 		}`), ast.ParserOptions{
 		ProcessAnnotation: true,
@@ -1886,7 +1889,7 @@ func TestUnconformingRule(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = evaluator.Evaluate(ctx, EvaluationTarget{Inputs: []string{path.Join(dir, "inputs")}})
-	assert.EqualError(t, err, `the rule "deny = true { true }" returns an unsupported value, at no_msg.rego:3`)
+	assert.EqualError(t, err, `the rule "deny = true { true }" returns an unsupported value, at no_msg.rego:5`)
 }
 
 func TestNewConftestEvaluatorComputeIncludeExclude(t *testing.T) {

--- a/internal/opa/__snapshots__/inspect_test.snap
+++ b/internal/opa/__snapshots__/inspect_test.snap
@@ -8,7 +8,7 @@
     },
     "location": {
       "file": "more/bacon.REGO",
-      "row": 8,
+      "row": 6,
       "col": 1
     },
     "path": [
@@ -37,7 +37,7 @@
     },
     "location": {
       "file": "spam.rego",
-      "row": 8,
+      "row": 6,
       "col": 1
     },
     "path": [
@@ -67,7 +67,7 @@
     },
     "location": {
       "file": "more/bacon.REGO",
-      "row": 8,
+      "row": 6,
       "col": 1
     },
     "path": [
@@ -96,7 +96,7 @@
     },
     "location": {
       "file": "spam.rego",
-      "row": 8,
+      "row": 6,
       "col": 1
     },
     "path": [

--- a/internal/opa/inspect_test.go
+++ b/internal/opa/inspect_test.go
@@ -45,10 +45,11 @@ func Test_InspectMultiple(t *testing.T) {
 			paths: []string{"foo/bar/bacon.rego"},
 			modules: []string{hd.Doc(`
 				package bacon
+				import rego.v1
 
 				# METADATA
 				# title: Enough spam
-				deny {
+				deny if {
 					input.spam_count > 42
 				}
 			`)},
@@ -57,7 +58,7 @@ func Test_InspectMultiple(t *testing.T) {
 					{
 						"location":{
 							"file":"foo/bar/bacon.rego",
-							"row":5,
+							"row":6,
 							"col":1
 						},
 						"path":[
@@ -91,9 +92,7 @@ func TestInspectDir(t *testing.T) {
 	files := map[string]string{
 		"spam.rego": hd.Doc(`
 			package spam
-
-			import future.keywords.contains
-			import future.keywords.if
+			import rego.v1
 
 			# METADATA
 			# title: Enough spam
@@ -107,9 +106,7 @@ func TestInspectDir(t *testing.T) {
 		"spam.text":        "ignored",
 		"more/bacon.REGO": hd.Doc(`
 			package more.bacon
-
-			import future.keywords.contains
-			import future.keywords.if
+			import rego.v1
 
 			# METADATA
 			# title: Enough bacon
@@ -169,48 +166,54 @@ func TestCheckRules(t *testing.T) {
 		{
 			name: "assignement",
 			rego: `package test
+			import rego.v1
 			x := "value"`,
 		},
 		{
 			name: "no message",
 			rego: `package test
-			deny { true }`,
+			import rego.v1
+			deny if { true }`,
 			err: `the rule "deny = true { true }" returns an unsupported value, at rules.rego:2`,
 		},
 		{
 			// we can't check for this, we don't know the type of `x`
 			name: "var assignement",
 			rego: `package test
-			deny[x] { x := true }`,
+			import rego.v1
+			deny contains x if { x := true }`,
 		},
 		{
 			// we can't check for this, we don't know if `o` is an empty object
 			name: "object assignement",
 			rego: `package test
-			import future.keywords.contains
-			import future.keywords.if
+			import rego.v1
 			deny contains o if { o := {} }`,
 		},
 		{
 			name: "not string",
 			rego: `package test
-			deny { 2 }`,
+			import rego.v1
+			deny if { 2 }`,
 			err: `the rule "deny = true { 2 }" returns an unsupported value, at rules.rego:2`,
 		},
 		{
 			name: "string",
 			rego: `package test
-			deny[msg] { msg := "str" }`,
+			import rego.v1
+			deny contains msg if { msg := "str" }`,
 		},
 		{
 			name: "object",
 			rego: `package test
+			import rego.v1
 			deny := {"key": "val"}`,
 		},
 		{
 			name: "function",
 			rego: `package test
-			deny[fn()]{
+			import rego.v1
+			deny contains fn() if {
 				true
 			}
 			fn := {"key": "val"}`,
@@ -218,7 +221,8 @@ func TestCheckRules(t *testing.T) {
 		{
 			name: "assign",
 			rego: `package test
-			deny := "value" {
+			import rego.v1
+			deny := "value" if {
 				true
 			}`,
 		},

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -55,26 +55,29 @@ func TestTitle(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with custom annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   hmm: 14
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with title annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: title
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "title",
 		},
 	}
@@ -101,37 +104,41 @@ func TestDescription(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with custom annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   hmm: 14
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with title annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# description: description
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "description",
 		},
 		{
 			name: "with xref links",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# description: >-
 				#   See xref:release_policy.adoc#attestation_task_bundle_package[here] and
 				#   xref:attachment$trusted_tekton_tasks.yml[over there] for details.
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "See here and over there for details.",
 		},
 	}
@@ -158,27 +165,30 @@ func TestKind(t *testing.T) {
 			name: "other rule",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: test
-				helper() { true }`)),
+				helper if { true }`)),
 			expected: Other,
 		},
 		{
 			name: "deny rule",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: test
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: Deny,
 		},
 		{
 			name: "warn rule",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: test
-				warn() { true }`)),
+				warn if { true }`)),
 			expected: Warn,
 		},
 	}
@@ -205,36 +215,40 @@ func TestShortName(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "without custom annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: title
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with custom annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   hmm: 14
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with short_name annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: here
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "here",
 		},
 	}
@@ -261,46 +275,51 @@ func TestEffectiveOn(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { false }`)),
+				import rego.v1
+				deny if { false }`)),
 			expected: "",
 		},
 		{
 			name: "without custom annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: title
-				deny() { false }`)),
+				deny if { false }`)),
 			expected: "",
 		},
 		{
 			name: "with custom annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   hmm: 14
-				deny() { false }`)),
+				deny if { false }`)),
 			expected: "",
 		},
 		{
 			name: "with effective_on annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   effective_on: 2022-01-01T00:00:00Z
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "2022-01-01T00:00:00Z",
 		},
 		{
 			name: "with effective_on annotation as string",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   effective_on: '2022-01-01T00:00:00Z'
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "2022-01-01T00:00:00Z",
 		},
 	}
@@ -324,22 +343,24 @@ func TestSolution(t *testing.T) {
 			name: "with solution",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   solution: Chunky bacon
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "Chunky bacon",
 		},
 		{
 			name: "with xref links",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#  solution: >-
 				#    See xref:release_policy.adoc#attestation_task_bundle_package[here] and
 				#    xref:attachment$trusted_tekton_tasks.yml[over there] for details.
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "See here and over there for details.",
 		},
 	}
@@ -366,50 +387,55 @@ func TestCollections(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: []string{},
 		},
 		{
 			name: "without custom annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# title: title
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{},
 		},
 		{
 			name: "with custom annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   hmm: 14
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{},
 		},
 		{
 			name: "with one collection annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   collections:
 				#     - A
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{"A"},
 		},
 		{
 			name: "with several collection annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   collections:
 				#     - A
 				#     - B
 				#     - C
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{"A", "B", "C"},
 		},
 	}
@@ -436,134 +462,148 @@ func TestCode(t *testing.T) {
 			name: "no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "with short_name",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.x",
 		},
 		{
 			name: "nested packages no annotations",
 			annotation: annotationRef(heredoc.Doc(`
 				package a.b.c
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: "",
 		},
 		{
 			name: "nested packages with short_name",
 			annotation: annotationRef(heredoc.Doc(`
 				package a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "nested packages with policy package",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "nested packages with policy.data package",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.data.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "data.a.b.c.x",
 		},
 		{
 			name: "nested packages with data package in regular part",
 			annotation: annotationRef(heredoc.Doc(`
 				package a.data.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.data.b.c.x",
 		},
 		{
 			name: "nested packages with policy package in regular part",
 			annotation: annotationRef(heredoc.Doc(`
 				package a.policy.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.policy.b.c.x",
 		},
 		{
 			name: "release category",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.release.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "pipeline category",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.pipeline.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "build_task category",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.build_task.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "task category",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.task.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "a.b.c.x",
 		},
 		{
 			name: "unknown category",
 			annotation: annotationRef(heredoc.Doc(`
 				package policy.something.a.b.c
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "something.a.b.c.x",
 		},
 		{
 			name: "without just known category package",
 			annotation: annotationRef(heredoc.Doc(`
 				package release
+				import rego.v1
 				# METADATA
 				# custom:
 				#   short_name: x
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: "x",
 		},
 	}
@@ -590,30 +630,33 @@ func TestDependsOn(t *testing.T) {
 			name: "no depends_on annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
-				deny() { true }`)),
+				import rego.v1
+				deny if { true }`)),
 			expected: []string{},
 		},
 		{
 			name: "single depends_on annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   depends_on: a.b.c
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{"a.b.c"},
 		},
 		{
 			name: "multiple depends_on annotation",
 			annotation: annotationRef(heredoc.Doc(`
 				package a
+				import rego.v1
 				# METADATA
 				# custom:
 				#   depends_on:
 				#     - a.b.c
 				#     - d.e.f
 				#     - g.h.i
-				deny() { true }`)),
+				deny if { true }`)),
 			expected: []string{"a.b.c", "d.e.f", "g.h.i"},
 		},
 	}

--- a/internal/test_data/policies/pipeline/basic.rego
+++ b/internal/test_data/policies/pipeline/basic.rego
@@ -1,5 +1,7 @@
 package policy.pipeline.basic
 
+import rego.v1
+
 import data.lib
 
 expected_kind := "Pipeline"
@@ -16,7 +18,7 @@ expected_kind := "Pipeline"
 #   short_name: unexpected_kind
 #   failure_msg: Unexpected kind '%s'
 #
-deny[result] {
+deny contains result if {
 	expected_kind != input.kind
 	result := lib.result_helper(rego.metadata.chain(), [input.kind])
 }


### PR DESCRIPTION
The idea here is that once we update to opa 1.0 we'll need to always use the new `deny contains foo if` syntax. This change is supposed to make it easier by using that syntax consistently now.

It requires importing `rego.v1` everywhere, but we do that consistently for all the rego in ec-policies, so let's also do it here also.

See also #2274 which I'd like to rebase on this once it's merged.

Ref: https://issues.redhat.com/browse/EC-1130