### PR TITLE
Upgrading go

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.7
+golang 1.23.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ## Build
 
-FROM docker.io/library/golang:1.22.7 AS build
+FROM docker.io/library/golang:1.23.6 AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -17,8 +17,8 @@
 ## Build
 
 # Ideally, use the official image from Red Hat, e.g. registry.access.redhat.com/ubi9/go-toolset,
-# but a 1.22 release does not yet exist.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22.7@sha256:376dd8d1291580a32824c7a072b72e1dce524bb9d300393b656931ba6156b86d AS build
+# but a 1.23 release does not yet exist.
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6@sha256:a7c185b0cc02c3d0fd54ec764d25a40639af8be1dc7ee1e82befb9086e418051 AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/acceptance
 
-go 1.22.7
+go 1.23.6
 
 require (
 	cuelang.org/go v0.11.1

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -303,8 +303,6 @@ github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71 h1:vQg7B+fR885wn2eZmRqNI9VoWDIGUAlgtgEtQiap0mc=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.71/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79 h1:3w1Yjakmg7bD4/EM+xvALQzSaBNcuL4CLjf0EH/0qys=
 github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli
 
-go 1.22.7
+go 1.23.6
 
 require (
 	cuelang.org/go v0.11.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/tools
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/daixiang0/gci v0.13.5

--- a/tools/kubectl/go.mod
+++ b/tools/kubectl/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-cli/tools/kubectl
 
-go 1.22.7
+go 1.23.6
 
 require k8s.io/kubernetes v1.31.3
 


### PR DESCRIPTION
Renovate is updating dependencies that require go be upgraded.

https://issues.redhat.com/browse/EC-1143