### PR TITLE
chore(Dockerfile): Update ubi reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -45,7 +45,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -147,13 +147,13 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
-    size: 1400933
-    checksum: sha256:c49a72d3ec0bf190d120d64ff9561dd6aa9a7928f0ffcd726daa626974e69902
+    size: 1398689
+    checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 645036
@@ -266,12 +266,12 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-for-aarch64-baseos-source-rpms
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
+    evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 1112974
@@ -420,13 +420,13 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
-    size: 1425529
-    checksum: sha256:4f89f5cf48a836392a03f8e037cdcb55b2d2b4ab05b8bba821a11cbc3e9a355d
+    size: 1422952
+    checksum: sha256:56283cbf84234ec9256fb68e2d2669bc5799862eb2ee40521b8ac59044567835
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pam-1.5.1-22.el9_5.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 687467
@@ -545,12 +545,12 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-for-ppc64le-baseos-source-rpms
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
+    evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 1112974
@@ -692,13 +692,13 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1423127
-    checksum: sha256:adea7d3b99a23d01925632de46597f90b9934f7f92b40c28f34ff5c501c6d8a6
+    size: 1420999
+    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 647471
@@ -811,12 +811,12 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
+    evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 1112974


### PR DESCRIPTION
This commit updates the UBI version to address CVE-2022-9043.

Ref: EC-1139