### PR TITLE
Create Konflux pipelines for v0.6 branch

### DIFF
--- a/.tekton/cli-build.yaml
+++ b/.tekton/cli-build.yaml
@@ -28,15 +28,6 @@ spec:
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - description: >-
-        OCI repository of the CLI image to use as a reference in the Tekton bundle. When setting
-        this value, take into account where the CLI image will be available for usage. For certain
-        workflows, e.g. pull request, this should be the repo in which the CLI image is built into
-        because those CLI images are not promoted to another location. For merge workflows that go
-        through a release, for example, this should be the repository for which the CLI image will
-        be released to.
-      name: bundle-cli-ref-repo
-      type: string
     - default: .
       description: Path to the source code of an application's component from where to build image.
       name: path-context
@@ -268,32 +259,6 @@ spec:
           values:
             - "true"
         - input: $(params.build-source-image)
-          operator: in
-          values:
-            - "true"
-    - name: build-tekton-bundle
-      params:
-        - name: IMAGE
-          value: $(params.output-image).bundle
-        - name: CONTEXT
-          value: tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
-        - name: STEPS_IMAGE
-          value: $(params.bundle-cli-ref-repo)@$(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: SOURCE_ARTIFACT
-          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      runAfter:
-        - build-image-index
-      taskRef:
-        params:
-          - name: name
-            value: tkn-bundle-oci-ta
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.1@sha256:fa83bc60093c026fe1282a7008e134e2618c08cc50bf50b16562d21c852fd26b
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
           operator: in
           values:
             - "true"

--- a/.tekton/cli-v06-pull-request.yaml
+++ b/.tekton/cli-v06-pull-request.yaml
@@ -7,14 +7,14 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-v0.6"
     pipelinesascode.tekton.dev/pipeline: ".tekton/cli-build.yaml"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-main-ci
-    appstudio.openshift.io/component: cli-main-ci
+    appstudio.openshift.io/application: ec-v06
+    appstudio.openshift.io/component: cli-v06
     pipelines.appstudio.openshift.io/type: build
-  name: cli-main-ci-on-pull-request
+  name: cli-v06-on-pull-request
   namespace: rhtap-contract-tenant
 spec:
   params:
@@ -23,9 +23,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:on-pr-{{revision}}
-    - name: bundle-cli-ref-repo
-      value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci
+      value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v06/cli-v06:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile

--- a/.tekton/cli-v06-push.yaml
+++ b/.tekton/cli-v06-push.yaml
@@ -6,14 +6,14 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-v0.6"
     pipelinesascode.tekton.dev/pipeline: ".tekton/cli-build.yaml"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ec-main-ci
-    appstudio.openshift.io/component: cli-main-ci
+    appstudio.openshift.io/application: ec-v06
+    appstudio.openshift.io/component: cli-v06
     pipelines.appstudio.openshift.io/type: build
-  name: cli-main-ci-on-push
+  name: cli-v06-on-push
   namespace: rhtap-contract-tenant
 spec:
   params:
@@ -22,9 +22,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:{{revision}}
-    - name: bundle-cli-ref-repo
-      value: quay.io/enterprise-contract/cli
+      value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v06/cli-v06:{{revision}}
     - name: image-expires-after
       value: ''
     - name: dockerfile


### PR DESCRIPTION
Notes:
- I did this manually based on the current pipeline definitions in main branch. Generally Konflux should create a PR for us, but for some reason it didn't work this time. See https://issues.redhat.com/browse/KFLUXSPRT-2145

- I removed the build-tekton-bundle task, which creates a Tekton bundle in the main branch Konflux build because we don't plan to create a Tekton bundle in the release branch builds.

- One reason we might *want* to use the generated PR is that we get a fresh pipeline definition. But I think actually we should do that in main branch first, using the method described at https://konflux.pages.redhat.com/docs/users/how-tos/configuring/reconfiguring-build-pipeline.html I think overall it's better if we stick to the same pipeline from main branch when cutting a release branch.

Ref: https://issues.redhat.com/browse/EC-1135