### PR TITLE
add pipeline_intention metadata to per-component VSAs

### DIFF
--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -167,17 +167,18 @@ type testRunner interface {
 }
 
 const (
-	effectiveOnFormat   = "2006-01-02T15:04:05Z"
-	effectiveOnTimeout  = -90 * 24 * time.Hour // keep effective_on metadata up to 90 days
-	metadataCode        = "code"
-	metadataCollections = "collections"
-	metadataDependsOn   = "depends_on"
-	metadataDescription = "description"
-	metadataSeverity    = "severity"
-	metadataEffectiveOn = "effective_on"
-	metadataSolution    = "solution"
-	metadataTerm        = "term"
-	metadataTitle       = "title"
+	effectiveOnFormat         = "2006-01-02T15:04:05Z"
+	effectiveOnTimeout        = -90 * 24 * time.Hour // keep effective_on metadata up to 90 days
+	metadataCode              = "code"
+	metadataCollections       = "collections"
+	metadataDependsOn         = "depends_on"
+	metadataDescription       = "description"
+	metadataPipelineIntention = "pipeline_intention"
+	metadataSeverity          = "severity"
+	metadataEffectiveOn       = "effective_on"
+	metadataSolution          = "solution"
+	metadataTerm              = "term"
+	metadataTitle             = "title"
 )
 
 const (
@@ -638,6 +639,10 @@ func (c conftestEvaluator) computeSuccesses(
 			success.Metadata[metadataDependsOn] = rule.DependsOn
 		}
 
+		if len(rule.PipelineIntention) > 0 {
+			success.Metadata[metadataPipelineIntention] = rule.PipelineIntention
+		}
+
 		if !c.isResultIncluded(success, target, missingIncludes) {
 			log.Debugf("Skipping result success: %#v", success)
 			continue
@@ -710,6 +715,12 @@ func addMetadataToResults(ctx context.Context, r *Result, rule rule.Info) {
 	}
 	if len(rule.DependsOn) > 0 {
 		r.Metadata[metadataDependsOn] = rule.DependsOn
+	}
+	if len(rule.PipelineIntention) > 0 {
+		log.Debugf("Evaluator Debug: Adding pipeline_intention %v to rule %s", rule.PipelineIntention, rule.Code)
+		r.Metadata[metadataPipelineIntention] = rule.PipelineIntention
+	} else {
+		log.Debugf("Evaluator Debug: No pipeline_intention for rule %s", rule.Code)
 	}
 
 	// If the rule has been effective for a long time, we'll consider

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1402,6 +1402,7 @@ func TestCollectAnnotationData(t *testing.T) {
 		#   collections: [A, B, C]
 		#   effective_on: 2022-01-01T00:00:00Z
 		#   depends_on: a.b.c
+		#   pipeline_intention: [release, production]
 		deny contains msg if {
 			msg := "hi"
 		}`), ast.ParserOptions{
@@ -1413,16 +1414,17 @@ func TestCollectAnnotationData(t *testing.T) {
 
 	assert.Equal(t, policyRules{
 		"a.b.c.short": {
-			Code:             "a.b.c.short",
-			Collections:      []string{"A", "B", "C"},
-			DependsOn:        []string{"a.b.c"},
-			Description:      "Description",
-			EffectiveOn:      "2022-01-01T00:00:00Z",
-			Kind:             rule.Deny,
-			Package:          "a.b.c",
-			ShortName:        "short",
-			Title:            "Title",
-			DocumentationUrl: "https://conforma.dev/docs/policy/release_policy.html#c__short",
+			Code:              "a.b.c.short",
+			Collections:       []string{"A", "B", "C"},
+			DependsOn:         []string{"a.b.c"},
+			Description:       "Description",
+			EffectiveOn:       "2022-01-01T00:00:00Z",
+			Kind:              rule.Deny,
+			Package:           "a.b.c",
+			PipelineIntention: []string{"release", "production"},
+			ShortName:         "short",
+			Title:             "Title",
+			DocumentationUrl:  "https://conforma.dev/docs/policy/release_policy.html#c__short",
 		},
 	}, rules)
 }
@@ -1451,6 +1453,11 @@ func TestRuleMetadata(t *testing.T) {
 			Title:       "Warning3",
 			Description: "Warning 3 description",
 			EffectiveOn: effectiveOnTest,
+		},
+		"pipelineIntentionRule": rule.Info{
+			Title:             "Pipeline Intention Rule",
+			Description:       "Rule with pipeline intention",
+			PipelineIntention: []string{"release", "production"},
 		},
 	}
 	cases := []struct {
@@ -1542,6 +1549,25 @@ func TestRuleMetadata(t *testing.T) {
 			want: Result{
 				Metadata: map[string]any{
 					"collections": []any{"A"},
+				},
+			},
+		},
+		{
+			name: "add pipeline intention metadata",
+			result: Result{
+				Metadata: map[string]any{
+					"code":        "pipelineIntentionRule",
+					"collections": []any{"B"},
+				},
+			},
+			rules: rules,
+			want: Result{
+				Metadata: map[string]any{
+					"code":               "pipelineIntentionRule",
+					"collections":        []string{"B"},
+					"title":              "Pipeline Intention Rule",
+					"description":        "Rule with pipeline intention",
+					"pipeline_intention": []string{"release", "production"},
 				},
 			},
 		},

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -146,6 +146,23 @@ func collections(a *ast.AnnotationsRef) []string {
 	return collections
 }
 
+func pipelineIntention(a *ast.AnnotationsRef) []string {
+	pipelineIntentions := make([]string, 0, 3)
+	if a == nil || a.Annotations == nil || a.Annotations.Custom == nil {
+		return pipelineIntentions
+	}
+
+	if values, ok := a.Annotations.Custom["pipeline_intention"].([]any); ok {
+		for _, value := range values {
+			if intention, ok := value.(string); ok {
+				pipelineIntentions = append(pipelineIntentions, intention)
+			}
+		}
+	}
+
+	return pipelineIntentions
+}
+
 func packages(a *ast.AnnotationsRef) []string {
 	packages := []string{}
 	if a == nil {
@@ -262,32 +279,34 @@ const (
 )
 
 type Info struct {
-	Code             string
-	Collections      []string
-	DependsOn        []string
-	Description      string
-	DocumentationUrl string
-	Severity         string
-	EffectiveOn      string
-	Kind             RuleKind
-	Package          string
-	ShortName        string
-	Solution         string
-	Title            string
+	Code              string
+	Collections       []string
+	DependsOn         []string
+	Description       string
+	DocumentationUrl  string
+	Severity          string
+	EffectiveOn       string
+	Kind              RuleKind
+	Package           string
+	PipelineIntention []string
+	ShortName         string
+	Solution          string
+	Title             string
 }
 
 func RuleInfo(a *ast.AnnotationsRef) Info {
 	return Info{
-		Code:             code(a),
-		Collections:      collections(a),
-		Description:      description(a),
-		DependsOn:        dependsOn(a),
-		DocumentationUrl: documentationUrl(a),
-		EffectiveOn:      effectiveOn(a),
-		Solution:         solution(a),
-		Kind:             kind(a),
-		Package:          packageName(a),
-		ShortName:        shortName(a),
-		Title:            title(a),
+		Code:              code(a),
+		Collections:       collections(a),
+		Description:       description(a),
+		DependsOn:         dependsOn(a),
+		DocumentationUrl:  documentationUrl(a),
+		EffectiveOn:       effectiveOn(a),
+		Solution:          solution(a),
+		Kind:              kind(a),
+		Package:           packageName(a),
+		PipelineIntention: pipelineIntention(a),
+		ShortName:         shortName(a),
+		Title:             title(a),
 	}
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -218,7 +218,7 @@ func keepSomeMetadata(results []evaluator.Result) {
 
 func keepSomeMetadataSingle(result evaluator.Result) {
 	for key := range result.Metadata {
-		if key == "code" || key == "effective_on" || key == "term" {
+		if key == "code" || key == "effective_on" || key == "term" || key == "pipeline_intention" {
 			continue
 		}
 		delete(result.Metadata, key)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1041,3 +1041,69 @@ func TestSetAttestationSyntaxCheckFromError(t *testing.T) {
 		})
 	}
 }
+
+func TestKeepSomeMetadataSingle(t *testing.T) {
+	cases := []struct {
+		name             string
+		input            evaluator.Result
+		expectedMetadata map[string]interface{}
+	}{
+		{
+			name: "preserves required metadata including pipeline_intention",
+			input: evaluator.Result{
+				Message: "Test message",
+				Metadata: map[string]interface{}{
+					"code":               "test.rule",
+					"effective_on":       "2023-01-01",
+					"term":               "test-term",
+					"pipeline_intention": []string{"release", "production"},
+					"title":              "Test Rule Title",
+					"description":        "Test Rule Description",
+					"some_other_key":     "should be removed",
+				},
+			},
+			expectedMetadata: map[string]interface{}{
+				"code":               "test.rule",
+				"effective_on":       "2023-01-01",
+				"term":               "test-term",
+				"pipeline_intention": []string{"release", "production"},
+			},
+		},
+		{
+			name: "preserves basic metadata without pipeline_intention",
+			input: evaluator.Result{
+				Message: "Test message",
+				Metadata: map[string]interface{}{
+					"code":           "test.rule",
+					"effective_on":   "2023-01-01",
+					"title":          "Test Rule Title",
+					"description":    "Test Rule Description",
+					"some_other_key": "should be removed",
+				},
+			},
+			expectedMetadata: map[string]interface{}{
+				"code":         "test.rule",
+				"effective_on": "2023-01-01",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy to avoid modifying the original
+			result := evaluator.Result{
+				Message:  tc.input.Message,
+				Metadata: make(map[string]interface{}),
+			}
+			for k, v := range tc.input.Metadata {
+				result.Metadata[k] = v
+			}
+
+			// Apply the function
+			keepSomeMetadataSingle(result)
+
+			// Verify the result
+			assert.Equal(t, tc.expectedMetadata, result.Metadata)
+		})
+	}
+}

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -280,3 +280,125 @@ func TestGeneratePredicate(t *testing.T) {
 	assert.Equal(t, comp.Source, pred.Component["source"])
 	assert.Equal(t, comp.Successes, pred.RuleResults)
 }
+
+func TestGeneratePredicateWithPipelineIntention(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []evaluator.Result
+		expected map[string]interface{}
+	}{
+		{
+			name: "rule with pipeline_intention metadata",
+			results: []evaluator.Result{
+				{
+					Message: "Rule with pipeline intention passed",
+					Metadata: map[string]interface{}{
+						"code":               "release.security_check",
+						"title":              "Security Check",
+						"pipeline_intention": []string{"release", "production"},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"code":               "release.security_check",
+				"title":              "Security Check",
+				"pipeline_intention": []string{"release", "production"},
+			},
+		},
+		{
+			name: "rule without pipeline_intention metadata",
+			results: []evaluator.Result{
+				{
+					Message: "Rule without pipeline intention passed",
+					Metadata: map[string]interface{}{
+						"code":  "general.basic_check",
+						"title": "Basic Check",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"code":  "general.basic_check",
+				"title": "Basic Check",
+			},
+		},
+		{
+			name: "mixed rules with and without pipeline_intention",
+			results: []evaluator.Result{
+				{
+					Message: "Rule with pipeline intention",
+					Metadata: map[string]interface{}{
+						"code":               "release.security_check",
+						"pipeline_intention": []string{"release"},
+					},
+				},
+				{
+					Message: "Rule without pipeline intention",
+					Metadata: map[string]interface{}{
+						"code": "general.basic_check",
+					},
+				},
+			},
+			expected: map[string]interface{}{}, // We'll check both results individually
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test data
+			report := applicationsnapshot.Report{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Name: "test-policy",
+				},
+			}
+
+			comp := applicationsnapshot.Component{
+				SnapshotComponent: appapi.SnapshotComponent{
+					Name:           "test-component",
+					ContainerImage: "test-image:tag",
+					Source:         appapi.ComponentSource{},
+				},
+				Success:    true,
+				Violations: []evaluator.Result{},
+				Warnings:   []evaluator.Result{},
+				Successes:  tt.results,
+			}
+
+			// Create generator and generate predicate
+			generator := NewGenerator(report)
+			pred, err := generator.GeneratePredicate(context.Background(), comp)
+			require.NoError(t, err)
+
+			// Verify basic predicate fields
+			assert.Equal(t, comp.ContainerImage, pred.ImageRef)
+			assert.Equal(t, "passed", pred.ValidationResult)
+			assert.Equal(t, "ec-cli", pred.Verifier)
+
+			// Verify rule results contain expected metadata
+			assert.Equal(t, len(tt.results), len(pred.RuleResults))
+
+			if tt.name == "mixed rules with and without pipeline_intention" {
+				// Special case: check each result individually
+				for _, result := range pred.RuleResults {
+					if result.Metadata["code"] == "release.security_check" {
+						assert.Equal(t, []string{"release"}, result.Metadata["pipeline_intention"])
+					} else if result.Metadata["code"] == "general.basic_check" {
+						_, hasPipelineIntention := result.Metadata["pipeline_intention"]
+						assert.False(t, hasPipelineIntention, "Rule without pipeline_intention should not have the field")
+					}
+				}
+			} else {
+				// Single result case: check expected metadata
+				result := pred.RuleResults[0]
+				for key, expectedValue := range tt.expected {
+					assert.Equal(t, expectedValue, result.Metadata[key], "Metadata field %s should match", key)
+				}
+
+				// Verify pipeline_intention is absent when not expected
+				if _, expectedPipelineIntention := tt.expected["pipeline_intention"]; !expectedPipelineIntention {
+					_, hasPipelineIntention := result.Metadata["pipeline_intention"]
+					assert.False(t, hasPipelineIntention, "Rule without pipeline_intention should not have the field")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add pipelineIntention() function to extract pipeline_intention from Rego annotations
- Update rule.Info struct to include PipelineIntention []string field
- Modify evaluator to include pipeline_intention in rule result metadata
- Add comprehensive unit and integration tests across all layers
- Ensure pipeline_intention flows from Rego annotations → VSA output
- Maintain backward compatibility with existing functionality

This enables VSAs to include pipeline intention metadata from policy rules, supporting use cases where rules are specific to certain pipeline types (e.g., release, production).