### PR TITLE
Updating conditional value to sealights workflow

### DIFF
--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -96,7 +96,7 @@ jobs:
           ./slcli config init --lang go --token ./sltoken.txt
 
       - name: Configuring SeaLights - on pull_request event
-        if: env.on-event == 'pull_request'
+        if: env.on-event == 'pull_request_target'
         run: |
           echo "[Sealights] Configuring SeaLights to scan the pull request branch"
           echo "Latest commit sha: ${LATEST_COMMIT_SHA}"


### PR DESCRIPTION
We saw the first true run of the new Sealights workflow skip the configuration step due to the conditional looking for `pull_request` instead of `pull_request_target` which was changed during the review process.

This PR updates the conditional to be `pull_request_target`