### PR TITLE
Add --show-warnings flag to control warning output

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -350,6 +350,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			}
 
 			showSuccesses, _ := cmd.Flags().GetBool("show-successes")
+			showWarnings, _ := cmd.Flags().GetBool("show-warnings")
 
 			// worker is responsible for processing one component at a time from the jobs channel,
 			// and for emitting a corresponding result for the component on the results channel.
@@ -453,11 +454,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				data.output = append(data.output, fmt.Sprintf("%s=%s", applicationsnapshot.JSON, data.outputFile))
 			}
 
-			report, err := applicationsnapshot.NewReport(data.snapshot, components, data.policy, manyPolicyInput, showSuccesses, data.expansion)
+			report, err := applicationsnapshot.NewReport(data.snapshot, components, data.policy, manyPolicyInput, showSuccesses, showWarnings, data.expansion)
 			if err != nil {
 				return err
 			}
-			p := format.NewTargetParser(applicationsnapshot.JSON, format.Options{ShowSuccesses: showSuccesses}, cmd.OutOrStdout(), utils.FS(cmd.Context()))
+			p := format.NewTargetParser(applicationsnapshot.JSON, format.Options{ShowSuccesses: showSuccesses, ShowWarnings: showWarnings}, cmd.OutOrStdout(), utils.FS(cmd.Context()))
 			utils.SetColorEnabled(data.noColor, data.forceColor)
 			if err := report.WriteAll(data.output, p); err != nil {
 				return err

--- a/cmd/validate/input.go
+++ b/cmd/validate/input.go
@@ -117,6 +117,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 			}
 
 			showSuccesses, _ := cmd.Flags().GetBool("show-successes")
+			showWarnings, _ := cmd.Flags().GetBool("show-warnings")
 
 			// Set numWorkers to the value from our flag. The default is 5.
 			numWorkers := data.workers
@@ -146,7 +147,11 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 
 					if err == nil {
 						res.input.Violations = out.Violations()
-						res.input.Warnings = out.Warnings()
+
+						warnings := out.Warnings()
+						if showWarnings {
+							res.input.Warnings = warnings
+						}
 
 						successes := out.Successes()
 						res.input.SuccessCount = len(successes)
@@ -207,7 +212,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 				return err
 			}
 
-			p := format.NewTargetParser(input.JSON, format.Options{ShowSuccesses: showSuccesses}, cmd.OutOrStdout(), utils.FS(cmd.Context()))
+			p := format.NewTargetParser(input.JSON, format.Options{ShowSuccesses: showSuccesses, ShowWarnings: showWarnings}, cmd.OutOrStdout(), utils.FS(cmd.Context()))
 			if err := report.WriteAll(data.output, p); err != nil {
 				return err
 			}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -43,5 +43,6 @@ func NewValidateCmd() *cobra.Command {
 		Short: "Validate conformance with the provided policies",
 	}
 	validateCmd.PersistentFlags().Bool("show-successes", false, "")
+	validateCmd.PersistentFlags().Bool("show-warnings", true, "")
 	return validateCmd
 }

--- a/docs/modules/ROOT/pages/ec_validate.adoc
+++ b/docs/modules/ROOT/pages/ec_validate.adoc
@@ -6,6 +6,7 @@ Validate conformance with the provided policies
 
 -h, --help:: help for validate (Default: false)
 --show-successes::  (Default: false)
+--show-warnings::  (Default: true)
 
 == Options inherited from parent commands
 

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -166,6 +166,7 @@ JSON of the "spec" or a reference to a Kubernetes object [<namespace>/]<name>
 --retry-max-retry:: maximum number of retry attempts (Default: 3)
 --retry-max-wait:: maximum wait time between retries (Default: 3s)
 --show-successes::  (Default: false)
+--show-warnings::  (Default: true)
 --timeout:: max overall execution duration (Default: 5m0s)
 --trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)

--- a/docs/modules/ROOT/pages/ec_validate_input.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_input.adoc
@@ -72,6 +72,7 @@ mark (?) sign, for example: --output text=output.txt?show-successes=false
 --retry-max-retry:: maximum number of retry attempts (Default: 3)
 --retry-max-wait:: maximum wait time between retries (Default: 3s)
 --show-successes::  (Default: false)
+--show-warnings::  (Default: true)
 --timeout:: max overall execution duration (Default: 5m0s)
 --trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)

--- a/docs/modules/ROOT/pages/ec_validate_policy.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_policy.adoc
@@ -38,6 +38,7 @@ ec validate policy --policy-configuration github.com/org/repo/policy.yaml
 --retry-max-retry:: maximum number of retry attempts (Default: 3)
 --retry-max-wait:: maximum wait time between retries (Default: 3s)
 --show-successes::  (Default: false)
+--show-warnings::  (Default: true)
 --timeout:: max overall execution duration (Default: 5m0s)
 --trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
 --verbose:: more verbose output (Default: false)

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -61,6 +61,7 @@ type Report struct {
 	EffectiveTime time.Time                        `json:"effective-time"`
 	PolicyInput   [][]byte                         `json:"-"`
 	ShowSuccesses bool                             `json:"-"`
+	ShowWarnings  bool                             `json:"-"`
 	Expansion     *ExpansionInfo                   `json:"-"`
 }
 
