### PR TITLE
Freshen pipeline definition from latest defaults

### DIFF
--- a/.tekton/cli-build.yaml
+++ b/.tekton/cli-build.yaml
@@ -3,6 +3,11 @@ kind: Pipeline
 metadata:
   name: cli-build
 spec:
+  description: |
+    This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+    _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
   finally:
     - name: show-sbom
       params:
@@ -156,7 +161,7 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
         - name: dev-package-managers
-          value: 'true'
+          value: "true"
       runAfter:
         - clone-repository
       taskRef:
@@ -363,8 +368,10 @@ spec:
             - "false"
     - name: sast-snyk-check
       params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
@@ -446,10 +453,11 @@ spec:
             value: task
         resolver: bundles
     - name: rpms-signature-scan
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values: ["false"]
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
         - build-image-index
       taskRef:
@@ -461,11 +469,11 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
   workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
     pipelinesascode.tekton.dev/pipeline: ".tekton/cli-build.yaml"
   creationTimestamp: null
   labels:
@@ -26,10 +28,10 @@ spec:
       value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:on-pr-{{revision}}
     - name: bundle-cli-ref-repo
       value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci
-    - name: image-expires-after
-      value: 5d
     - name: dockerfile
       value: Dockerfile.dist
+    - name: image-expires-after
+      value: 5d
     - name: path-context
       value: .
     - name: prefetch-input

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -5,8 +5,10 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/enterprise-contract/ec-cli?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
     pipelinesascode.tekton.dev/pipeline: ".tekton/cli-build.yaml"
   creationTimestamp: null
   labels:
@@ -25,10 +27,10 @@ spec:
       value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main-ci/cli-main-ci:{{revision}}
     - name: bundle-cli-ref-repo
       value: quay.io/enterprise-contract/cli
-    - name: image-expires-after
-      value: ''
     - name: dockerfile
       value: Dockerfile.dist
+    - name: image-expires-after
+      value: ''
     - name: path-context
       value: .
     - name: prefetch-input


### PR DESCRIPTION
There are some small functional changes:
* Setting pipelinesascode.tekton.dev/cancel-in-progress: "true" for pre-merge, and "false" for post-merge.

* Adding the image-digest param to the snyk task and removing the digest from the image-url param value.

The other changes are not functionally consequential, but they make it easier to compare the existing yaml to the newly generated yaml.

Ref: https://issues.redhat.com/browse/EC-1135