### PR TITLE
chore: call ImageReferenceInStubRegistry with format string

### DIFF
--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           # Needed in hack/derive-version.sh
           fetch-depth: 0
 


### PR DESCRIPTION
* without the format string as the 2nd argument, Sealights
   was throwing error as: "non-constant format string in call
   to ImageReferenceInStubRegistry"
* So, I added a format string.