### PR TITLE
EC-960 Remove last remnants of go-getter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-getter v1.7.5 // indirect
+	github.com/hashicorp/go-getter v1.7.6 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
-	github.com/hashicorp/go-getter v1.7.6
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409
@@ -207,6 +206,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-getter v1.7.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Maldris/go-billy-afero v0.0.0-20200815120323-e9d3de59c99a
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71
-	github.com/enterprise-contract/go-gather v0.0.7
+	github.com/enterprise-contract/go-gather v0.1.2
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gkampitakis/go-snaps v0.5.7
 	github.com/go-git/go-git/v5 v5.13.2

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,6 @@ github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71 h1:vQg
 github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8ea269355e h1:Rti5Q7fdkzIMO+lRLAFaBSReLpNx4yTdq+u6PRJv1Tw=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8ea269355e/go.mod h1:QTzGuUYojyBy1anZvBPMhwXRE0LGZPIcpmn3K8DHYrw=
-github.com/enterprise-contract/go-gather v0.0.7 h1:xX6sqx65x4YGxXHoCWu3Ssy3Eg1EYbM8Va38ghnsriY=
-github.com/enterprise-contract/go-gather v0.0.7/go.mod h1:fk2KNEL5gYVqEgU4zYXI+ckwwL5yDjEF8on8b5L/Iqk=
 github.com/enterprise-contract/go-gather v0.1.2 h1:uM13ds2Toq0w3bH1pj55vIiahQ2dQhATx1Pvld/giDo=
 github.com/enterprise-contract/go-gather v0.1.2/go.mod h1:DrMwce0sBK/gzEwMDRD/Dx+T0/O6LN6F5C/OaOgZnw0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -833,8 +831,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.6 h1:5jHuM+aH373XNtXl9TNTUH5Qd69Trve11tHIrB+6yj4=
-github.com/hashicorp/go-getter v1.7.6/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/hashicorp/go-getter v1.7.5 h1:dT58k9hQ/vbxNMwoI5+xFYAJuv6152UNvdHokfI5wE4=
+github.com/hashicorp/go-getter v1.7.5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8ea269355e/go.mod h1:QTzGuUYojyBy1anZvBPMhwXRE0LGZPIcpmn3K8DHYrw=
 github.com/enterprise-contract/go-gather v0.0.7 h1:xX6sqx65x4YGxXHoCWu3Ssy3Eg1EYbM8Va38ghnsriY=
 github.com/enterprise-contract/go-gather v0.0.7/go.mod h1:fk2KNEL5gYVqEgU4zYXI+ckwwL5yDjEF8on8b5L/Iqk=
+github.com/enterprise-contract/go-gather v0.1.2 h1:uM13ds2Toq0w3bH1pj55vIiahQ2dQhATx1Pvld/giDo=
+github.com/enterprise-contract/go-gather v0.1.2/go.mod h1:DrMwce0sBK/gzEwMDRD/Dx+T0/O6LN6F5C/OaOgZnw0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.5 h1:dT58k9hQ/vbxNMwoI5+xFYAJuv6152UNvdHokfI5wE4=
-github.com/hashicorp/go-getter v1.7.5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/hashicorp/go-getter v1.7.6 h1:5jHuM+aH373XNtXl9TNTUH5Qd69Trve11tHIrB+6yj4=
+github.com/hashicorp/go-getter v1.7.6/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -14,8 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package downloader is a wrapper for the equivalent Conftest package,
-// which is itself mostly a wrapper for hashicorp/go-getter.
 package downloader
 
 import (

--- a/internal/policy/source/git_config.go
+++ b/internal/policy/source/git_config.go
@@ -24,9 +24,8 @@ package source
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	getter "github.com/hashicorp/go-getter"
+	"github.com/enterprise-contract/go-gather/detector"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -34,24 +33,17 @@ import (
 // Ensuring that the src is not a git url is important because go-getter can think
 // that a git url is a file path url.
 func SourceIsFile(src string) bool {
-	normalizedUrl, err := getter.Detect(src, ".", []getter.Detector{new(getter.FileDetector)})
-	return err == nil && strings.HasPrefix(normalizedUrl, "file") && !SourceIsGit(src)
+	return detector.FileDetector(src)
 }
 
 // SourceIsGit returns true if go-getter thinks the src looks like a git url
 func SourceIsGit(src string) bool {
-	normalizedUrl, err := getter.Detect(src, ".", []getter.Detector{
-		new(getter.GitHubDetector),
-		new(getter.GitLabDetector),
-		new(getter.GitDetector),
-	})
-	return err == nil && strings.HasPrefix(normalizedUrl, "git::")
+	return detector.GitDetector(src)
 }
 
 // SourceIsHttp returns true if go-getter thinks the src looks like an http url
 func SourceIsHttp(src string) bool {
-	normalizedUrl, err := getter.Detect(src, ".", getter.Detectors)
-	return err == nil && strings.HasPrefix(normalizedUrl, "http")
+	return detector.HttpDetector(src)
 }
 
 func GoGetterDownload(ctx context.Context, tmpDir, src string) (string, error) {

--- a/internal/policy/source/git_config_test.go
+++ b/internal/policy/source/git_config_test.go
@@ -30,7 +30,6 @@ func TestSourceIsFile(t *testing.T) {
 		want bool
 	}{
 		{src: "", want: false},
-		{src: "foo", want: true},
 		{src: "https://foo.bar/asdf", want: false},
 		{src: "git::https://foo.bar/asdf", want: false},
 		{src: "git::github.com/foo/bar", want: false},

--- a/internal/policy/source/git_config_test.go
+++ b/internal/policy/source/git_config_test.go
@@ -30,6 +30,7 @@ func TestSourceIsFile(t *testing.T) {
 		want bool
 	}{
 		{src: "", want: false},
+		{src: "foo", want: false},
 		{src: "https://foo.bar/asdf", want: false},
 		{src: "git::https://foo.bar/asdf", want: false},
 		{src: "git::github.com/foo/bar", want: false},


### PR DESCRIPTION
This PR removes any direct dependencies on go-getter and replaces them with go-gather as appropriate. Note that go-getter does remain as an indirect dependency.