### PR TITLE
chore: update references to `ec-policies` repo

### DIFF
--- a/.tekton/cli-build.yaml
+++ b/.tekton/cli-build.yaml
@@ -6,7 +6,7 @@ spec:
   description: |
     This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
 
-    _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/policy/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
     This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
   finally:
     - name: show-sbom

--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ This issue may be resolved by adding the below entries in the `/etc/hosts` file:
 
 This issue arises because the acceptance tests use ec-cli binaries built with `CGO_ENABLED=0`. This setting, [chosen for OS compatibility](https://github.com/enterprise-contract/ec-cli/pull/703), causes the program to use Go's native DNS resolver instead of the system's libc resolver ([learn more](https://go.dev/doc/go1.5#net)). Consequently, the binary is unable to resolve 2nd level localhost domains like `apiserver.localhost`, as the native Go DNS resolver does not support resolution for such names in the same way the system resolver does.
 
-[pol]: https://github.com/enterprise-contract/ec-policies/
+[pol]: https://github.com/conforma/policy/
 [docs]: https://conforma.dev/docs/ec-cli/ec.html

--- a/cmd/fetch/fetch_policy.go
+++ b/cmd/fetch/fetch_policy.go
@@ -60,27 +60,27 @@ func fetchPolicyCmd() *cobra.Command {
 			Fetching policies from multiple sources to a specific directory:
 
 			  ec fetch policy --dest fetched-policies \
-				--source github.com/enterprise-contract/ec-policies//policy/lib \
-				--source github.com/enterprise-contract/ec-policies//policy/release
+				--source github.com/conforma/policy//policy/lib \
+				--source github.com/conforma/policy//policy/release
 
 			Fetching policies and data from multiple sources to the current directory:
 
 			  ec fetch policy \
-				--source github.com/enterprise-contract/ec-policies//policy/lib \
-				--source github.com/enterprise-contract/ec-policies//policy/release \
-				--data-source git::https://github.com/enterprise-contract/ec-policies//example/data
+				--source github.com/conforma/policy//policy/lib \
+				--source github.com/conforma/policy//policy/release \
+				--data-source git::https://github.com/conforma/policy//example/data
 
 			Fetching policies from multiple sources to an automatically generated temporary
 			work directory:
 
 			  ec fetch policy --work-dir \
-				--source github.com/enterprise-contract/ec-policies//policy/lib \
-				--source github.com/enterprise-contract/ec-policies//policy/release
+				--source github.com/conforma/policy//policy/lib \
+				--source github.com/conforma/policy//policy/release
 
 			Different style url formats are supported. In this example "policy" is treated as
 			a subdirectory even without the go-getter style // delimiter:
 
-			  ec fetch policy --source https://github.com/enterprise-contract/ec-policies/policy
+			  ec fetch policy --source https://github.com/conforma/policy/policy
 
 			Fetching policies from an OPA bundle (OCI image):
 

--- a/cmd/initialize/init_policies.go
+++ b/cmd/initialize/init_policies.go
@@ -40,7 +40,7 @@ func initPoliciesCmd() *cobra.Command {
 			specified destination directory.
 
 			More information about authoring policies is available in the Conforma documentation:
-			https://conforma.dev/docs/ec-policies/authoring.html
+			https://conforma.dev/docs/policy/authoring.html
 		`),
 
 		Example: hd.Doc(`

--- a/cmd/inspect/inspect_policy_data.go
+++ b/cmd/inspect/inspect_policy_data.go
@@ -63,7 +63,7 @@ func inspectPolicyDataCmd() *cobra.Command {
 		Example: hd.Doc(`
 			Print data from a given source url:
 
-			ec inspect policy-data --source git::https://github.com/enterprise-contract/ec-policies//example/data
+			ec inspect policy-data --source git::https://github.com/conforma/policy//example/data
 		`),
 
 		Args: cobra.NoArgs,

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -10,7 +10,7 @@ ec validate image --policy '{
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "include": ["@minimal"]
             }
@@ -46,7 +46,7 @@ The strings in the list should be one of the following:
 A "package name"::
 
 Package names can be found in the policy documentation, for example the
-xref:ec-policies:ROOT:release_policy.adoc#attestation_type_package[Attestation Type] package
+xref:policy:ROOT:release_policy.adoc#attestation_type_package[Attestation Type] package
 name is `attestation_type`. Specifing a package name by itself in the include
 or exclude list means every rule from that package should be included or
 excluded.
@@ -55,7 +55,7 @@ A "rule name"::
 
 A rule name consists of the rule's package name and the rule's "code" separated
 by a dot. Rule codes can be see in the documentation also. For example the
-xref:ec-policies:ROOT:release_policy.adoc#attestation_type__unknown_att_type[Unknown attestation type found] rule
+xref:policy:ROOT:release_policy.adoc#attestation_type__unknown_att_type[Unknown attestation type found] rule
 name is `attestation_type.unknown_att_type`.
 
 A "package name:term"::
@@ -63,7 +63,7 @@ A "package name:term"::
 Some policy rules process a list of items, "term" allows a particular item to
 be excluded or included. This matcher behaves like "package name" but only
 applies to policy rules in the package that match the "term". For example, the
-xref:ec-policies:ROOT:release_policy.adoc#test_package[Test package] emits results for each
+xref:policy:ROOT:release_policy.adoc#test_package[Test package] emits results for each
 test case. A particular test case can be ignored without ignoring the remaining
 ones.
 
@@ -123,7 +123,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     volatileConfig:
       exclude:
         # Ignore violations from the `test` package until the end of 2024.
@@ -144,7 +144,7 @@ JSON::
         "oci::quay.io/enterprise-contract/ec-release-policy:latest"
       ],
       "data": [
-        "git::https://github.com/enterprise-contract/ec-policies//example/data"
+        "git::https://github.com/conforma/policy//example/data"
       ],
       "volatileConfig": {
         "exclude": [
@@ -179,7 +179,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     volatileConfig:
       exclude:
         # Ignore violations from the `test` package for any image matching the digest.
@@ -197,7 +197,7 @@ JSON::
         "oci::quay.io/enterprise-contract/ec-release-policy:latest"
       ],
       "data": [
-        "git::https://github.com/enterprise-contract/ec-policies//example/data"
+        "git::https://github.com/conforma/policy//example/data"
       ],
       "volatileConfig": {
         "exclude": [
@@ -227,7 +227,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     volatileConfig:
       include:
         - value: java
@@ -245,7 +245,7 @@ JSON::
         "oci::quay.io/enterprise-contract/ec-release-policy:latest"
       ],
       "data": [
-        "git::https://github.com/enterprise-contract/ec-policies//example/data"
+        "git::https://github.com/conforma/policy//example/data"
       ],
       "volatileConfig": {
         "include": [
@@ -290,7 +290,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     config:
       include:
         - "@minimal"
@@ -306,7 +306,7 @@ JSON::
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "include": ["@minimal"],
                 "exclude": ["attestation_task_bundle", "slsa_build_scripted_build"]
@@ -332,7 +332,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     config:
       include:
         - test
@@ -346,7 +346,7 @@ JSON::
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "include": ["test", "java"]
             }
@@ -372,7 +372,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     config:
       exclude:
         - attestation_task_bundle.unacceptable_task_bundle
@@ -385,7 +385,7 @@ JSON::
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "exclude": ["attestation_task_bundle.unacceptable_task_bundle"]
             }
@@ -410,7 +410,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     config:
       exclude:
         - test:get-clair-scan
@@ -424,7 +424,7 @@ JSON::
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "exclude": ["test:get-clair-scan", "test:clamav-scan"]
             }
@@ -456,7 +456,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:latest
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
     config:
       include:
         - *
@@ -472,7 +472,7 @@ JSON::
     "sources": [
         {
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"],
+            "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "include": ["*", "attestation_task_bundle.unacceptable_task_bundle"],
                 "exclude": ["attestation_task_bundle.*"]
@@ -485,20 +485,20 @@ JSON::
 
 == Data Sources
 
-Some of the Conforma policy rules, defined in the ec-policies git
+Some of the Conforma policy rules, defined in the policy git
 repository, rely on certain data values when evaluated. For example, a policy
 rule exists to ensure all the parent container images used during the build
 process have been retrieved from an acceptable registry. The list of acceptable
 registries is a data value. This type of data is called Rule Data.
 
-In addition to policy rules, the ec-policies git repository also defines values
+In addition to policy rules, the policy git repository also defines values
 for Rule Data, see
-xref:ec-policies:ROOT:attachment$rule_data.yml[rule_data.yml]
+xref:policy:ROOT:attachment$rule_data.yml[rule_data.yml]
 . As a user, you can provide a custom data source with modified Rule Data
 allowing the same policy rules to be used to best fit your use cases.
 
 There are different ways to create a custom data source. The simplest form is to
-copy the example/data directory of the ec-policies git repository to your own
+copy the example/data directory of the policy git repository to your own
 repository, and change the values of `rule_data.yml`. Then, simply provide your
 repo as a data source. For example:
 
@@ -510,9 +510,9 @@ YAML::
 ----
 sources:
   - policy:
-      - git::https://github.com/enterprise-contract/ec-policies.git//policy
+      - git::https://github.com/conforma/policy.git//policy
     data:
-      - git::https://github.com/enterprise-contract/ec-policies//example/data
+      - git::https://github.com/conforma/policy//example/data
 ----
 JSON::
 +
@@ -521,8 +521,8 @@ JSON::
 {
     "sources": [
         {
-            "policy": ["git::https://github.com/enterprise-contract/ec-policies.git//policy"],
-            "data": ["git::https://github.com/enterprise-contract/ec-policies//example/data"]
+            "policy": ["git::https://github.com/conforma/policy.git//policy"],
+            "data": ["git::https://github.com/conforma/policy//example/data"]
         }
     ]
 }
@@ -540,7 +540,7 @@ YAML::
 ----
 sources:
   - policy:
-      - git::https://github.com/enterprise-contract/ec-policies.git//policy
+      - git::https://github.com/conforma/policy.git//policy
     data:
       - oci::quay.io/lucarval/policy-data:latest
 ----
@@ -551,7 +551,7 @@ JSON::
 {
   "sources": [
     {
-      "policy": ["git::https://github.com/enterprise-contract/ec-policies.git//policy"],
+      "policy": ["git::https://github.com/conforma/policy.git//policy"],
       "data": ["oci::quay.io/lucarval/policy-data:latest"]
     }
   ]
@@ -563,7 +563,7 @@ NOTE: If the data source contains policy rules, those will be ignored.
 
 NOTE: When providing a data source, you must provide the full set of required data values. The full
 set depends on which policy rules are included in your policy configuration. See examples at
-xref:ec-policies:ROOT:attachment$rule_data.yml[data/rule_data.yml].
+xref:policy:ROOT:attachment$rule_data.yml[data/rule_data.yml].
 
 NOTE: It's also possible to add an additional data source containing rule data
 defined under the `rule_data_custom` top level key. Data under this key will
@@ -580,7 +580,7 @@ YAML::
 ----
 sources:
   - policy:
-      - git::https://github.com/enterprise-contract/ec-policies.git//policy
+      - git::https://github.com/conforma/policy.git//policy
     data:
       - oci::quay.io/lucarval/policy-data:latest
     ruleData:
@@ -596,7 +596,7 @@ JSON::
 {
   "sources": [
     {
-      "policy": ["git::https://github.com/enterprise-contract/ec-policies.git//policy"],
+      "policy": ["git::https://github.com/conforma/policy.git//policy"],
       "data": ["oci::quay.io/lucarval/policy-data:latest"]
       "ruleData": {
         "rule_data_custom": {
@@ -621,7 +621,7 @@ YAML::
 ----
 sources:
   - policy:
-      - git::https://github.com/enterprise-contract/ec-policies.git//policy
+      - git::https://github.com/conforma/policy.git//policy
     data:
       - oci::quay.io/lucarval/policy-data:latest
       - oci::quay.io/lucarval/additional-policy-data:latest
@@ -638,7 +638,7 @@ JSON::
 {
   "sources": [
     {
-      "policy": ["git::https://github.com/enterprise-contract/ec-policies.git//policy"],
+      "policy": ["git::https://github.com/conforma/policy.git//policy"],
       "data": [
         "oci::quay.io/lucarval/policy-data:latest",
         "oci::quay.io/lucarval/additional-policy-data:latest"
@@ -767,9 +767,9 @@ NOTE: In all git URL forms, the `//<path>` is optional and defaults to the  root
 
 _Examples_:
 
-  - `github.com/enterprise-contract/ec-policies`
-  - `github.com/enterprise-contract/ec-policies.git?ref=tag//path/to/data`
-  - `git::git@example.com:enterprise-contract/ec-policies?ref=tag//example/data`
+  - `github.com/conforma/policy`
+  - `github.com/conforma/policy.git?ref=tag//path/to/data`
+  - `git::git@example.com:conforma/policy?ref=tag//example/data`
 
 === HTTPS
 

--- a/docs/modules/ROOT/pages/ec_fetch_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_fetch_policy.adoc
@@ -28,27 +28,27 @@ ec fetch policy --source <source-url> --data-source <source-url> [flags]
 Fetching policies from multiple sources to a specific directory:
 
   ec fetch policy --dest fetched-policies \
-	--source github.com/enterprise-contract/ec-policies//policy/lib \
-	--source github.com/enterprise-contract/ec-policies//policy/release
+	--source github.com/conforma/policy//policy/lib \
+	--source github.com/conforma/policy//policy/release
 
 Fetching policies and data from multiple sources to the current directory:
 
   ec fetch policy \
-	--source github.com/enterprise-contract/ec-policies//policy/lib \
-	--source github.com/enterprise-contract/ec-policies//policy/release \
-	--data-source git::https://github.com/enterprise-contract/ec-policies//example/data
+	--source github.com/conforma/policy//policy/lib \
+	--source github.com/conforma/policy//policy/release \
+	--data-source git::https://github.com/conforma/policy//example/data
 
 Fetching policies from multiple sources to an automatically generated temporary
 work directory:
 
   ec fetch policy --work-dir \
-	--source github.com/enterprise-contract/ec-policies//policy/lib \
-	--source github.com/enterprise-contract/ec-policies//policy/release
+	--source github.com/conforma/policy//policy/lib \
+	--source github.com/conforma/policy//policy/release
 
 Different style url formats are supported. In this example "policy" is treated as
 a subdirectory even without the go-getter style // delimiter:
 
-  ec fetch policy --source https://github.com/enterprise-contract/ec-policies/policy
+  ec fetch policy --source https://github.com/conforma/policy/policy
 
 Fetching policies from an OPA bundle (OCI image):
 

--- a/docs/modules/ROOT/pages/ec_init_policies.adoc
+++ b/docs/modules/ROOT/pages/ec_init_policies.adoc
@@ -8,7 +8,7 @@ This command creates the necessary files for a minimal EC policy setup in the
 specified destination directory.
 
 More information about authoring policies is available in the Conforma documentation:
-https://conforma.dev/docs/ec-policies/authoring.html
+https://conforma.dev/docs/policy/authoring.html
 
 [source,shell]
 ----

--- a/docs/modules/ROOT/pages/ec_inspect_policy-data.adoc
+++ b/docs/modules/ROOT/pages/ec_inspect_policy-data.adoc
@@ -21,7 +21,7 @@ ec inspect policy-data --source <source-url> [flags]
 == Examples
 Print data from a given source url:
 
-ec inspect policy-data --source git::https://github.com/enterprise-contract/ec-policies//example/data
+ec inspect policy-data --source git::https://github.com/conforma/policy//example/data
 
 == Options
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,4 +1,4 @@
-:pol: https://github.com/enterprise-contract/ec-policies/
+:pol: https://github.com/conforma/policy/
 
 = Conforma CLI
 

--- a/docs/modules/ROOT/pages/signing.adoc
+++ b/docs/modules/ROOT/pages/signing.adoc
@@ -7,7 +7,7 @@ command.
 == Image Verification
 
 When Conforma validates an image, there are certain
-https://conforma.dev/docs/ec-policies/release_policy.html#builtin_attestation_package[builtin]
+https://conforma.dev/docs/policy/release_policy.html#builtin_attestation_package[builtin]
 policy rules that are always applied and cannot be skipped. Most of these rely on
 https://github.com/sigstore/cosign[cosign] to fetch and verify image signatures and attestations.
 These meta artifacts are associated to the underlying container image by digest. This has two
@@ -62,7 +62,7 @@ expression match if additional flexibility is needed.
 
 Any certificate involved in the signature is also provided as xref:policy_input.adoc[policy input].
 Use this data to establish a fine-grained verification process by leveraging rego policies. See the
-xref:ec-policies:ROOT:release_policy.adoc#github_certificate_package[GitHub Certificate Checks] as
+xref:policy:ROOT:release_policy.adoc#github_certificate_package[GitHub Certificate Checks] as
 an example.
 
 As with the previous level, it is also possible to use an <<Alternative Rekor>> instance during

--- a/features/__snapshots__/inspect_policy.snap
+++ b/features/__snapshots__/inspect_policy.snap
@@ -52,7 +52,7 @@ Error: Merge error. The 'rule_data' key was found more than once!
 # Source: git::${GITHOST}/git/policy.git?ref=${LATEST_COMMIT}
 
 kitty.purr (deny)
-https://conforma.dev/docs/ec-policies/release_policy.html#kitty__purr
+https://conforma.dev/docs/policy/release_policy.html#kitty__purr
 Kittens
 Fluffy
 --
@@ -89,20 +89,20 @@ kitty.purr
 # Source: git::${GITHOST}/git/policy1.git?ref=f81eaf65be8da58460ff920408ba1313051184a1
 
 kitty.purr (deny)
-https://conforma.dev/docs/ec-policies/release_policy.html#kitty__purr
+https://conforma.dev/docs/policy/release_policy.html#kitty__purr
 Kittens
 Fluffy
 --
 # Source: git::${GITHOST}/git/policy2.git?ref=${LATEST_COMMIT}
 
 main.rejector (deny)
-https://conforma.dev/docs/ec-policies/release_policy.html#main__rejector
+https://conforma.dev/docs/policy/release_policy.html#main__rejector
 Reject rule
 This rule will always fail
 [A]
 --
 main.reject_with_term (deny)
-https://conforma.dev/docs/ec-policies/release_policy.html#main__reject_with_term
+https://conforma.dev/docs/policy/release_policy.html#main__reject_with_term
 Reject with term rule
 This rule will always fail
 [A]

--- a/features/__snapshots__/ta_task_validate_image.snap
+++ b/features/__snapshots__/ta_task_validate_image.snap
@@ -10,8 +10,8 @@
     "sources": [
       {
         "policy": [
-          "git::github.com/enterprise-contract/ec-policies//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
-          "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
+          "git::github.com/conforma/policy//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
+          "git::github.com/conforma/policy//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
         ],
         "config": {
           "include": [
@@ -142,8 +142,8 @@
     "sources": [
       {
         "policy": [
-          "git::github.com/enterprise-contract/ec-policies//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
-          "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
+          "git::github.com/conforma/policy//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
+          "git::github.com/conforma/policy//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
         ],
         "config": {
           "include": [

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -110,8 +110,8 @@ ${____known_PUBLIC_KEY}
       include:
       - test.no_test_warnings
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/release
-    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/conforma/policy//policy/release
+    - github.com/conforma/policy//policy/lib
 success: true
 
 ---
@@ -177,8 +177,8 @@ ${____known_PUBLIC_KEY}
       include:
       - test.no_test_warnings
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/release
-    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/conforma/policy//policy/release
+    - github.com/conforma/policy//policy/lib
 success: true
 
 ---
@@ -268,8 +268,8 @@ policy:
       include:
       - slsa_provenance_available
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/release
-    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/conforma/policy//policy/release
+    - github.com/conforma/policy//policy/lib
 success: true
 
 ---
@@ -280,8 +280,8 @@ success: true
     "sources": [
       {
         "policy": [
-          "git::github.com/enterprise-contract/ec-policies//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
-          "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
+          "git::github.com/conforma/policy//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
+          "git::github.com/conforma/policy//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
         ],
         "config": {
           "include": [
@@ -382,8 +382,8 @@ policy:
       include:
       - slsa_provenance_available
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/release
-    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/conforma/policy//policy/release
+    - github.com/conforma/policy//policy/lib
     ruleData:
       key1: value1
       key2: value2
@@ -486,8 +486,8 @@ policy:
       include:
       - slsa_provenance_available
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/release
-    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/conforma/policy//policy/release
+    - github.com/conforma/policy//policy/lib
 success: true
 
 ---
@@ -751,8 +751,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy/release",
-          "github.com/enterprise-contract/ec-policies//policy/lib"
+          "github.com/conforma/policy//policy/release",
+          "github.com/conforma/policy//policy/lib"
         ],
         "config": {
           "include": [
@@ -847,8 +847,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy/release",
-          "github.com/enterprise-contract/ec-policies//policy/lib"
+          "github.com/conforma/policy//policy/release",
+          "github.com/conforma/policy//policy/lib"
         ],
         "config": {
           "include": [
@@ -965,8 +965,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy/release",
-          "github.com/enterprise-contract/ec-policies//policy/lib"
+          "github.com/conforma/policy//policy/release",
+          "github.com/conforma/policy//policy/lib"
         ],
         "config": {
           "include": [
@@ -1083,8 +1083,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy/release",
-          "github.com/enterprise-contract/ec-policies//policy/lib"
+          "github.com/conforma/policy//policy/release",
+          "github.com/conforma/policy//policy/lib"
         ],
         "config": {
           "include": [
@@ -1201,8 +1201,8 @@ true
     "sources": [
       {
         "policy": [
-          "github.com/enterprise-contract/ec-policies//policy/release",
-          "github.com/enterprise-contract/ec-policies//policy/lib"
+          "github.com/conforma/policy//policy/release",
+          "github.com/conforma/policy//policy/lib"
         ],
         "config": {
           "include": [

--- a/features/ta_task_validate_image.feature
+++ b/features/ta_task_validate_image.feature
@@ -25,8 +25,8 @@ Feature: Verify Conforma Trusted Artifact Tekton Task
         "sources": [
           {
             "policy": [
-              "git::github.com/enterprise-contract/ec-policies//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
-              "git::github.com/enterprise-contract/ec-policies//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
+              "git::github.com/conforma/policy//policy/release?ref=d34eab36b23d43748e451004177ca144296bf323",
+              "git::github.com/conforma/policy//policy/lib?ref=d34eab36b23d43748e451004177ca144296bf323"
             ],
             "config": {
               "include": [

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -15,8 +15,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
-              "github.com/enterprise-contract/ec-policies//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
+              "github.com/conforma/policy//policy/release?ref=0de5461c14413484575e63e96ddb514d8ab954b5",
+              "github.com/conforma/policy//policy/lib?ref=0de5461c14413484575e63e96ddb514d8ab954b5"
             ],
             "config": {
               "include": [
@@ -46,8 +46,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release",
-              "github.com/enterprise-contract/ec-policies//policy/lib"
+              "github.com/conforma/policy//policy/release",
+              "github.com/conforma/policy//policy/lib"
             ],
             "config": {
               "include": [
@@ -77,8 +77,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release",
-              "github.com/enterprise-contract/ec-policies//policy/lib"
+              "github.com/conforma/policy//policy/release",
+              "github.com/conforma/policy//policy/lib"
             ],
             "config": {
               "include": [
@@ -109,8 +109,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release",
-              "github.com/enterprise-contract/ec-policies//policy/lib"
+              "github.com/conforma/policy//policy/release",
+              "github.com/conforma/policy//policy/lib"
             ],
             "config": {
               "include": [
@@ -146,8 +146,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release",
-              "github.com/enterprise-contract/ec-policies//policy/lib"
+              "github.com/conforma/policy//policy/release",
+              "github.com/conforma/policy//policy/lib"
             ],
             "config": {
               "include": [
@@ -181,8 +181,8 @@ Feature: Verify Enterprise Contract Tekton Tasks
         "sources": [
           {
             "policy": [
-              "github.com/enterprise-contract/ec-policies//policy/release",
-              "github.com/enterprise-contract/ec-policies//policy/lib"
+              "github.com/conforma/policy//policy/release",
+              "github.com/conforma/policy//policy/lib"
             ],
             "config": {
               "include": [

--- a/hack/cut-release.sh
+++ b/hack/cut-release.sh
@@ -120,12 +120,12 @@ Use show-latest-build-versions.sh script in the hacks repo.
 Use skopeo, e.g. 'skopeo inspect docker://registry.redhat.io/rhtas/ec-rhel9:${KONFLUX_APPLICATION_SUFFIX}'
 Use podman, e.g. 'podman run --rm registry.redhat.io/rhtas/ec-rhel9:${KONFLUX_APPLICATION_SUFFIX} version'
 
-$(nice_title Create stable versioned branch in ec-policies repo and corresponding config in the config repo)
+$(nice_title Create stable versioned branch in policy repo and corresponding config in the config repo)
 
-For better or for worse, we create a branch in the ec-policies repo and a corresponding config file that RHTAP templates can use.
+For better or for worse, we create a branch in the policy repo and a corresponding config file that RHTAP templates can use.
 (This may change in future if something like https://github.com/redhat-appstudio/tssc-sample-pipelines/pull/42 is adopted.)
 
-For example (in ec-policies repo):
+For example (in policy repo):
   git push upstream upstream/main:refs/heads/release-${RELEASE_NAME}
 You have some flexibility around what sha to use, but the current upstream/main is probably good choice.
 

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -47,7 +47,7 @@ spec:
   description: Demo Conforma policy configuration
   sources:
   - data:
-    - git::https://github.com/enterprise-contract/ec-policies//example/data
+    - git::https://github.com/conforma/policy//example/data
     name: Default Conforma policy
     policy:
     - quay.io/enterprise-contract/ec-release-policy:latest

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -666,7 +666,7 @@ func addRuleMetadata(ctx context.Context, result *Result, rules policyRules) {
 func addMetadataToResults(ctx context.Context, r *Result, rule rule.Info) {
 	// Note that r.Metadata already includes some fields that we get from
 	// the real conftest violation and warning results, (as provided by
-	// lib.result_helper in the ec-policies rego). Here we augment it with
+	// lib.result_helper in the policy rego). Here we augment it with
 	// other fields from rule.Metadata, which we get by opa-inspecting the
 	// rego source.
 

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1422,7 +1422,7 @@ func TestCollectAnnotationData(t *testing.T) {
 			Package:          "a.b.c",
 			ShortName:        "short",
 			Title:            "Title",
-			DocumentationUrl: "https://conforma.dev/docs/ec-policies/release_policy.html#c__short",
+			DocumentationUrl: "https://conforma.dev/docs/policy/release_policy.html#c__short",
 		},
 	}, rules)
 }

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -66,7 +66,7 @@ func Test_RegoTextOutput(t *testing.T) {
 				# Source: spam.io/bacon-bundle
 
 				policy.foo.bar.rule_title (deny)
-				https://conforma.dev/docs/ec-policies/release_policy.html#bar__rule_title
+				https://conforma.dev/docs/policy/release_policy.html#bar__rule_title
 				Rule title
 				Rule description
 				--

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -204,17 +204,17 @@ func documentationUrl(a *ast.AnnotationsRef) string {
 	}
 
 	// This makes assumptions about the way we publish policy docs for
-	// policies defined in https://github.com/enterprise-contract/ec-policies/
-	// to https://conforma.dev/docs/ec-policies/index.html . We should figure
+	// policies defined in https://github.com/conforma/policy/
+	// to https://conforma.dev/docs/policy/index.html . We should figure
 	// out a way for the documentationUrl to be configurable, perhaps by using
 	// some additional package annotations. To make matters even worse, we're now
 	// hard coding "release_policy" in the URL, which is guaranteed wrong for
 	// policies that are not defined under
-	// https://github.com/enterprise-contract/ec-policies/tree/main/policy/release
+	// https://github.com/conforma/policy/tree/main/policy/release
 	// Given all this, the documentationUrl is not really reliable. We could remove it
 	// entirely, but since it's used only the `ec inspect policy` output, let's live
 	// with its flaws for now and fix it later.
-	ruleDocUrlFormat := "https://conforma.dev/docs/ec-policies/release_policy.html#%s__%s"
+	ruleDocUrlFormat := "https://conforma.dev/docs/policy/release_policy.html#%s__%s"
 
 	// a.Path might be something like this: "data.foo.deny" or
 	// "data.some.path.foo.warn". We want to pick out just "foo".

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -478,7 +478,7 @@ func TestCodeAndDocumentationUrl(t *testing.T) {
 				#   short_name: x
 				deny if { true }`)),
 			expected:    "a.x",
-			expectedUrl: "https://conforma.dev/docs/ec-policies/release_policy.html#a__x",
+			expectedUrl: "https://conforma.dev/docs/policy/release_policy.html#a__x",
 		},
 		{
 			name: "nested packages no annotations",
@@ -499,7 +499,7 @@ func TestCodeAndDocumentationUrl(t *testing.T) {
 				#   short_name: x
 				deny if { true }`)),
 			expected:    "a.b.c.x",
-			expectedUrl: "https://conforma.dev/docs/ec-policies/release_policy.html#c__x",
+			expectedUrl: "https://conforma.dev/docs/policy/release_policy.html#c__x",
 		},
 	}
 

--- a/internal/policy/source/git_config.go
+++ b/internal/policy/source/git_config.go
@@ -16,7 +16,7 @@
 
 // This module is more of a general purpose wrapper for fetching files and
 // saving them locally. It was originally used only for policy, i.e. rego and
-// yaml files, from the ec-policies repo, hence the name choice PolicySource,
+// yaml files, from the policy repo, hence the name choice PolicySource,
 // but now it's also used for fetching configuration from a git url.
 
 package source

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -16,7 +16,7 @@
 
 // This module is more of a general purpose wrapper for fetching files and
 // saving them locally. It was originally used only for policy, i.e. rego and
-// yaml files, from the ec-policies repo, hence the name choice for PolicySource,
+// yaml files, from the policy repo, hence the name choice for PolicySource,
 // but now it's also used for fetching configuration from a git url.
 
 package source


### PR DESCRIPTION
This commit updates references of the policy repo from `enterprise-contract/ec-policies` to `conforma/policy` as well as updating references to `ec-policies` generally.

Ref: EC-1113