### PR TITLE
feat(evaluator): enhance rule discovery for VSA support

### DIFF
--- a/internal/evaluator/conftest_evaluator_unit_metadata_test.go
+++ b/internal/evaluator/conftest_evaluator_unit_metadata_test.go
@@ -65,10 +65,10 @@ func TestCollectAnnotationData(t *testing.T) {
 		ProcessAnnotation: true,
 	})
 
-	rules := policyRules{}
+	rules := PolicyRules{}
 	require.NoError(t, rules.collect(ast.NewAnnotationsRef(module.Annotations[0])))
 
-	assert.Equal(t, policyRules{
+	assert.Equal(t, PolicyRules{
 		"a.b.c.short": {
 			Code:              "a.b.c.short",
 			Collections:       []string{"A", "B", "C"},
@@ -92,7 +92,7 @@ func TestRuleMetadata(t *testing.T) {
 	ctx := context.TODO()
 	ctx = context.WithValue(ctx, effectiveTimeKey, effectiveTimeTest)
 
-	rules := policyRules{
+	rules := PolicyRules{
 		"warning1": rule.Info{
 			Title: "Warning1",
 		},
@@ -119,7 +119,7 @@ func TestRuleMetadata(t *testing.T) {
 	cases := []struct {
 		name   string
 		result Result
-		rules  policyRules
+		rules  PolicyRules
 		want   Result
 	}{
 		{

--- a/internal/evaluator/filters_test.go
+++ b/internal/evaluator/filters_test.go
@@ -94,7 +94,7 @@ func TestDefaultFilterFactory(t *testing.T) {
 //////////////////////////////////////////////////////////////////////////////
 
 func TestIncludeListFilter(t *testing.T) {
-	rules := policyRules{
+	rules := PolicyRules{
 		"pkg.rule":    {Collections: []string{"redhat"}},
 		"cve.rule":    {Collections: []string{"security"}},
 		"other.rule":  {},
@@ -145,7 +145,7 @@ func TestIncludeListFilter(t *testing.T) {
 //////////////////////////////////////////////////////////////////////////////
 
 func TestPipelineIntentionFilter(t *testing.T) {
-	rules := policyRules{
+	rules := PolicyRules{
 		"a.r": {PipelineIntention: []string{"release"}},
 		"b.r": {PipelineIntention: []string{"dev"}},
 		"c.r": {},
@@ -184,7 +184,7 @@ func TestPipelineIntentionFilter(t *testing.T) {
 //////////////////////////////////////////////////////////////////////////////
 
 func TestCompleteFilteringBehavior(t *testing.T) {
-	rules := policyRules{
+	rules := PolicyRules{
 		"release.rule1": {PipelineIntention: []string{"release"}},
 		"release.rule2": {PipelineIntention: []string{"release", "production"}},
 		"dev.rule1":     {PipelineIntention: []string{"dev"}},
@@ -236,7 +236,7 @@ func TestCompleteFilteringBehavior(t *testing.T) {
 func TestFilteringWithRulesWithoutMetadata(t *testing.T) {
 	// This test demonstrates how filtering works with rules that don't have
 	// pipeline_intention metadata, like the example fail_with_data.rego rule.
-	rules := policyRules{
+	rules := PolicyRules{
 		"main.fail_with_data": {}, // Rule without any metadata (like fail_with_data.rego)
 		"release.security":    {PipelineIntention: []string{"release"}},
 		"dev.validation":      {PipelineIntention: []string{"dev"}},
@@ -297,7 +297,7 @@ func TestECPolicyResolver(t *testing.T) {
 	resolver := NewECPolicyResolver(source, configProvider)
 
 	// Create mock rules
-	rules := policyRules{
+	rules := PolicyRules{
 		"cve.high_severity": rule.Info{
 			Package:     "cve",
 			Code:        "cve.high_severity",
@@ -362,7 +362,7 @@ func TestECPolicyResolver_DefaultBehavior(t *testing.T) {
 
 	resolver := NewECPolicyResolver(source, configProvider)
 
-	rules := policyRules{
+	rules := PolicyRules{
 		"cve.high_severity": rule.Info{
 			Package: "cve",
 			Code:    "cve.high_severity",
@@ -395,7 +395,7 @@ func TestECPolicyResolver_PipelineIntention(t *testing.T) {
 
 	resolver := NewECPolicyResolver(source, configProvider)
 
-	rules := policyRules{
+	rules := PolicyRules{
 		"tasks.build_task": rule.Info{
 			Package:           "tasks",
 			Code:              "tasks.build_task",
@@ -455,7 +455,7 @@ func TestECPolicyResolver_Example(t *testing.T) {
 	}
 
 	// Create mock rules that would be found in the policy
-	rules := policyRules{
+	rules := PolicyRules{
 		"cve.high_severity": rule.Info{
 			Package:     "cve",
 			Code:        "cve.high_severity",
@@ -559,7 +559,7 @@ func TestUnifiedPostEvaluationFilter(t *testing.T) {
 			},
 		}
 
-		rules := policyRules{
+		rules := PolicyRules{
 			"cve.high_severity": rule.Info{
 				Package: "cve",
 				Code:    "cve.high_severity",
@@ -632,7 +632,7 @@ func TestUnifiedPostEvaluationFilter(t *testing.T) {
 			},
 		}
 
-		rules := policyRules{
+		rules := PolicyRules{
 			"release.security_check": rule.Info{
 				Package:           "release",
 				Code:              "release.security_check",
@@ -652,10 +652,8 @@ func TestUnifiedPostEvaluationFilter(t *testing.T) {
 		filteredResults, updatedMissingIncludes := filter.FilterResults(
 			results, rules, "test-target", missingIncludes, time.Now())
 
-		// Should only include release.security_check (matches pipeline intention)
 		assert.Len(t, filteredResults, 1)
 
-		// Check that the correct result is included
 		if len(filteredResults) > 0 {
 			code := filteredResults[0].Metadata[metadataCode].(string)
 			assert.Equal(t, "release.security_check", code)
@@ -688,7 +686,7 @@ func TestUnifiedPostEvaluationFilter(t *testing.T) {
 			},
 		}
 
-		rules := policyRules{
+		rules := PolicyRules{
 			"cve.high_severity": rule.Info{
 				Package: "cve",
 				Code:    "cve.high_severity",
@@ -785,7 +783,7 @@ func TestUnifiedPostEvaluationFilterVsLegacy(t *testing.T) {
 			},
 		}
 
-		rules := policyRules{
+		rules := PolicyRules{
 			"cve.high_severity": rule.Info{
 				Package: "cve",
 				Code:    "high_severity",
@@ -904,7 +902,7 @@ func TestIncludeExcludePolicyResolver(t *testing.T) {
 	}
 
 	// Create rules with pipeline intention metadata
-	rules := policyRules{
+	rules := PolicyRules{
 		"build.rule1": rule.Info{
 			Code:              "build.rule1",
 			Package:           "build",

--- a/internal/evaluator/rule_discovery.go
+++ b/internal/evaluator/rule_discovery.go
@@ -1,0 +1,215 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/conforma/cli/internal/opa"
+	"github.com/conforma/cli/internal/opa/rule"
+	"github.com/conforma/cli/internal/policy/source"
+	"github.com/conforma/cli/internal/utils"
+)
+
+// RuleDiscoveryService provides functionality to discover and collect rules
+// from policy sources. This service is separate from evaluation to maintain
+// clear separation of concerns.
+type RuleDiscoveryService interface {
+	// DiscoverRules discovers and collects all available rules from the given
+	// policy sources. Returns a map of rule codes to rule information.
+	DiscoverRules(ctx context.Context, policySources []source.PolicySource) (PolicyRules, error)
+
+	// DiscoverRulesWithNonAnnotated discovers all rules (both annotated and non-annotated)
+	// from policy sources. Returns both the annotated rules and a set of non-annotated rule codes.
+	// This is used by the evaluator for comprehensive filtering.
+	DiscoverRulesWithNonAnnotated(ctx context.Context, policySources []source.PolicySource) (PolicyRules, map[string]bool, error)
+
+	// DiscoverRulesWithWorkDir discovers rules using a specific work directory.
+	// This is used by the evaluator to ensure policies are downloaded to the same location.
+	DiscoverRulesWithWorkDir(ctx context.Context, policySources []source.PolicySource, workDir string) (PolicyRules, map[string]bool, error)
+
+	// CombineRulesForFiltering combines annotated and non-annotated rules into a single
+	// PolicyRules map suitable for filtering. This encapsulates the logic for creating
+	// minimal rule.Info structures for non-annotated rules.
+	CombineRulesForFiltering(annotatedRules PolicyRules, nonAnnotatedRules map[string]bool) PolicyRules
+}
+
+type ruleDiscoveryService struct{}
+
+// NewRuleDiscoveryService creates a new rule discovery service.
+func NewRuleDiscoveryService() RuleDiscoveryService {
+	return &ruleDiscoveryService{}
+}
+
+// DiscoverRules implements the RuleDiscoveryService interface by collecting
+// all rules from the provided policy sources.
+func (r *ruleDiscoveryService) DiscoverRules(ctx context.Context, policySources []source.PolicySource) (PolicyRules, error) {
+	rules, _, err := r.DiscoverRulesWithNonAnnotated(ctx, policySources)
+	return rules, err
+}
+
+// DiscoverRulesWithNonAnnotated discovers all rules (both annotated and non-annotated)
+// from policy sources. This method provides the complete rule discovery functionality
+// that was previously embedded in the evaluator.
+func (r *ruleDiscoveryService) DiscoverRulesWithNonAnnotated(ctx context.Context, policySources []source.PolicySource) (PolicyRules, map[string]bool, error) {
+	// Create a temporary work directory for downloading policy sources
+	fs := utils.FS(ctx)
+	workDir, err := utils.CreateWorkDir(fs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create work directory: %w", err)
+	}
+
+	return r.DiscoverRulesWithWorkDir(ctx, policySources, workDir)
+}
+
+// DiscoverRulesWithWorkDir discovers all rules (both annotated and non-annotated)
+// from policy sources using a specific work directory. This is used by the evaluator
+// to ensure policies are downloaded to the same location.
+func (r *ruleDiscoveryService) DiscoverRulesWithWorkDir(ctx context.Context, policySources []source.PolicySource, workDir string) (PolicyRules, map[string]bool, error) {
+	rules := PolicyRules{}
+	nonAnnotatedRules := make(map[string]bool)
+	noRegoFilesError := false
+
+	// Download and collect rules from all policy sources
+	for _, s := range policySources {
+		dir, err := s.GetPolicy(ctx, workDir, false)
+		if err != nil {
+			log.Debugf("Unable to download source from %s: %v", s.PolicyUrl(), err)
+			return nil, nil, fmt.Errorf("failed to download policy source %s: %w", s.PolicyUrl(), err)
+		}
+
+		annotations := []*ast.AnnotationsRef{}
+
+		// We only want to inspect the directory of policy subdirs, not config or data subdirs
+		if s.Subdir() == "policy" {
+			fs := utils.FS(ctx)
+			annotations, err = opa.InspectDir(fs, dir)
+			if err != nil {
+				// Handle the case where no Rego files are found gracefully
+				if err.Error() == "no rego files found in policy subdirectory" {
+					log.Debugf("No Rego files found in policy subdirectory for %s", s.PolicyUrl())
+					noRegoFilesError = true
+					continue // Skip this source and continue with others
+				}
+
+				errMsg := err
+				// Let's try to give some more robust messaging to the user
+				policyURL, err := url.Parse(s.PolicyUrl())
+				if err != nil {
+					return nil, nil, errMsg
+				}
+				// Do we have a prefix at the end of the URL path?
+				// If not, this means we aren't trying to access a specific file
+				pos := strings.LastIndex(policyURL.Path, ".")
+				if pos == -1 {
+					// Are we accessing a GitHub or GitLab URL? If so, are we beginning with 'https' or 'http'?
+					if (policyURL.Host == "github.com" || policyURL.Host == "gitlab.com") && (policyURL.Scheme == "https" || policyURL.Scheme == "http") {
+						log.Debug("Git Hub or GitLab, http transport, and no file extension, this could be a problem.")
+						errMsg = fmt.Errorf("%s.\nYou've specified a %s URL with an %s:// scheme.\nDid you mean: %s instead?", errMsg, policyURL.Hostname(), policyURL.Scheme, fmt.Sprint(policyURL.Host+policyURL.RequestURI()))
+					}
+				}
+				return nil, nil, errMsg
+			}
+		}
+
+		// Collect ALL rules for filtering purposes - both with and without annotations
+		// This ensures that rules without metadata (like fail_with_data.rego) are properly included
+		for _, a := range annotations {
+			if a.Annotations != nil {
+				// Rules with annotations - collect full metadata
+				if err := rules.collect(a); err != nil {
+					return nil, nil, fmt.Errorf("failed to collect rule from %s: %w", s.PolicyUrl(), err)
+				}
+			} else {
+				// Rules without annotations - track for filtering only, not for success computation
+				ruleRef := a.GetRule()
+				if ruleRef != nil {
+					// Extract package name from the rule path
+					packageName := ""
+					if len(a.Path) > 1 {
+						// Path format is typically ["data", "package", "rule"]
+						// We want the package part (index 1)
+						if len(a.Path) >= 2 {
+							packageName = strings.ReplaceAll(a.Path[1].String(), `"`, "")
+						}
+					}
+
+					// Try to extract code from rule body first, fallback to rule name
+					code := extractCodeFromRuleBody(ruleRef)
+
+					// If no code found in body, use rule name
+					if code == "" {
+						shortName := ruleRef.Head.Name.String()
+						code = fmt.Sprintf("%s.%s", packageName, shortName)
+					}
+
+					// Debug: Print non-annotated rule processing
+					log.Debugf("Non-annotated rule: packageName=%s, code=%s", packageName, code)
+
+					// Track for filtering but don't add to rules map for success computation
+					nonAnnotatedRules[code] = true
+				}
+			}
+		}
+	}
+
+	log.Debugf("Discovered %d annotated rules and %d non-annotated rules from %d policy sources",
+		len(rules), len(nonAnnotatedRules), len(policySources))
+
+	// If no rego files were found in any policy source and no rules were discovered,
+	// return the original error message for backward compatibility.
+	// This maintains the expected behavior for the acceptance test scenario where
+	// a policy repository is downloaded but contains no valid rego files.
+	if noRegoFilesError && len(rules) == 0 && len(nonAnnotatedRules) == 0 {
+		return nil, nil, fmt.Errorf("no rego files found in policy subdirectory")
+	}
+
+	return rules, nonAnnotatedRules, nil
+}
+
+// CombineRulesForFiltering combines annotated and non-annotated rules into a single
+// PolicyRules map suitable for filtering. This method encapsulates the logic for
+// creating minimal rule.Info structures for non-annotated rules.
+func (r *ruleDiscoveryService) CombineRulesForFiltering(annotatedRules PolicyRules, nonAnnotatedRules map[string]bool) PolicyRules {
+	// Start with all annotated rules
+	allRules := make(PolicyRules)
+	for code, rule := range annotatedRules {
+		allRules[code] = rule
+	}
+
+	// Add non-annotated rules as minimal rule.Info for filtering
+	for code := range nonAnnotatedRules {
+		parts := strings.Split(code, ".")
+		if len(parts) >= 2 {
+			packageName := parts[len(parts)-2]
+			shortName := parts[len(parts)-1]
+			allRules[code] = rule.Info{
+				Code:      code,
+				Package:   packageName,
+				ShortName: shortName,
+			}
+		}
+	}
+
+	return allRules
+}

--- a/internal/evaluator/rule_discovery_test.go
+++ b/internal/evaluator/rule_discovery_test.go
@@ -1,0 +1,201 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conforma/cli/internal/policy/source"
+	"github.com/conforma/cli/internal/utils"
+)
+
+// mockPolicySource implements source.PolicySource for testing
+type mockPolicySource struct {
+	policyDir string
+}
+
+func (m mockPolicySource) GetPolicy(ctx context.Context, dest string, showMsg bool) (string, error) {
+	return m.policyDir, nil
+}
+
+func (m mockPolicySource) PolicyUrl() string {
+	return "mock-url"
+}
+
+func (m mockPolicySource) Subdir() string {
+	return "policy"
+}
+
+func (mockPolicySource) Type() source.PolicyType {
+	return source.PolicyKind
+}
+
+func TestRuleDiscoveryService_DiscoverRules(t *testing.T) {
+	// Create a test filesystem
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	// Create a test policy file with annotations
+	policyContent := `package test
+
+import rego.v1
+
+# METADATA
+# title: Test Rule
+# description: A test rule for rule discovery
+# custom:
+#   short_name: test_rule
+#   failure_msg: Test rule failed
+
+deny contains result if {
+    result := {
+        "msg": "Test rule failed",
+        "code": "test.test_rule"
+    }
+}`
+
+	// Write the policy file directly to the test filesystem
+	policyPath := "/policy/test.rego"
+	err := afero.WriteFile(fs, policyPath, []byte(policyContent), 0644)
+	require.NoError(t, err)
+
+	// Create a mock policy source that points to our test directory
+	policySource := mockPolicySource{policyDir: "/policy"}
+
+	// Create the rule discovery service
+	service := NewRuleDiscoveryService()
+
+	// Discover rules
+	rules, err := service.DiscoverRules(ctx, []source.PolicySource{policySource})
+	require.NoError(t, err)
+
+	// Verify that we found the expected rule
+	assert.Len(t, rules, 1, "Expected to find exactly one rule")
+
+	ruleInfo, exists := rules["test.test_rule"]
+	assert.True(t, exists, "Expected to find rule with code 'test.test_rule'")
+	assert.Equal(t, "test.test_rule", ruleInfo.Code)
+	assert.Equal(t, "test", ruleInfo.Package)
+	assert.Equal(t, "test_rule", ruleInfo.ShortName)
+	assert.Equal(t, "Test Rule", ruleInfo.Title)
+	assert.Equal(t, "A test rule for rule discovery", ruleInfo.Description)
+}
+
+func TestRuleDiscoveryService_DiscoverRules_NoPolicyFiles(t *testing.T) {
+	// Create a test filesystem
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	// Create an empty directory in the test filesystem
+	err := fs.MkdirAll("/empty", 0755)
+	require.NoError(t, err)
+
+	// Create a mock policy source that points to an empty directory
+	policySource := mockPolicySource{policyDir: "/empty"}
+
+	// Create the rule discovery service
+	service := NewRuleDiscoveryService()
+
+	// Discover rules - this should fail because no rego files are found
+	// This maintains backward compatibility with the acceptance test scenario
+	_, err = service.DiscoverRules(ctx, []source.PolicySource{policySource})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no rego files found in policy subdirectory")
+}
+
+func TestRuleDiscoveryService_DiscoverRules_MultipleSources(t *testing.T) {
+	// Create a test filesystem
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	// Create test policy files
+	policyContent1 := `package test1
+
+import rego.v1
+
+# METADATA
+# title: Test Rule 1
+# description: First test rule
+# custom:
+#   short_name: test_rule_1
+#   failure_msg: Test rule 1 failed
+
+deny contains result if {
+    result := {
+        "msg": "Test rule 1 failed",
+        "code": "test1.test_rule_1"
+    }
+}`
+
+	policyContent2 := `package test2
+
+import rego.v1
+
+# METADATA
+# title: Test Rule 2
+# description: Second test rule
+# custom:
+#   short_name: test_rule_2
+#   failure_msg: Test rule 2 failed
+
+deny contains result if {
+    result := {
+        "msg": "Test rule 2 failed",
+        "code": "test2.test_rule_2"
+    }
+}`
+
+	// Write the policy files directly to the test filesystem
+	policyPath1 := "/policy1/test1.rego"
+	err := afero.WriteFile(fs, policyPath1, []byte(policyContent1), 0644)
+	require.NoError(t, err)
+
+	policyPath2 := "/policy2/test2.rego"
+	err = afero.WriteFile(fs, policyPath2, []byte(policyContent2), 0644)
+	require.NoError(t, err)
+
+	// Create policy sources
+	policySource1 := mockPolicySource{policyDir: "/policy1"}
+	policySource2 := mockPolicySource{policyDir: "/policy2"}
+
+	// Create the rule discovery service
+	service := NewRuleDiscoveryService()
+
+	// Discover rules from both sources
+	rules, err := service.DiscoverRules(ctx, []source.PolicySource{policySource1, policySource2})
+	require.NoError(t, err)
+
+	// Verify that we found both rules
+	assert.Len(t, rules, 2, "Expected to find exactly two rules")
+
+	// Check first rule
+	ruleInfo1, exists := rules["test1.test_rule_1"]
+	assert.True(t, exists, "Expected to find rule with code 'test1.test_rule_1'")
+	assert.Equal(t, "test1.test_rule_1", ruleInfo1.Code)
+	assert.Equal(t, "test1", ruleInfo1.Package)
+
+	// Check second rule
+	ruleInfo2, exists := rules["test2.test_rule_2"]
+	assert.True(t, exists, "Expected to find rule with code 'test2.test_rule_2'")
+	assert.Equal(t, "test2.test_rule_2", ruleInfo2.Code)
+	assert.Equal(t, "test2", ruleInfo2.Package)
+}


### PR DESCRIPTION
This PR solves the problem of the evaluator not being able to dynamically discover and apply VSA-specific validation rules.

- Add rule discovery functionality for policy resolution
- Enhance conftest evaluator with VSA-specific metadata
- Improve filtering capabilities for VSA validation
- Add comprehensive tests for rule discovery