### PR TITLE
Checkout PR changes for testing instead of main

### DIFF
--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -51,11 +51,15 @@ jobs:
           echo "Invalid context for this workflow run. Exiting."
           exit 1
 
-      - name: Checkout repository
+      - name: Checkout PR Head
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Needed in hack/derive-version.sh
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show git sha and commit subject
+        run: git log --oneline -n1
+
 
       - name: Restore Cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2


### PR DESCRIPTION
# description
This solves the issue where the github workflow was using the latest commit from main instead of the new commit from the PR.

Issue came about because we need to use pull_request_target to use a secret in the workflow.

This change uses github.event.pull_request.head.sha to get the PR changes to test now

# Testing
This unfortunately needs to be merged for the changes to take effect since the job itself uses the pull_request_target which is main.

So I tested this by merging this change into my mirrored main branch 

I updated my mirrored repo by changing this
https://github.com/ascerra/cli-mirror/pull/65/files#diff-6f64955ec68373342700ce7013cb53adb89eb19e54ffaee071a31ca76d0e2fe6R57-R6

merged that into my mirrored repo then submitted a new PR which will use the change and we can now see the git log is showing the commit message from the PR not the previous commit merged into main
https://github.com/ascerra/cli-mirror/actions/runs/16632154737/job/47064205292?pr=66

Assisted-by: Gemini