### PR TITLE
Fix and re-add acceptance tests for sealights workflow

### DIFF
--- a/.github/workflows/checks-codecov.yaml
+++ b/.github/workflows/checks-codecov.yaml
@@ -102,45 +102,6 @@ jobs:
           files: ./coverage-integration.out
           flags: integration
 
-  Acceptance:
-    runs-on: ubuntu-latest
-    steps:
-      # Disabled until we figure out the "Could not resolve host: github.com" in
-      # acceptance tests
-      # - name: Harden Runner
-      #   uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
-      #   with:
-      #     egress-policy: audit
-      #     disable-telemetry: true
-
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Restore Cache
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: main
-          path: '**'
-
-      - name: Setup Go environment
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
-        with:
-          go-version-file: go.mod
-          cache: false
-
-      - name: Update podman
-        run: |
-          "${GITHUB_WORKSPACE}/hack/ubuntu-podman-update.sh"
-
-      - name: Acceptance test
-        run: make acceptance
-
-      - name: Upload coverage report
-        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
-        with:
-          files: ./coverage-acceptance.out
-          flags: acceptance
-
   Tools:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -152,3 +152,37 @@ jobs:
 
       - name: Test
         run: make test
+
+  Acceptance:
+    runs-on: ubuntu-latest
+    needs: [Initialize, Test]
+    env:
+      BSID: ${{ needs.Initialize.outputs.bsid }}
+      SEALIGHTS_LOG_LEVEL: none
+      SEALIGHTS_CONNECTION_TIMEOUT: 120s
+    steps:
+      - name: Restore workspace
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.run_id }}
+
+      - name: Update podman
+        run: |
+          "${GITHUB_WORKSPACE}/hack/ubuntu-podman-update.sh"
+      - name: Create a test session
+        run: ./slcli test start-stage --bsid=$BSID --testStage "Acceptance Tests"
+
+      - name: Acceptance test
+        env:
+          SEALIGHTS_LOG_LEVEL: none
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+        run: make acceptance-sealights
+
+      - name: Upload test results, end test session
+        if: success() || failure()
+        run: |
+          cat ./junit-acceptance.xml
+          ./slcli test upload-reports --bsid=$BSID --report-location ./junit-acceptance.xml
+          ./slcli test end-stage --bsid=$BSID --executionId "Acceptance Tests"


### PR DESCRIPTION
# Description
Adding
  DOCKER_BUILDKIT: 1
  COMPOSE_DOCKER_CLI_BUILD: 1
to the acceptance test env field fixes the timeout issue we were seeing.

I believe this regressions could come from an update in either ubunut-latest image or podman as we are pulling latest changes for both each time we run.

# Testing
This has been tested in my mirror of the cli repo

See the many passing actions with this change in place
https://github.com/ascerra/cli-mirror/actions/workflows/checks-sealights.yaml

Assisted by: Cursor AI