### PR TITLE
Revert workaround for malformed URI schemas

### DIFF
--- a/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
+++ b/pkg/schema/__snapshots__/slsa_provenance_v0.2_test.snap
@@ -167,6 +167,10 @@ nil
   [I#/predicate/invocation/configSource/entryPoint] [S#/properties/predicate/properties/invocation/properties/configSource/properties/entryPoint/type] expected string, but got number
 ---
 
+[TestPredicateInvocationConfigSourceEntryPoint/case_3 - 1]
+nil
+---
+
 [TestPredicateInvocationParameters/case_0 - 1]
 nil
 ---
@@ -217,10 +221,6 @@ nil
 ---
 
 [TestPredicateMetadataBuildInvocationId/case_3 - 1]
-nil
----
-
-[TestPredicateInvocationConfigSourceEntryPoint/case_3 - 1]
 nil
 ---
 
@@ -407,11 +407,13 @@ nil
 ---
 
 [TestPredicateMaterialsUri/case_1 - 1]
-nil
+[I#] [S#] doesn't validate with https://slsa.dev/provenance/v0.2#
+  [I#/predicate/materials/0/uri] [S#/properties/predicate/properties/materials/items/properties/uri/format] '' is not valid 'uri'
 ---
 
 [TestPredicateMaterialsUri/case_2 - 1]
-nil
+[I#] [S#] doesn't validate with https://slsa.dev/provenance/v0.2#
+  [I#/predicate/materials/0/uri] [S#/properties/predicate/properties/materials/items/properties/uri/format] 'not_uri' is not valid 'uri'
 ---
 
 [TestPredicateMaterialsUri/case_3 - 1]

--- a/pkg/schema/slsa_provenance_v0.2.json
+++ b/pkg/schema/slsa_provenance_v0.2.json
@@ -151,7 +151,8 @@
             "type": "object",
             "properties": {
               "uri": {
-                "type": "string"
+                "type": "string",
+                "format": "uri"
               },
               "digest": {
                 "$ref": "#/$defs/DigestSet"


### PR DESCRIPTION
This reverts commit c1596bb, that was a temporary workaround to handle malformed URIs generated by tekton chains.
The workaround is no longer necessary, since this issue was fixed in the upstream Chains repository.

Ref: https://issues.redhat.com/browse/EC-87
Ref: https://github.com/enterprise-contract/ec-cli/pull/649
Ref: https://github.com/tektoncd/chains/pull/792