### PR TITLE
Issue warning for unmatched include directives

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -5122,3 +5122,102 @@ Error: success criteria not met
 Error: success criteria not met
 
 ---
+
+[policy rule filtering fails due to inexistent inclusion patterns:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/ec-happy-day@sha256:${REGISTRY_acceptance/ec-happy-day:latest_DIGEST}",
+      "source": {},
+      "warnings": [
+        {
+          "msg": "Include criterion 'not-a-rule' doesn't match any policy rule"
+        }
+      ],
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass_with_collection"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/ec-happy-day}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/ec-happy-day}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::${GITHOST}/git/happy-day-policy.git?ref=${LATEST_COMMIT}"
+        ],
+        "config": {
+          "exclude": [
+            "filtering.always_fail",
+            "filtering.always_fail_with_collection"
+          ],
+          "include": [
+            "@stamps",
+            "filtering.always_pass",
+            "not-a-rule"
+          ]
+        }
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[policy rule filtering fails due to inexistent inclusion patterns:stderr - 1]
+
+---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -588,6 +588,35 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: policy rule filtering fails due to inexistent inclusion patterns
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | filtering.rego | examples/filtering.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ],
+          "config": {
+            "include": ["@stamps", "filtering.always_pass", "not-a-rule"],
+            "exclude": ["filtering.always_fail", "filtering.always_fail_with_collection"]
+          }
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
   Scenario: inline application snapshot
     Given a key pair named "known"
     Given an image named "acceptance/ec-happy-day"

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1282,6 +1282,33 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "warning for missing includes",
+			results: []Outcome{
+				{
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "lunch.spam"}},
+						{Metadata: map[string]any{"code": "breakfast.spam", "term": []any{"bacon", "nocab"}}},
+					},
+				},
+			},
+			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast.pancakes", "lunch"}},
+			want: []Outcome{
+				{
+					Skipped:    []Result{},
+					Warnings:   []Result{},
+					Exceptions: []Result{},
+					Failures: []Result{
+						{Metadata: map[string]any{"code": "lunch.spam"}},
+					},
+				},
+				{
+					Warnings: []Result{
+						{Message: "Include criterion 'breakfast.pancakes' doesn't match any policy rule"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When the 'include' directive in a policy configuration references a rule or collection that does not exist in the specified policy sources, the `ec validate image` command now issues a warning instead of silently ignoring the entry.

This addresses a bug where users could mistakenly believe a misconfigured policy was being fully applied, leading to misleading validation results.

Ref: https://issues.redhat.com/browse/EC-729