### PR TITLE
Revert "Workaround for release pipeline tekton task"

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -182,14 +182,6 @@ spec:
       - name: HOME
         value: "$(params.HOMEDIR)"
 
-    # This is a workaround for a problem observed on a particular cluster where the
-    # use-trusted-artifacts step runs with root user causing a docker credential file
-    # to not be readable in later steps. There might be solution coming related to the
-    # security context constraints on the cluster, but setting this explicitly here
-    # should probably be harmless either way.
-    securityContext:
-      runAsUser: 1001
-
   steps:
     - name: use-trusted-artifact
       args:


### PR DESCRIPTION
See PR #2513. I don't think we'll need this, but just in case it does break something, and we decide to quickly revert, here's a PR to do it.

Related slack thread:
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1746425126665539

This reverts commit a5ba155a781386f6de60e332fef12cbac4b884cf.