### PR TITLE
Allow using rekor public key in ec.sigstore func

### DIFF
--- a/acceptance/examples/sigstore.rego
+++ b/acceptance/examples/sigstore.rego
@@ -40,6 +40,16 @@ _errors contains error if {
 }
 
 _errors contains error if {
+	opts := {k: v |
+		some k, v in data.config.default_sigstore_opts
+		v != ""
+	}
+	info := ec.sigstore.verify_image(_image_ref, opts)
+	some raw_error in info.errors
+	error := sprintf("image incomplete sigstore opts (%s): %s", [opts, raw_error])
+}
+
+_errors contains error if {
 	info := ec.sigstore.verify_attestation(_image_ref, _sigstore_opts)
 	some raw_error in info.errors
 	error := sprintf("image attestation verification failed: %s", [raw_error])
@@ -80,6 +90,16 @@ _errors contains error if {
 	builder_id := _builder_id(att)
 	builder_id != "https://tekton.dev/chains/v2"
 	error := sprintf("unexpected builder ID: %s", [builder_id])
+}
+
+_errors contains error if {
+	opts := {k: v |
+		some k, v in data.config.default_sigstore_opts
+		v != ""
+	}
+	info := ec.sigstore.verify_attestation(_image_ref, opts)
+	some raw_error in info.errors
+	error := sprintf("attestation incomplete sigstore opts (%s): %s", [opts, raw_error])
 }
 
 _image_ref := input.image.ref

--- a/docs/modules/ROOT/pages/ec_sigstore_verify_attestation.adoc
+++ b/docs/modules/ROOT/pages/ec_sigstore_verify_attestation.adoc
@@ -4,12 +4,12 @@ Use sigstore to verify the attestation of an image.
 
 == Usage
 
-  result = ec.sigstore.verify_attestation(ref: string, opts: object<certificate_identity: string, certificate_identity_regexp: string, certificate_oidc_issuer: string, certificate_oidc_issuer_regexp: string, ignore_rekor: boolean, public_key: string, rekor_url: string>)
+  result = ec.sigstore.verify_attestation(ref: string, opts: object<ignore_rekor: boolean>[string: string])
 
 == Parameters
 
 * `ref` (`string`): OCI image reference
-* `opts` (`object<certificate_identity: string, certificate_identity_regexp: string, certificate_oidc_issuer: string, certificate_oidc_issuer_regexp: string, ignore_rekor: boolean, public_key: string, rekor_url: string>`): Sigstore verification options
+* `opts` (`object<ignore_rekor: boolean>[string: string]`): Sigstore verification options. Dynamic string properties: `certificate_identity`, `certificate_identity_regexp`, `certificate_oidc_issuer`, `certificate_oidc_issuer_regexp`, `public_key`, `rekor_url`, `rekor_public_key`.
 
 == Return
 

--- a/docs/modules/ROOT/pages/ec_sigstore_verify_image.adoc
+++ b/docs/modules/ROOT/pages/ec_sigstore_verify_image.adoc
@@ -4,12 +4,12 @@ Use sigstore to verify the signature of an image.
 
 == Usage
 
-  result = ec.sigstore.verify_image(ref: string, opts: object<certificate_identity: string, certificate_identity_regexp: string, certificate_oidc_issuer: string, certificate_oidc_issuer_regexp: string, ignore_rekor: boolean, public_key: string, rekor_url: string>)
+  result = ec.sigstore.verify_image(ref: string, opts: object<ignore_rekor: boolean>[string: string])
 
 == Parameters
 
 * `ref` (`string`): OCI image reference
-* `opts` (`object<certificate_identity: string, certificate_identity_regexp: string, certificate_oidc_issuer: string, certificate_oidc_issuer_regexp: string, ignore_rekor: boolean, public_key: string, rekor_url: string>`): Sigstore verification options
+* `opts` (`object<ignore_rekor: boolean>[string: string]`): Sigstore verification options. Dynamic string properties: `certificate_identity`, `certificate_identity_regexp`, `certificate_oidc_issuer`, `certificate_oidc_issuer_regexp`, `public_key`, `rekor_url`, `rekor_public_key`.
 
 == Return
 

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -103,6 +103,21 @@ func TestSigstoreVerifyImage(t *testing.T) {
 			},
 		},
 		{
+			name:    "long lived key with rekor public key",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			uri:     ast.StringTerm(goodImage.String()),
+			opts:    options{publicKey: utils.TestPublicKey, rekorPublicKey: utils.TestRekorPublicKey},
+			optsVerifier: func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.NotNil(t, checkOpts)
+				require.False(t, checkOpts.IgnoreTlog)
+				require.Empty(t, checkOpts.Identities)
+				require.Nil(t, checkOpts.RekorClient)
+				require.NotEmpty(t, checkOpts.RekorPubKeys.Keys[utils.TestRekorURLLogID])
+			},
+		},
+		{
 			name:    "fulcio key regex",
 			success: ast.BooleanTerm(true),
 			errors:  ast.ArrayTerm(),
@@ -251,6 +266,21 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 				require.NotNil(t, checkOpts.RekorClient)
 			},
 			sigs: []oci.Signature{goodSig},
+		},
+		{
+			name:    "long lived key with rekor public key",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			uri:     ast.StringTerm(goodImage.String()),
+			opts:    options{publicKey: utils.TestPublicKey, rekorPublicKey: utils.TestRekorPublicKey},
+			optsVerifier: func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.NotNil(t, checkOpts)
+				require.False(t, checkOpts.IgnoreTlog)
+				require.Empty(t, checkOpts.Identities)
+				require.Nil(t, checkOpts.RekorClient)
+				require.NotEmpty(t, checkOpts.RekorPubKeys.Keys[utils.TestRekorURLLogID])
+			},
 		},
 		{
 			name:    "fulcio key",


### PR DESCRIPTION
This commit extends the `ec.sigstore.verify_image` and `ec.sigstore.verify_attestation` to accept a new option, `rekor_public_key`. When provided, an offline Rekor verification is performed on the signature.

Ref: EC-1200