### PR TITLE
Include 'term' attribute in report by default

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -76,7 +76,7 @@
 ---
 
 [JUnit and AppStudio output format:stdout - 1]
-<testsuites tests="7" failures="3"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="7" failures="3" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.reject_with_term: Fails always (term1)" classname="main.reject_with_term: Fails always (term1)"><failure message="Fails always (term1)"><![CDATA[Fails always (term1)]]></failure></testcase><testcase name="main.reject_with_term: Fails always (term2)" classname="main.reject_with_term: Fails always (term2)"><failure message="Fails always (term2)"><![CDATA[Fails always (term2)]]></failure></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
+<testsuites tests="7" failures="3"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="7" failures="3" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.reject_with_term: Fails always (term1) [term=term1]" classname="main.reject_with_term: Fails always (term1) [term=term1]"><failure message="Fails always (term1)"><![CDATA[Fails always (term1)]]></failure></testcase><testcase name="main.reject_with_term: Fails always (term2) [term=[term2 term3]]" classname="main.reject_with_term: Fails always (term2) [term=[term2 term3]]"><failure message="Fails always (term2)"><![CDATA[Fails always (term2)]]></failure></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
 
 ---
 
@@ -540,13 +540,18 @@ Error: success criteria not met
         {
           "msg": "Fails always (term1)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": "term1"
           }
         },
         {
           "msg": "Fails always (term2)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": [
+              "term2",
+              "term3"
+            ]
           }
         },
         {
@@ -1102,13 +1107,18 @@ Error: success criteria not met
         {
           "msg": "Fails always (term1)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": "term1"
           }
         },
         {
           "msg": "Fails always (term2)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": [
+              "term2",
+              "term3"
+            ]
           }
         },
         {
@@ -1936,6 +1946,7 @@ Results:
 [31m✕[0m [31m[Violation] main.reject_with_term[0m
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always (term1)
+  Term: term1
   Title: Reject with term rule
   Description: This rule will always fail. To exclude this rule add "main.reject_with_term:term1" to the `exclude` section of the
   policy configuration.
@@ -1944,6 +1955,7 @@ Results:
 [31m✕[0m [31m[Violation] main.reject_with_term[0m
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always (term2)
+  Terms: term2, term3
   Title: Reject with term rule
   Description: This rule will always fail. To exclude this rule add one or more of "main.reject_with_term:term2",
   "main.reject_with_term:term3" to the `exclude` section of the policy configuration.
@@ -4799,10 +4811,12 @@ Results:
 ✕ [Violation] main.reject_with_term
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always (term1)
+  Term: term1
 
 ✕ [Violation] main.reject_with_term
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always (term2)
+  Terms: term2, term3
 
 ✕ [Violation] main.rejector
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
@@ -4828,13 +4842,18 @@ Error: success criteria not met
         {
           "msg": "Fails always (term1)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": "term1"
           }
         },
         {
           "msg": "Fails always (term2)",
           "metadata": {
-            "code": "main.reject_with_term"
+            "code": "main.reject_with_term",
+            "term": [
+              "term2",
+              "term3"
+            ]
           }
         },
         {

--- a/internal/applicationsnapshot/templates/_results.tmpl
+++ b/internal/applicationsnapshot/templates/_results.tmpl
@@ -24,6 +24,14 @@
       {{- indentWrap $indent $wrap (printf "Reason: %s" .Message) }}{{ nl -}}
     {{- end -}}
 
+    {{- if .Metadata.term }}
+      {{- if isString .Metadata.term }}
+        {{- indentWrap $indent $wrap (printf "Term: %s" .Metadata.term) }}{{ nl -}}
+      {{- else -}}
+        {{- with $list := joinStrSlice .Metadata.term ", " -}}{{- indentWrap $indent $wrap (printf "Terms: %s" $list) -}}{{ nl -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+
     {{- if .Metadata.title }}
       {{- indentWrap $indent $wrap (printf "Title: %s" .Metadata.title) }}{{ nl -}}
     {{- end -}}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -218,7 +218,7 @@ func keepSomeMetadata(results []evaluator.Result) {
 
 func keepSomeMetadataSingle(result evaluator.Result) {
 	for key := range result.Metadata {
-		if key == "code" || key == "effective_on" {
+		if key == "code" || key == "effective_on" || key == "term" {
 			continue
 		}
 		delete(result.Metadata, key)

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -151,6 +151,35 @@ func toMap(values ...interface{}) (map[string]interface{}, error) {
 	return m, nil
 }
 
+func isString(value interface{}) bool {
+	switch value.(type) {
+	case string:
+		return true
+	default:
+		return false
+	}
+}
+
+func joinStrSlice(slice []interface{}, sep string) (string, error) {
+	var b strings.Builder
+
+	for index, s := range slice {
+
+		elem, ok := s.(string)
+		if !ok {
+			return "", fmt.Errorf("joinStrSlice argument must be a slice of strings")
+		}
+
+		if index > 0 {
+			b.WriteString(sep)
+		}
+
+		b.WriteString(elem)
+	}
+
+	return b.String(), nil
+}
+
 // Can make it easier to get the right number of line breaks
 func nl() string {
 	return "\n"
@@ -166,5 +195,7 @@ var templateHelpers = template.FuncMap{
 	"indent":         indent,
 	"indentWrap":     indentWrap,
 	"toMap":          toMap,
+	"isString":       isString,
+	"joinStrSlice":   joinStrSlice,
 	"nl":             nl,
 }

--- a/internal/utils/templates_test.go
+++ b/internal/utils/templates_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"embed"
 	_ "embed"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,113 @@ func TestSetupTemplate(t *testing.T) {
 		} else {
 			err = tmpl.ExecuteTemplate(&buf, tt.main, tt.input)
 			assert.NoError(t, err)
+		}
+		assert.Equal(t, tt.expected, buf.String())
+	}
+}
+
+func TestTemplateHelpers(t *testing.T) {
+	tmpl, err := SetupTemplate(testTemplatesFS)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		main        string
+		expected    string
+		expectedErr error
+		input       map[string]interface{}
+	}{
+		{
+			main: "helpers.tmpl",
+			input: map[string]interface{}{
+				"colorText": map[string]interface{}{
+					"color": "success",
+					"str":   "color test",
+				},
+				"indicator": map[string]interface{}{
+					"color": "warning",
+				},
+				"colorIndicator": map[string]interface{}{
+					"color": "violation",
+				},
+				"wrap": map[string]interface{}{
+					"width": 3,
+					"s":     "wrapped string",
+				},
+				"indent": map[string]interface{}{
+					"n": 3,
+					"s": "indentation test",
+				},
+				"indentWrap": map[string]interface{}{
+					"n":     3,
+					"width": 10,
+					"s":     "indent wrapped test",
+				},
+				"toMap": map[string]interface{}{
+					"k1": "key1",
+					"v1": "value1",
+					"k2": "key2",
+					"v2": "value2",
+				},
+				"isString": map[string]interface{}{
+					"value": "str",
+				},
+				"joinStrSlice": map[string]interface{}{
+					"slice": []interface{}{"one", "two", "three"},
+					"sep":   ",",
+				},
+			},
+			expected:    "\x1b[32mcolor test\x1b[0m\n›indicator\n\x1b[31m✕\x1b[0mcolorIndicator\nwrapped\nstring\n   indentation test\n   indent\n   wrapped\n   test\nkey1: value1\nkey2: value2\n\ntrue\none,two,three",
+			expectedErr: nil,
+		},
+		{
+			main: "helpers.tmpl",
+			input: map[string]interface{}{
+				"colorText": map[string]interface{}{
+					"color": "another",
+					"str":   "color test",
+				},
+				"isString": map[string]interface{}{
+					"value": 2,
+				},
+			},
+			expected:    "color test\nfalse\n",
+			expectedErr: nil,
+		},
+		{
+			main: "helpers.tmpl",
+			input: map[string]interface{}{
+				"joinStrSlice": map[string]interface{}{
+					"slice": []interface{}{1, 2, 3},
+					"sep":   ",",
+				},
+			},
+			expected:    "",
+			expectedErr: errors.New("joinStrSlice argument must be a slice of strings"),
+		},
+		{
+			main: "helpers.tmpl",
+			input: map[string]interface{}{
+				"toMap": map[string]interface{}{
+					"k1": 1,
+					"v1": "value1",
+					"k2": 2,
+					"v2": "value2",
+				},
+			},
+			expected:    "",
+			expectedErr: errors.New("toMap keys must be strings"),
+		},
+	}
+	for _, tt := range tests {
+		var buf bytes.Buffer
+
+		SetColorEnabled(false, true)
+		err := tmpl.ExecuteTemplate(&buf, tt.main, tt.input)
+
+		if tt.expectedErr != nil {
+			assert.ErrorContains(t, err, tt.expectedErr.Error())
+		} else {
+			assert.Nil(t, err)
 		}
 		assert.Equal(t, tt.expected, buf.String())
 	}

--- a/internal/utils/test_templates/helpers.tmpl
+++ b/internal/utils/test_templates/helpers.tmpl
@@ -1,0 +1,56 @@
+{{- if .colorText -}}
+    {{- colorText .colorText.color .colorText.str -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .indicator -}}
+    {{- indicator .indicator.color -}} indicator
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .colorIndicator -}}
+    {{- colorIndicator .colorIndicator.color -}} colorIndicator
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .wrap -}}
+    {{- wrap .wrap.width .wrap.s -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .indent -}}
+    {{- indent .indent.n .indent.s -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .indentWrap -}}
+    {{- indentWrap .indentWrap.n .indentWrap.width .indentWrap.s -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .toMap -}}
+    {{- with $map := toMap .toMap.k1 .toMap.v1 .toMap.k2 .toMap.v2 -}}
+        {{- range $key, $value := $map -}}
+            {{- printf "%s: %s" $key $value -}}
+            {{- nl -}}
+        {{- end -}}
+    {{- end -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .isString -}}
+    {{- if isString .isString.value -}} true {{- else -}} false {{- end -}}
+    {{- nl -}}
+{{- end -}}
+
+
+{{- if .joinStrSlice -}}
+    {{- joinStrSlice .joinStrSlice.slice .joinStrSlice.sep -}}
+{{- end -}}


### PR DESCRIPTION
Add the 'term' attribute in the YAML and JSON reports produced by 'ec validate image', eliminating the need for the '--info' flag. The term may be useful in include/exclude clauses

Ref: https://issues.redhat.com/browse/EC-673