### PR TITLE
Remove the debug output from the tekton task

### DIFF
--- a/features/__snapshots__/ta_task_validate_image.snap
+++ b/features/__snapshots__/ta_task_validate_image.snap
@@ -4,6 +4,29 @@
 }
 ---
 
+[Golden container image with trusted artifacts:show-config - 1]
+{
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::github.com/enterprise-contract/ec-policies//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
+          "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
+      }
+    ],
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
+  },
+  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----\n",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
 [Golden container image with trusted artifacts:report-json - 1]
 {
   "success": true,

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -276,20 +276,24 @@ success: true
 
 [Golden container image:show-config - 1]
 {
-  "sources": [
-    {
-      "policy": [
-        "git::github.com/enterprise-contract/ec-policies//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
-        "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
-      ],
-      "config": {
-        "include": [
-          "slsa_provenance_available"
-        ]
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::github.com/enterprise-contract/ec-policies//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
+          "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
       }
-    }
-  ],
-  "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
+    ],
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
+  },
+  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----\n",
+  "effective-time": "${TIMESTAMP}"
 }
 ---
 

--- a/features/ta_task_validate_image.feature
+++ b/features/ta_task_validate_image.feature
@@ -48,3 +48,5 @@ Feature: Verify Conforma Trusted Artifact Tekton Task
     Then the task should succeed
      And the task logs for step "report-json" should match the snapshot
      And the task results should match the snapshot
+     And the task logs for step "show-config" should match the snapshot
+

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -297,27 +297,7 @@ Feature: Verify Enterprise Contract Tekton Tasks
       | IGNORE_REKOR         | true                                                                          |
       | EFFECTIVE_TIME       | 2020-01-01T00:00:00Z                                                          |
     Then the task should succeed
-      And the task logs for step "debug-log" should contain "Using provided effective time 2020-01-01T00:00:00Z"
-
-  # Previously we did allow a custom timeout to be set via the TIMEOUT param, but now it's ignored.
-  # (This test could be removed in the future, but let's keep it for now I guess.)
-  Scenario: Deprecated timeout param is ignored
-    Given a working namespace
-      And a key pair named "known"
-      And an image named "acceptance/timeout"
-      And a valid image signature of "acceptance/timeout" image signed by the "known" key
-      And a valid attestation of "acceptance/timeout" signed by the "known" key
-      And a cluster policy with content:
-      ```
-      {"publicKey": ${known_PUBLIC_KEY}}
-      ```
-    When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
-      | IMAGES               | {"components": [{"containerImage": "${REGISTRY}/acceptance/timeout"}]} |
-      | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                            |
-      | IGNORE_REKOR         | true                                                                   |
-      | TIMEOUT              | 666s                                                                   |
-    Then the task should succeed
-      And the task logs for step "debug-log" should contain "globalTimeout is 100h0m0s"
+      And the task logs for step "show-config" should contain "effective-time":"2020-01-01T00:00:00Z"
 
   Scenario: SSL_CERT_DIR environment variable is customized
     Given a working namespace

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -316,7 +316,7 @@ spec:
       image: quay.io/enterprise-contract/ec-cli:snapshot
       command: [jq]
       args:
-        - ".policy"
+        - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
         - "$(params.HOMEDIR)/report-json.json"
 
     - name: assert

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -230,7 +230,6 @@ spec:
       args:
         - validate
         - image
-        - "--verbose"
         - "--images"
         - "/tekton/home/snapshot.json"
         - "--policy"
@@ -259,7 +258,6 @@ spec:
         - "appstudio=$(results.TEST_OUTPUT.path)"
         - "--output"
         - "json=$(params.HOMEDIR)/report-json.json"
-        - "--logfile=$(params.HOMEDIR)/debug.log"
       env:
         - name: SSL_CERT_DIR
           # The Tekton Operator automatically sets the SSL_CERT_DIR env to the value below but,
@@ -320,12 +318,6 @@ spec:
       args:
         - ".policy"
         - "$(params.HOMEDIR)/report-json.json"
-
-    - name: debug-log
-      image: quay.io/enterprise-contract/ec-cli:snapshot
-      command: [cat]
-      args:
-        - "$(params.HOMEDIR)/debug.log"
 
     - name: assert
       image: quay.io/enterprise-contract/ec-cli:snapshot

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -222,7 +222,6 @@ spec:
       args:
         - validate
         - image
-        - "--verbose"
         - "--images"
         - "/tekton/home/snapshot.json"
         - "--policy"
@@ -251,7 +250,6 @@ spec:
         - "appstudio=$(results.TEST_OUTPUT.path)"
         - "--output"
         - "json=$(params.HOMEDIR)/report-json.json"
-        - "--logfile=$(params.HOMEDIR)/debug.log"
       env:
         - name: SSL_CERT_DIR
           # The Tekton Operator automatically sets the SSL_CERT_DIR env to the value below but,
@@ -342,18 +340,6 @@ spec:
       args:
         - ".policy"
         - "$(params.HOMEDIR)/report-json.json"
-
-    - name: debug-log
-      computeResources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          memory: 256Mi
-      image: quay.io/enterprise-contract/ec-cli:snapshot
-      command: [cat]
-      args:
-        - "$(params.HOMEDIR)/debug.log"
 
     - name: assert
       computeResources:

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -338,7 +338,7 @@ spec:
       image: quay.io/enterprise-contract/ec-cli:snapshot
       command: [jq]
       args:
-        - ".policy"
+        - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
         - "$(params.HOMEDIR)/report-json.json"
 
     - name: assert


### PR DESCRIPTION
Remove the debug output from the tekton task since it's too long and not that useful

Ref: https://issues.redhat.com/browse/EC-1206