### PR TITLE
Renovate doesnt support schedule with minutes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    "config:best-practices"
+    "config:best-practices",
+    "schedule:earlySundays"
   ],
   "timezone": "America/New_York",
-  "schedule": ["0 15 * * 0"],
   "baseBranches": ["main", "release-v0.5", "release-v0.6"],
   "packageRules": [
     {


### PR DESCRIPTION
The cron scheduler doesnt support specifying minutes. This new schedule will run early each Sunday.