### PR TITLE
Use Tekton's conditional step instead of bash

### DIFF
--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -42,6 +42,7 @@ var (
 	tempPathRegex      = regexp.MustCompile(`\$\{TEMP\}([^: \\"]+)[: ]?`)                                                    // starts with "${TEMP}" and ends with something not in path, perhaps breaks on Windows due to the colon
 	randomBitsRegex    = regexp.MustCompile(`([a-f0-9]+)$`)                                                                  // in general, we add random bits to paths as suffixes
 	unixTimestamp      = regexp.MustCompile(`("| )(?:\d{10})(\\"|"|$)`)                                                      // Recent Unix timestamp in second resolution
+	tektonTimestamp    = regexp.MustCompile(`\b\d{10}\.\d+\b`)                                                               // timestamp used in Tekton logs
 )
 
 type errCapture struct {
@@ -117,6 +118,9 @@ func MatchSnapshot(ctx context.Context, qualifier, text string, vars map[string]
 
 	// more timestamps, Unix here
 	text = unixTimestamp.ReplaceAllString(text, "$1$${TIMESTAMP}$2")
+
+	// Tekton timestamps
+	text = tektonTimestamp.ReplaceAllString(text, "$${TIMESTAMP}")
 
 	// handle temp directories, replace local temp path with "${TEMP}"
 	text = strings.ReplaceAll(text, os.TempDir(), "${TEMP}")

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -374,7 +374,6 @@ ${TIMESTAMP} Skipping step because a previous step failed
 ---
 
 [Initialize TUF fails:initialize-tuf - 1]
-Initializing TUF root...
 Error: Get "http://tuf.invalid/root.json": dial tcp: lookup tuf.invalid on 10.96.0.10:53: no such host
 
 ---
@@ -471,7 +470,7 @@ success: true
 ---
 
 [Initialize TUF succeeds:initialize-tuf - 1]
-TUF_MIRROR parameter not provided. Skipping TUF root initialization.
+{"level":"info","ts":${TIMESTAMP},"caller":"entrypoint/entrypointer.go:265","msg":"Step was skipped due to when expressions were evaluated to false."}
 
 ---
 
@@ -522,7 +521,7 @@ TUF_MIRROR parameter not provided. Skipping TUF root initialization.
 ---
 
 [Outputs are there:initialize-tuf - 1]
-TUF_MIRROR parameter not provided. Skipping TUF root initialization.
+{"level":"info","ts":${TIMESTAMP},"caller":"entrypoint/entrypointer.go:265","msg":"Step was skipped due to when expressions were evaluated to false."}
 
 ---
 

--- a/hack/tekton/kustomization.yaml
+++ b/hack/tekton/kustomization.yaml
@@ -28,6 +28,7 @@ patches:
         namespace: tekton-pipelines
       data:
         enable-tekton-oci-bundles: true
+        enable-step-actions: true
 
 generators:
   - tekton.yaml

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -174,20 +174,18 @@ spec:
 
     - name: initialize-tuf
       image: quay.io/enterprise-contract/ec-cli:snapshot
-      script: |-
-        set -euo pipefail
-
-        if [[ -z "${TUF_MIRROR:-}" ]]; then
-            echo 'TUF_MIRROR parameter not provided. Skipping TUF root initialization.'
-            exit
-        fi
-
-        echo 'Initializing TUF root...'
-        ec sigstore initialize --mirror "${TUF_MIRROR}" --root "${TUF_MIRROR}/root.json"
-        echo 'Done!'
-      env:
-        - name: TUF_MIRROR
-          value: "$(params.TUF_MIRROR)"
+      command: [ec]
+      args:
+        - sigstore
+        - initialize
+        - --mirror
+        - $(params.TUF_MIRROR)
+        - --root
+        - $(params.TUF_MIRROR)/root.json
+      when:
+        - input: $(params.TUF_MIRROR)
+          operator: "notin"
+          values: [""]
 
     - name: reduce
       env:


### PR DESCRIPTION
This commit changes the `initialize-tuf` step of the `verify-enterprise-contract` Tekton Task to use a `when` expression instead of using bash as the conditional.