### PR TITLE
Set BUILD_SUFFIX build arg for main branch builds

### DIFF
--- a/.tekton/cli-main-ci-pull-request.yaml
+++ b/.tekton/cli-main-ci-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     - name: build-source-image
       value: 'true'
     - name: build-args-file
-      value: quick-build-args.conf
+      value: main-pre-merge-build-args.conf
     - name: hermetic
       value: 'true'
   pipelineRef:

--- a/.tekton/cli-main-ci-push.yaml
+++ b/.tekton/cli-main-ci-push.yaml
@@ -38,7 +38,7 @@ spec:
     - name: build-source-image
       value: 'true'
     - name: build-args-file
-      value: ''
+      value: main-build-args.conf
     - name: hermetic
       value: 'true'
   pipelineRef:

--- a/main-build-args.conf
+++ b/main-build-args.conf
@@ -1,0 +1,3 @@
+# The default in Dockerfile.dist is "redhat" but we
+# want that in release branch only, not main branch
+BUILD_SUFFIX=

--- a/main-pre-merge-build-args.conf
+++ b/main-pre-merge-build-args.conf
@@ -1,0 +1,6 @@
+# The default in Dockerfile.dist is "redhat" but we
+# want that in release branch only, not main branch
+BUILD_SUFFIX=
+# Save time by not building all the platform/arch
+# cominations in a pre-merge build pipeline
+BUILD_LIST=linux_amd64

--- a/quick-build-args.conf
+++ b/quick-build-args.conf
@@ -1,1 +1,0 @@
-BUILD_LIST=linux_amd64


### PR DESCRIPTION
Use the build-args-file pipeline param to do it. I considered using the build-args pipeline param instead, but since we're already using build-args-file figured let's continue using it.

Another reasonable way to do this would have been to change the default value and then use a build arg for the release branch builds, but I decided this way was a little nicer since we have multiple release branches and only one main branch.

Ref: https://issues.redhat.com/browse/EC-1223