### PR TITLE
fix(EC-1063): Add new Konflux SAST tasks to pipelines

### DIFF
--- a/.tekton/cli-build.yaml
+++ b/.tekton/cli-build.yaml
@@ -297,6 +297,58 @@ spec:
           operator: in
           values:
             - "true"
+    - name: sast-unicode-check
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-unicode-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:424f2f659c02998dc3a43e1ce869e3148982c59adb74f953f8fa91ff1c9ab86e
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces: []
+    - name: sast-shell-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-shell-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:4b704fa3a3f56a350dd93df506e2d13d102202f124548604877377db2c4c9c22
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+      workspaces: []
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL


### PR DESCRIPTION
The 'sast-unicode-check' and 'sast-shell-check' tasks will become required for all Konflux builds on April 1st.

This change adds them to the Konflux build pipeline definitions in this repo.

See also:
- [Related Announcement](https://groups.google.com/a/redhat.com/g/konflux-announce/c/OEcuK1Sr7dI/m/xKwD_bMcAQAJ)
- [Task definitions](https://github.com/konflux-ci/build-definitions/tree/main/task).
- [KONFLUX-2264](https://issues.redhat.com/browse/KONFLUX-2264)
- [EC-1063](https://issues.redhat.com/browse/EC-1063)

(This PR was generated automatically using [the script here](https://gitlab.cee.redhat.com/ynanavat/generate-bulk-tekton-prs/-/blob/main/bulk-update-repos.sh?ref_type=heads).)