### PR TITLE
Remove base branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>conforma/.github//config/renovate/renovate.json"
-  ],
-  "baseBranches": ["main", "release-v0.5", "release-v0.6"]
+  ]
 }


### PR DESCRIPTION
Having the multiple base branches is suspected
of causing OOM errors with Mintmaker due to the
size of the updates.

https://issues.redhat.com/browse/EC-1244