### PR TITLE
update references to golden-container repo

### DIFF
--- a/benchmark/simple/simple.go
+++ b/benchmark/simple/simple.go
@@ -68,8 +68,8 @@ func ec(dir string) func() {
   "containerImage": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container@sha256:166e38c156fa81d577a7ba7a948b68c79005a06e302779d1bebc7d31e8bea315",
   "source": {
 	"git": {
-	  "url": "https://github.com/enterprise-contract/golden-container",
-	  "revision": "8327c1ce7472b017b9396fe26d5d5e1ed0eb61cc"
+	  "url": "https://github.com/conforma/golden-container",
+	  "revision": "2dec8f515a64ef2f21ee3e7b1ed41da77a5c5a9a"
 	}
   }
 }

--- a/hack/keyless-demo.sh
+++ b/hack/keyless-demo.sh
@@ -15,9 +15,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# The Conforma golden container, see https://github.com/enterprise-contract/golden-container/
-IMAGE=${IMAGE:-"ghcr.io/enterprise-contract/golden-container:latest"}
-IDENTITY_REGEXP=${IDENTITY_REGEXP:-"https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|enterprise-contract\/golden-container)\/"}
+# The Conforma golden container, see https://github.com/conforma/golden-container/
+IMAGE=${IMAGE:-"ghcr.io/conforma/golden-container:latest"}
+IDENTITY_REGEXP=${IDENTITY_REGEXP:-"https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|conforma\/golden-container)\/"}
 IDENTITY_ISSUER=${IDENTITY_ISSUER:-"https://token.actions.githubusercontent.com"}
 
 # Festoji, see https://github.com/lcarva/festoji

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -16,11 +16,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This is an image regularly built in Konflux for testing purposes.
-# See https://github.com/enterprise-contract/golden-container
+# See https://github.com/conforma/golden-container
 IMAGE=${IMAGE:-"quay.io/konflux-ci/ec-golden-image:latest"}
 
 # Assume the latest image was pushed already
-GIT_REPO=${GIT_REPO:-enterprise-contract/golden-container}
+GIT_REPO=${GIT_REPO:-conforma/golden-container}
 GIT_SHA=${GIT_SHA:-$(curl -s "https://api.github.com/repos/${GIT_REPO}/commits?per_page=1" | jq -r '.[0].sha')}
 
 # We can use `ec validate image --image $IMAGE` but to be more


### PR DESCRIPTION
This commit updates the repository path of the `golden-container` image from `enterprise-contract` to `conforma` in various scripts and `.go` files.

Ref: EC-1107