### PR TITLE
Split report-json into more manageable line lengths

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -288,9 +288,15 @@ spec:
     - name: report-json
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue  # progress even if the step fails so we can see the debug logs
-      command: [cat]
+      command: [sh, -c]
       args:
-        - "$(params.HOMEDIR)/report-json.json"
+        # Format the JSON output to wrap lines at 8000 characters per line.
+        # The report can get very large, so add some line breaks
+        # rather than print it as a single line. This makes it easier to render
+        # in the UI, easier to copy/paste, and less likely to cause problems
+        # with logging systems or other consumers of the data (assuming they
+        # correctly parse the full output).
+        - "jq . $(params.HOMEDIR)/report-json.json | awk '{gsub(/^ +/, \"\"); acc += length; if (acc >= 8000) { printf \"\\n\"; acc=length } printf $0 }'"
 
     - name: summary
       image: quay.io/enterprise-contract/ec-cli:snapshot

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -286,9 +286,15 @@ spec:
           memory: 256Mi
       image: quay.io/enterprise-contract/ec-cli:snapshot
       onError: continue  # progress even if the step fails so we can see the debug logs
-      command: [cat]
+      command: [sh, -c]
       args:
-        - "$(params.HOMEDIR)/report-json.json"
+        # Format the JSON output to wrap lines at 8000 characters per line.
+        # The report can get very large, so add some line breaks
+        # rather than print it as a single line. This makes it easier to render
+        # in the UI, easier to copy/paste, and less likely to cause problems
+        # with logging systems or other consumers of the data (assuming they
+        # correctly parse the full output).
+        - "jq . $(params.HOMEDIR)/report-json.json | awk '{gsub(/^ +/, \"\"); acc += length; if (acc >= 8000) { printf \"\\n\"; acc=length } printf $0 }'"
 
     - name: summary
       computeResources:


### PR DESCRIPTION
split report-json.json at 8000 characters

improves readability by splitting the file when it exceeds 8000 characters.

Ref: https://issues.redhat.com/browse/EC-1207