### PR TITLE
Update enterprise-contract-controller dependency

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cucumber/godog v0.15.0
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f
 	github.com/doiit/picocolors v1.0.1
-	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79
+	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/gkampitakis/go-snaps v0.5.7
 	github.com/go-git/go-billy/v5 v5.6.0

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -303,8 +303,8 @@ github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79 h1:3w1Yjakmg7bD4/EM+xvALQzSaBNcuL4CLjf0EH/0qys=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107 h1:WB9KEfybpKP01EaERyCCx4rHW9F5JgBIATlr3Fyjky4=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Maldris/go-billy-afero v0.0.0-20200815120323-e9d3de59c99a
 	github.com/conforma/go-gather v1.0.2
 	github.com/docker/docker v27.5.0+incompatible
-	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79
+	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gkampitakis/go-snaps v0.5.7
 	github.com/go-git/go-git/v5 v5.13.2

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,8 @@ github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79 h1:3w1Yjakmg7bD4/EM+xvALQzSaBNcuL4CLjf0EH/0qys=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.79/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107 h1:WB9KEfybpKP01EaERyCCx4rHW9F5JgBIATlr3Fyjky4=
+github.com/enterprise-contract/enterprise-contract-controller/api v0.1.107/go.mod h1:zkK1IrRezUgKGK4tkN9hJtpu8NVqjKTMh4EshxXOi3g=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20250120083621-7be5271048b1 h1:yndSypI6/5y411oT0D3gngWVhFiMp287P8YFhoBJT0A=
 github.com/enterprise-contract/go-containerregistry v0.20.3-0.20250120083621-7be5271048b1/go.mod h1:DaoYmvol46cxSLz7Ftzj/orhtJAzATQOlBL2JuZIxQs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
I'm trying to run `ec validate policy` and it doesn't know about the new "reference" key in the volatileConfig exclude.

This should fix it since the newer `ecc.Schema` will be pulled in and used in `internal/policy/policy.go`.

Notes:
- I would expect renovate to create a PR to update this dependency, but seems like it didn't.
- I'm surprised this wasn't causing problems already, since I thought there was some CI related to doing and `ec validate policy` in the `konflux-release-data` repo..?.
- See also [this PR](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/6289) which is related since it's pulling in the same schema update that this change pulls in.