### PR TITLE
Properly handle error output when validating image

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -2320,6 +2320,16 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:33: rego_type_error: undefi
 
 ---
 
+[happy day with invalid extra rule data:stdout - 1]
+
+---
+
+[happy day with invalid extra rule data:stderr - 1]
+Error: Incorrect syntax for --extra-rule-data 0
+Incorrect syntax for --extra-rule-data 1
+
+---
+
 [rule dependencies:stdout - 1]
 {
   "success": false,

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -124,6 +124,31 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: happy day with invalid extra rule data
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --extra-rule-data key-without-value-1,key-without-value-2 --show-successes --output json"
+    Then the exit status should be 1
+    Then the output should match the snapshot
+
   Scenario: invalid image signature
     Given a key pair named "known"
     Given a key pair named "unknown"


### PR DESCRIPTION
The 'ec validate image' command now handles error cases more organically, by collecting them and returning them as a list at the end of the execution, returning with exit status 1.
The previous implementation caused the command to exit with status 2 and to output the whole exception in the stderr channel.

Ref: https://issues.redhat.com/browse/EC-1020