### PR TITLE
feat: improve performance for verifying images

### DIFF
--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -57,7 +57,7 @@ paths can be provided by using the `:` separator.
 
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
-*Default*: `1`
+*Default*: `35`
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +
 *Default*: `false`

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -284,9 +284,9 @@ spec:
       computeResources:
         requests:
           cpu: 250m
-          memory: 6Gi
+          memory: 8Gi
         limits:
-          memory: 6Gi
+          memory: 8Gi
       volumeMounts:
         - name: trusted-ca
           mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -128,7 +128,7 @@ spec:
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.
-      default: "1"
+      default: "35"
 
     - name: SINGLE_COMPONENT
       description: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
@@ -284,9 +284,9 @@ spec:
       computeResources:
         requests:
           cpu: 250m
-          memory: 2Gi
+          memory: 6Gi
         limits:
-          memory: 2Gi
+          memory: 6Gi
       volumeMounts:
         - name: trusted-ca
           mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt


### PR DESCRIPTION
We have been trying to speed up policy evaluation, especially for large sets of images. As expected, when we increase the number of workers, the memory requirements also increase to prevent hitting OOM kills on the pods. In our analysis, however, we saw that memory consumption peaked at around 6GB even for large sets of images (>35).

While very small sets of images will likely not see a benefit from the increased worker count, most of the verifications we have seen are larger sets.

It is a valid option to override these options when consuming this task, but it would have to be modified for many consumers. I am proposing to update the defaults as we can quickly see benefits in the evaluation times, even for modestly large sets of images.