### PR TITLE
Use new Konflux built Tekton Bundle in Red Hat Konflux

### DIFF
--- a/hack/update-build-definitions.sh
+++ b/hack/update-build-definitions.sh
@@ -30,13 +30,14 @@ TARGET_DIR="${1}"
 cd "${TARGET_DIR}" || exit 1
 
 echo 'Resolving task bundle...'
+TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
 TASK_BUNDLE_TAG="${2:-snapshot}"
 MANIFEST=$(mktemp --tmpdir)
 function cleanup() {
     rm "${MANIFEST}"
 }
 trap cleanup EXIT
-skopeo inspect "docker://quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}" --raw > "${MANIFEST}"
+skopeo inspect "docker://${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}" --raw > "${MANIFEST}"
 TASK_BUNDLE_DIGEST="$(skopeo manifest-digest "${MANIFEST}")"
 REVISION="$(jq -r '.annotations["org.opencontainers.image.revision"]' "${MANIFEST}")"
 if [[ -z "${KEEP_TAG:-}" && -n "${REVISION}" && "${REVISION}" != null ]]; then
@@ -44,9 +45,10 @@ if [[ -z "${KEEP_TAG:-}" && -n "${REVISION}" && "${REVISION}" != null ]]; then
 fi
 # Sanity check
 diff \
-    <(skopeo inspect --raw "docker://quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}") \
-    <(skopeo inspect --raw "docker://quay.io/enterprise-contract/ec-task-bundle@${TASK_BUNDLE_DIGEST}")
-TASK_BUNDLE_REF="quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
+    <(skopeo inspect --raw "docker://${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}") \
+    <(skopeo inspect --raw "docker://${TASK_BUNDLE_REPO}@${TASK_BUNDLE_DIGEST}")
+
+TASK_BUNDLE_REF="${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
 echo "Resolved bundle is ${TASK_BUNDLE_REF}"
 
 function update() {

--- a/hack/update-build-definitions.sh
+++ b/hack/update-build-definitions.sh
@@ -30,8 +30,16 @@ TARGET_DIR="${1}"
 cd "${TARGET_DIR}" || exit 1
 
 echo 'Resolving task bundle...'
-TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
-TASK_BUNDLE_TAG="${2:-snapshot}"
+
+# Task definition built and pushed from main branch in the ec-cli
+# repo by the Conforma Konflux build pipeline
+TASK_BUNDLE_REPO=quay.io/enterprise-contract/tekton-task
+TASK_BUNDLE_TAG="${2:-latest}"
+
+# The same but built and pushed by a GitHub Workflow. Now deprecated.
+#TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
+#TASK_BUNDLE_TAG="${2:-snapshot}"
+
 MANIFEST=$(mktemp --tmpdir)
 function cleanup() {
     rm "${MANIFEST}"

--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -28,8 +28,16 @@ TARGET_DIR="${1}"
 cd "${TARGET_DIR}" || exit 1
 
 echo 'Resolving task bundle...'
-TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
-TASK_BUNDLE_TAG="${2:-snapshot}"
+
+# Task definition built and pushed from main branch in the ec-cli
+# repo by the Conforma Konflux build pipeline
+TASK_BUNDLE_REPO=quay.io/enterprise-contract/tekton-task
+TASK_BUNDLE_TAG="${2:-latest}"
+
+# The same but built and pushed by a GitHub Workflow. Now deprecated.
+#TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
+#TASK_BUNDLE_TAG="${2:-snapshot}"
+
 MANIFEST=$(mktemp --tmpdir)
 function cleanup() {
     rm "${MANIFEST}"

--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -28,13 +28,14 @@ TARGET_DIR="${1}"
 cd "${TARGET_DIR}" || exit 1
 
 echo 'Resolving task bundle...'
+TASK_BUNDLE_REPO=quay.io/enterprise-contract/ec-task-bundle
 TASK_BUNDLE_TAG="${2:-snapshot}"
 MANIFEST=$(mktemp --tmpdir)
 function cleanup() {
     rm "${MANIFEST}"
 }
 trap cleanup EXIT
-skopeo inspect "docker://quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}" --raw > "${MANIFEST}"
+skopeo inspect "docker://${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}" --raw > "${MANIFEST}"
 TASK_BUNDLE_DIGEST="$(skopeo manifest-digest "${MANIFEST}")"
 REVISION="$(jq -r '.annotations["org.opencontainers.image.revision"]' "${MANIFEST}")"
 if [[ -n "${REVISION}" && "${REVISION}" != null ]]; then
@@ -42,9 +43,10 @@ if [[ -n "${REVISION}" && "${REVISION}" != null ]]; then
 fi
 # Sanity check
 diff \
-    <(skopeo inspect --raw "docker://quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}") \
-    <(skopeo inspect --raw "docker://quay.io/enterprise-contract/ec-task-bundle@${TASK_BUNDLE_DIGEST}")
-TASK_BUNDLE_REF="quay.io/enterprise-contract/ec-task-bundle:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
+    <(skopeo inspect --raw "docker://${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}") \
+    <(skopeo inspect --raw "docker://${TASK_BUNDLE_REPO}@${TASK_BUNDLE_DIGEST}")
+
+TASK_BUNDLE_REF="${TASK_BUNDLE_REPO}:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
 echo "Resolved bundle is ${TASK_BUNDLE_REF}"
 echo "Resolved revision is ${REVISION}"
 


### PR DESCRIPTION
Update two scripts used by the automation which updates build-definitions and infra-deployments.

See also https://github.com/enterprise-contract/infra-deployments-ci/blob/main/.github/workflows/create-pr.yaml .

Ref: [EC-913](https://issues.redhat.com/browse/EC-913)