### PR TITLE
chore(deps): bump dependency version for go-gather

### DIFF
--- a/cmd/inspect/inspect_policy_test.go
+++ b/cmd/inspect/inspect_policy_test.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"testing"
 
-	fileMetadata "github.com/enterprise-contract/go-gather/gather/file"
-	"github.com/enterprise-contract/go-gather/metadata"
+	fileMetadata "github.com/conforma/go-gather/gather/file"
+	"github.com/conforma/go-gather/metadata"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"

--- a/cmd/validate/common_test.go
+++ b/cmd/validate/common_test.go
@@ -21,7 +21,7 @@ package validate
 import (
 	"context"
 
-	"github.com/enterprise-contract/go-gather/metadata"
+	"github.com/conforma/go-gather/metadata"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/spf13/cobra"

--- a/cmd/validate/image_integration_test.go
+++ b/cmd/validate/image_integration_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
+	ociMetadata "github.com/conforma/go-gather/gather/oci"
 	"github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	ociMetadata "github.com/enterprise-contract/go-gather/gather/oci"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	hd "github.com/MakeNowJust/heredoc"
-	ociMetadata "github.com/enterprise-contract/go-gather/gather/oci"
+	ociMetadata "github.com/conforma/go-gather/gather/oci"
 	"github.com/gkampitakis/go-snaps/snaps"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/sigstore/cosign/v2/pkg/cosign"

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	cuelang.org/go v0.11.1
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Maldris/go-billy-afero v0.0.0-20200815120323-e9d3de59c99a
+	github.com/conforma/go-gather v1.0.0
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71
-	github.com/enterprise-contract/go-gather v0.1.2
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gkampitakis/go-snaps v0.5.7
 	github.com/go-git/go-git/v5 v5.13.2

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
+github.com/conforma/go-gather v1.0.0 h1:9dCL3UW+SdkadEgPrpBbztbzxzkXMN5MbcpXiZAt+WA=
+github.com/conforma/go-gather v1.0.0/go.mod h1:AbNsdkXUBG9nEyNOGs7Tx3B0N0zgOirZS4Cus/xDhrg=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=
@@ -549,8 +551,6 @@ github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71 h1:vQg
 github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8ea269355e h1:Rti5Q7fdkzIMO+lRLAFaBSReLpNx4yTdq+u6PRJv1Tw=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20241118083807-8c8ea269355e/go.mod h1:QTzGuUYojyBy1anZvBPMhwXRE0LGZPIcpmn3K8DHYrw=
-github.com/enterprise-contract/go-gather v0.1.2 h1:uM13ds2Toq0w3bH1pj55vIiahQ2dQhATx1Pvld/giDo=
-github.com/enterprise-contract/go-gather v0.1.2/go.mod h1:DrMwce0sBK/gzEwMDRD/Dx+T0/O6LN6F5C/OaOgZnw0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"sync"
 
-	ghttp "github.com/enterprise-contract/go-gather/gather/http"
-	goci "github.com/enterprise-contract/go-gather/gather/oci"
-	"github.com/enterprise-contract/go-gather/metadata"
-	"github.com/enterprise-contract/go-gather/registry"
+	ghttp "github.com/conforma/go-gather/gather/http"
+	goci "github.com/conforma/go-gather/gather/oci"
+	"github.com/conforma/go-gather/metadata"
+	"github.com/conforma/go-gather/registry"
 	"github.com/sirupsen/logrus"
 	"oras.land/oras-go/v2/registry/remote/retry"
 

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -33,9 +33,9 @@ import (
 	"sync"
 	"testing"
 
-	ghttp "github.com/enterprise-contract/go-gather/gather/http"
-	goci "github.com/enterprise-contract/go-gather/gather/oci"
-	"github.com/enterprise-contract/go-gather/metadata"
+	ghttp "github.com/conforma/go-gather/gather/http"
+	goci "github.com/conforma/go-gather/gather/oci"
+	"github.com/conforma/go-gather/metadata"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/random"

--- a/internal/policy/source/git_config.go
+++ b/internal/policy/source/git_config.go
@@ -25,7 +25,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/enterprise-contract/go-gather/detector"
+	"github.com/conforma/go-gather/detector"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -31,11 +31,11 @@ import (
 	"runtime/trace"
 	"sync"
 
+	fileMetadata "github.com/conforma/go-gather/gather/file"
+	gitMetadata "github.com/conforma/go-gather/gather/git"
+	ociMetadata "github.com/conforma/go-gather/gather/oci"
+	"github.com/conforma/go-gather/metadata"
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	fileMetadata "github.com/enterprise-contract/go-gather/gather/file"
-	gitMetadata "github.com/enterprise-contract/go-gather/gather/git"
-	ociMetadata "github.com/enterprise-contract/go-gather/gather/oci"
-	"github.com/enterprise-contract/go-gather/metadata"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -28,9 +28,9 @@ import (
 	"sync"
 	"testing"
 
+	fileMetadata "github.com/conforma/go-gather/gather/file"
+	"github.com/conforma/go-gather/metadata"
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	fileMetadata "github.com/enterprise-contract/go-gather/gather/file"
-	"github.com/enterprise-contract/go-gather/metadata"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
This commit updates the imports for `go-gather` which recently moved to another github org.

Ref: EC-1106