### PR TITLE
fix(deps): update `go-gather` to version v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cuelang.org/go v0.11.1
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Maldris/go-billy-afero v0.0.0-20200815120323-e9d3de59c99a
-	github.com/conforma/go-gather v1.0.0
+	github.com/conforma/go-gather v1.0.1
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gkampitakis/go-snaps v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
-github.com/conforma/go-gather v1.0.0 h1:9dCL3UW+SdkadEgPrpBbztbzxzkXMN5MbcpXiZAt+WA=
-github.com/conforma/go-gather v1.0.0/go.mod h1:AbNsdkXUBG9nEyNOGs7Tx3B0N0zgOirZS4Cus/xDhrg=
+github.com/conforma/go-gather v1.0.1 h1:i91Qyqwrgm5vE42OdqRZ1XJ+DCi0eXrTCmsEGZTOF1g=
+github.com/conforma/go-gather v1.0.1/go.mod h1:AbNsdkXUBG9nEyNOGs7Tx3B0N0zgOirZS4Cus/xDhrg=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=


### PR DESCRIPTION
This commit updates the `go-gather` dependency to v1.0.1 to resolve a bug affecting the handling of non-prefixed relative paths (i.e. `path/to/file`).

Ref: EC-1158