### PR TITLE
securityContext workaround for release pipeline tekton task

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -182,6 +182,14 @@ spec:
       - name: HOME
         value: "$(params.HOMEDIR)"
 
+    # This is a workaround for a problem observed on a particular cluster where the
+    # use-trusted-artifacts step runs with root user causing a docker credential file
+    # to not be readable in later steps. There might be solution coming related to the
+    # security context constraints on the cluster, but setting this explicitly here
+    # should probably be harmless either way.
+    securityContext:
+      runAsUser: 1001
+
   steps:
     - name: use-trusted-artifact
       args:


### PR DESCRIPTION
Set `securityConttext.runAsUser` explicitly for all steps in the `verify-conforma-konflux-ta` tekton task.
 
See also [the long and interesting slack thread about the problem](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1746425126665539).