### PR TITLE
Include reduce-snapshot in Konflux built image

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -79,6 +79,9 @@ COPY --from=build "/build/dist/ec_${TARGETOS}_${TARGETARCH}" /usr/local/bin/ec
 # Copy the one kubectl binary that can run in this container
 COPY --from=build "/build/dist/kubectl_${TARGETOS}_${TARGETARCH}" /usr/local/bin/kubectl
 
+# Copy reduce-snapshot script needed for single component mode
+COPY hack/reduce-snapshot.sh /usr/local/bin
+
 # OpenShift preflight check requires a license
 COPY --from=build /build/LICENSE /licenses/LICENSE
 


### PR DESCRIPTION
This was added for the upstream build only, and we didn't notice until now, since RHTAP pipelines are starting to use an updated task definition that include the reduce-snapshot step.

Ref: https://issues.redhat.com/browse/RHTAP-4567