### PR TITLE
build(Dockerfile): remove git-core from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ LABEL \
   io.openshift.tags="conforma ec opa cosign sigstore"
 
 # Install tools we want to use in the Tekton task
-RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
+RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install gzip jq ca-certificates
 
 # Copy all the binaries so they're available to extract and download
 # (Beware if you're testing this locally it will copy everything from
@@ -86,6 +86,6 @@ COPY --from=build /build/LICENSE /licenses/LICENSE
 USER 1001
 
 # Show some version numbers for troubleshooting purposes
-RUN git version && jq --version && ec version && ls -l /usr/local/bin
+RUN jq --version && ec version && ls -l /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/ec"]

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -62,7 +62,7 @@ LABEL \
   com.redhat.component="ec-cli"
 
 # Install tools we want to use in the Tekton task
-RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install git-core jq
+RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install gzip jq ca-certificates
 
 # Copy all the binaries so they're available to extract and download
 # (Beware if you're testing this locally it will copy everything from
@@ -86,6 +86,6 @@ COPY --from=build /build/LICENSE /licenses/LICENSE
 USER 1001
 
 # Show some version numbers for troubleshooting purposes
-RUN git version && jq --version && ec version && ls -l /usr/local/bin
+RUN jq --version && ec version && ls -l /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/ec"]


### PR DESCRIPTION
This commit removes the `git-core` package from the Dockerfile as it is no longer required with the removal of the `go-getter` package as a direct dependency. This commit adds the installation of the `gzip` and `ca-certificates` packages as they had been installed as a part of the `git-core` installation.

Ref: EC-962