### PR TITLE
Tweak GitHub Workflow Sealights concurrency group

### DIFF
--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
I'm not 100% confident about this, but the theory is that sometimes the `github.event_name` is actually 'pull_request_target' instead of 'pull_request' and the logic is incorrectly falling back to the github.ref value, which means my CI check gets cancelled incorrectly.

With this change, whenever there is a pull request number the number will be used in the concurrency group.

Assisted-by: Chat GPT

Ref: https://issues.redhat.com/browse/EC-1345