@@ -127,7 +128,7 @@ var OutputFormats = []string{
 
 // WriteReport returns a new instance of Report representing the state of
 // components from the snapshot.
-func NewReport(snapshot string, components []Component, policy policy.Policy, policyInput [][]byte, showSuccesses bool, expansion *ExpansionInfo) (Report, error) {
+func NewReport(snapshot string, components []Component, policy policy.Policy, policyInput [][]byte, showSuccesses bool, showWarnings bool, expansion *ExpansionInfo) (Report, error) {
 	success := true
 
 	// Set the report success, remains true if all components are successful
@@ -158,6 +159,7 @@ func NewReport(snapshot string, components []Component, policy policy.Policy, po
 		PolicyInput:   policyInput,
 		EffectiveTime: policy.EffectiveTime().UTC(),
 		ShowSuccesses: showSuccesses,
+		ShowWarnings:  showWarnings,
 		Expansion:     expansion,
 	}, nil
 }
@@ -261,6 +263,7 @@ func (r *Report) toSummary() summary {
 
 func (r *Report) applyOptions(opts format.Options) {
 	r.ShowSuccesses = opts.ShowSuccesses
+	r.ShowWarnings = opts.ShowWarnings
 }
 
 // condensedMsg reduces repetitive error messages.

--- a/internal/applicationsnapshot/templates/text_report.tmpl
+++ b/internal/applicationsnapshot/templates/text_report.tmpl
@@ -7,13 +7,13 @@ Result: {{ $t.Result }}
 Violations: {{ $t.Failures }}, Warnings: {{ $t.Warnings }}, Successes: {{ $t.Successes }}{{ nl -}}
 
 {{- template "_components.tmpl" $c -}}
-{{- if or (gt $t.Failures 0) (gt $t.Warnings 0) (and (gt $t.Successes 0) $r.ShowSuccesses) -}}
+{{- if or (gt $t.Failures 0) (and (gt $t.Warnings 0) $r.ShowWarnings) (and (gt $t.Successes 0) $r.ShowSuccesses) -}}
 Results:{{ nl -}}
 {{- if gt $t.Failures 0 -}}
   {{- template "_results.tmpl" (toMap "Components" $c "Type" "Violation") -}}
 {{- end -}}
 
-{{- if gt $t.Warnings 0 -}}
+{{- if and (gt $t.Warnings 0) $r.ShowWarnings -}}
   {{- template "_results.tmpl" (toMap "Components" $c "Type" "Warning") -}}
 {{- end -}}
 
@@ -22,6 +22,6 @@ Results:{{ nl -}}
 {{- end -}}
 {{- end -}}
 
-{{- if or (gt $t.Failures 0) (gt $t.Warnings 0) -}}
+{{- if or (gt $t.Failures 0) (and (gt $t.Warnings 0) $r.ShowWarnings) -}}
 For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/{{ nl -}}
 {{- end -}}

--- a/internal/format/target.go
+++ b/internal/format/target.go
@@ -35,6 +35,7 @@ type Target struct {
 // options that can be configured per Target
 type Options struct {
 	ShowSuccesses bool
+	ShowWarnings  bool
 }
 
 // mutate parses the given string as URL query parameters and sets the fields
@@ -48,6 +49,14 @@ func (o *Options) mutate(given string) error {
 	if v := vals.Get("show-successes"); v != "" {
 		if f, err := strconv.ParseBool(v); err == nil {
 			o.ShowSuccesses = f
+		} else {
+			return err
+		}
+	}
+
+	if v := vals.Get("show-warnings"); v != "" {
+		if f, err := strconv.ParseBool(v); err == nil {
+			o.ShowWarnings = f
 		} else {
 			return err
 		}

--- a/internal/format/target_test.go
+++ b/internal/format/target_test.go
@@ -31,6 +31,7 @@ func TestTargetParser(t *testing.T) {
 	defaultPath := "default.out"
 	defaultOptions := Options{
 		ShowSuccesses: false,
+		ShowWarnings:  true,
 	}
 
 	cases := []struct {
@@ -44,9 +45,12 @@ func TestTargetParser(t *testing.T) {
 		{name: "format", expectedFormat: "spam", expectedOptions: defaultOptions, targetName: "spam"},
 		{name: "format no file", expectedFormat: "spam", expectedOptions: defaultOptions, targetName: "spam="},
 		{name: "format and file", expectedFormat: "spam", expectedOptions: defaultOptions, targetName: "spam=spam.out", expectedPath: "spam.out"},
-		{name: "format and option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true}, targetName: "spam?show-successes=true"},
-		{name: "format no file with option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true}, targetName: "spam=?show-successes=true"},
-		{name: "format with file and option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true}, targetName: "spam=spam.out?show-successes=true", expectedPath: "spam.out"},
+		{name: "format and option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true, ShowWarnings: true}, targetName: "spam?show-successes=true"},
+		{name: "format no file with option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true, ShowWarnings: true}, targetName: "spam=?show-successes=true"},
+		{name: "format with file and option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true, ShowWarnings: true}, targetName: "spam=spam.out?show-successes=true", expectedPath: "spam.out"},
+		{name: "format with show-warnings option", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: false, ShowWarnings: false}, targetName: "spam?show-warnings=false"},
+		{name: "format with both options", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: true, ShowWarnings: false}, targetName: "spam?show-successes=true&show-warnings=false"},
+		{name: "format with both options reversed", expectedFormat: "spam", expectedOptions: Options{ShowSuccesses: false, ShowWarnings: true}, targetName: "spam?show-warnings=true&show-successes=false"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
* Add --show-warnings flag to validate command with default `true`
* Modify text template to conditionally show warnings
* Update both image and input subcommands to use the flag

resolves: EC-1304