### PR TITLE
fix reference.adoc xref

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -20,7 +20,7 @@ ec validate image --policy '{
 ----
 
 The configuration can be provided as a reference to a
-xref:ecc:ROOT:reference.adoc[EnterpriseContractPolicy] Kubernetes custom
+xref:cli:ROOT:reference.adoc[EnterpriseContractPolicy] Kubernetes custom
 resource by either name (e.g. "my-policy") in the current namespace, or by
 providing namespace and the name separaded by slash (`/`) character, such as in
 this example:


### PR DESCRIPTION
This commit updates the reference of `ecc:ROOT:reference.adoc` to `cli:ROOT:reference.adoc` based on refactoring of the `conforma/crds` repository.

Ref: EC-1422