### PR TITLE
validate vsa command

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -4,10 +4,10 @@ go 1.24.4
 
 require (
 	cuelang.org/go v0.11.1
+	github.com/conforma/crds/api v0.1.0
 	github.com/cucumber/godog v0.15.0
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f
 	github.com/doiit/picocolors v1.0.1
-	github.com/conforma/crds/api v0.1.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/gkampitakis/go-snaps v0.5.7
 	github.com/go-git/go-billy/v5 v5.6.0

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -314,8 +314,6 @@ github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.112 h1:4/PBvqANhDiJgpzOZG/zCj7Gl6jtsaMFRwCiFF2KNOg=
-github.com/enterprise-contract/enterprise-contract-controller/api v0.1.112/go.mod h1:YfIsqAmIc3ncPfxOw6LEsngWdeAVSO+V7svjoNpxyKs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -35,6 +35,7 @@ func init() {
 	ValidateCmd.AddCommand(validateImageCmd(image.ValidateImage))
 	ValidateCmd.AddCommand(validateInputCmd(input.ValidateInput))
 	ValidateCmd.AddCommand(ValidatePolicyCmd(policy.ValidatePolicy))
+	ValidateCmd.AddCommand(NewValidateVSACmd())
 }
 
 func NewValidateCmd() *cobra.Command {

--- a/cmd/validate/vsa.go
+++ b/cmd/validate/vsa.go
@@ -1,0 +1,942 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	hd "github.com/MakeNowJust/heredoc"
+	ecapi "github.com/conforma/crds/api/v1alpha1"
+	"github.com/google/go-containerregistry/pkg/name"
+	app "github.com/konflux-ci/application-api/api/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/conforma/cli/internal/applicationsnapshot"
+	"github.com/conforma/cli/internal/policy/equivalence"
+	validate_utils "github.com/conforma/cli/internal/validate"
+	"github.com/conforma/cli/internal/validate/vsa"
+)
+
+// ValidationResult represents the result of VSA validation
+type ValidationResult struct {
+	Passed  bool   `json:"passed"`
+	Message string `json:"message,omitempty"`
+}
+
+// IdentifierType represents the type of VSA identifier
+type IdentifierType int
+
+const (
+	// IdentifierFile represents a local file path (absolute, relative, or files with extensions)
+	IdentifierFile IdentifierType = iota
+	// IdentifierImageDigest represents a container image digest (e.g., sha256:abc123...)
+	IdentifierImageDigest
+	// IdentifierImageReference represents a container image reference (e.g., nginx:latest, registry.io/repo:tag)
+	IdentifierImageReference
+)
+
+// ComponentResult represents the validation result for a snapshot component
+type ComponentResult struct {
+	ComponentName string
+	ImageRef      string
+	Result        *ValidationResult
+	Error         error
+}
+
+// validateVSAData holds the command data
+type validateVSAData struct {
+	// Input options
+	vsaIdentifier string // Single VSA identifier (image digest, file path)
+	images        string // Application snapshot file
+	policyConfig  string // Policy configuration
+
+	// VSA retrieval options
+	vsaRetrieval []string // VSA retrieval backends (rekor@, file@)
+
+	// Policy comparison options
+	effectiveTime string // Effective time for comparison
+	// Note: imageDigest, imageRef, imageURL will be extracted from vsaIdentifier or images
+
+	// VSA options
+	vsaExpirationStr string        // VSA expiration threshold as string
+	vsaExpiration    time.Duration // VSA expiration threshold as duration
+
+	// Output options
+	output     []string // Output formats
+	outputFile string   // Output file
+	strict     bool     // Strict mode (fail on any error)
+
+	// Parallel processing options
+	workers int // Number of worker threads for parallel processing
+
+	// Output formatting options
+	noColor    bool // Disable color output
+	forceColor bool // Force color output
+
+	// Internal state
+	policySpec ecapi.EnterpriseContractPolicySpec
+	retriever  vsa.VSARetriever
+}
+
+func NewValidateVSACmd() *cobra.Command {
+	data := &validateVSAData{
+		strict:           true,
+		effectiveTime:    "now",
+		vsaExpirationStr: "168h",          // 7 days default
+		vsaExpiration:    168 * time.Hour, // 7 days default
+		workers:          5,               // 5 workers default
+	}
+
+	cmd := &cobra.Command{
+		Use:   "vsa <vsa-identifier>",
+		Short: "Validate VSA (Verification Summary Attestation)",
+		Long: hd.Doc(`
+			Validate VSA by comparing the embedded policy against a supplied policy configuration.
+			
+			Supports validation of:
+			- Single VSA by identifier (image digest, file path)
+			- Multiple VSAs from application snapshot
+			
+			VSA retrieval supports:
+			- Rekor transparency log
+			- Local filesystem storage
+			- Multiple backends with fallback
+		`),
+		// Check positional arguments
+		// Example: ec validate vsa image1@sha256:abc123 --policy policy.yaml
+		Args: func(cmd *cobra.Command, args []string) error {
+			// Custom argument validation using Cobra's Args field
+			if len(args) > 1 {
+				return fmt.Errorf("too many arguments provided")
+			}
+
+			// Validate VSA identifier format if provided
+			if len(args) == 1 {
+				identifier := args[0]
+				if !isValidVSAIdentifier(identifier) {
+					return fmt.Errorf("invalid VSA identifier format: %s", identifier)
+				}
+			}
+
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateVSAInput(data, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runValidateVSA(cmd, data, args)
+		},
+	}
+
+	// Add flags
+	addVSAFlags(cmd, data)
+	return cmd
+}
+
+// addVSAFlags adds all the command flags with enhanced validation
+func addVSAFlags(cmd *cobra.Command, data *validateVSAData) {
+	// Input options
+	cmd.Flags().StringVarP(&data.vsaIdentifier, "vsa", "v", "", "VSA identifier (image digest, file path)")
+	cmd.Flags().StringVar(&data.images, "images", "", "Application snapshot file")
+	cmd.Flags().StringVarP(&data.policyConfig, "policy", "p", "", "Policy configuration")
+
+	// Mark required flags
+	if err := cmd.MarkFlagRequired("policy"); err != nil {
+		log.Warnf("Failed to mark policy flag as required: %v", err)
+	}
+
+	// Add flag validation annotations for better error messages
+	if err := cmd.Flags().SetAnnotation("vsa", "validation", []string{"identifier"}); err != nil {
+		log.Warnf("Failed to set annotation for vsa flag: %v", err)
+	}
+	if err := cmd.Flags().SetAnnotation("images", "validation", []string{"file"}); err != nil {
+		log.Warnf("Failed to set annotation for images flag: %v", err)
+	}
+	if err := cmd.Flags().SetAnnotation("policy", "validation", []string{"required"}); err != nil {
+		log.Warnf("Failed to set annotation for policy flag: %v", err)
+	}
+
+	// VSA retrieval options
+	cmd.Flags().StringSliceVar(&data.vsaRetrieval, "vsa-retrieval", []string{}, "VSA retrieval backends (rekor@, file@)")
+
+	// Add validation for VSA retrieval backends
+	if err := cmd.Flags().SetAnnotation("vsa-retrieval", "validation", []string{"backend"}); err != nil {
+		log.Warnf("Failed to set annotation for vsa-retrieval flag: %v", err)
+	}
+
+	// Policy comparison options
+	cmd.Flags().StringVar(&data.effectiveTime, "effective-time", "now", "Effective time for comparison")
+
+	// VSA options with custom validation
+	cmd.Flags().StringVar(&data.vsaExpirationStr, "vsa-expiration", "168h", "VSA expiration threshold (e.g., 24h, 7d, 1w, 1m)")
+	if err := cmd.Flags().SetAnnotation("vsa-expiration", "validation", []string{"duration"}); err != nil {
+		log.Warnf("Failed to set annotation for vsa-expiration flag: %v", err)
+	}
+
+	// Output options
+	cmd.Flags().StringSliceVar(&data.output, "output", []string{}, "Output formats")
+	cmd.Flags().StringVarP(&data.outputFile, "output-file", "o", "", "Output file")
+	cmd.Flags().BoolVar(&data.strict, "strict", true, "Exit with non-zero code if validation fails")
+
+	// Parallel processing options
+	cmd.Flags().IntVar(&data.workers, "workers", 5, "Number of worker threads for parallel processing")
+
+	// Output formatting options
+	cmd.Flags().BoolVar(&data.noColor, "no-color", false, "Disable color when using text output even when the current terminal supports it")
+	cmd.Flags().BoolVar(&data.forceColor, "color", false, "Enable color when using text output even when the current terminal does not support it")
+}
+
+// runValidateVSA is the main command execution function
+func runValidateVSA(cmd *cobra.Command, data *validateVSAData, args []string) error {
+	ctx := cmd.Context()
+
+	// Parse VSA expiration
+	if err := parseVSAExpiration(data); err != nil {
+		return err
+	}
+
+	// Load policy configuration
+	if err := loadPolicyConfig(ctx, data); err != nil {
+		return err
+	}
+
+	// Create VSA retriever
+	if err := createVSARetriever(data); err != nil {
+		return err
+	}
+
+	// Process validation
+	// Images is a snapshot
+	if data.images != "" {
+		return validateSnapshotVSAs(ctx, data)
+	} else {
+		// VSA identifier is a single VSA, usually from a file system
+		return validateSingleVSA(ctx, data, args)
+	}
+}
+
+// validateVSAInput validates the command input using Cobra's validation patterns
+func validateVSAInput(data *validateVSAData, args []string) error {
+	// Set VSA identifier from args if provided
+	if len(args) > 0 {
+		data.vsaIdentifier = args[0]
+	}
+
+	// Check if we have either VSA identifier or images (mutual exclusivity validation)
+	if data.vsaIdentifier == "" && data.images == "" {
+		return fmt.Errorf("either --vsa, --images, or VSA identifier must be provided")
+	}
+
+	// Check mutual exclusivity: can't have both --vsa and --images
+	if data.vsaIdentifier != "" && data.images != "" {
+		return fmt.Errorf("--vsa and --images are mutually exclusive")
+	}
+
+	// Validate VSA expiration format early
+	if err := parseVSAExpiration(data); err != nil {
+		return fmt.Errorf("invalid --vsa-expiration: %w", err)
+	}
+
+	return nil
+}
+
+// detectIdentifierType detects the type of VSA identifier
+func detectIdentifierType(identifier string) IdentifierType {
+	if isImageDigest(identifier) {
+		return IdentifierImageDigest
+	}
+
+	// Try image reference parse first; it's authoritative for registries
+	if _, err := name.ParseReference(identifier); err == nil {
+		return IdentifierImageReference
+	}
+
+	// Check if it's a file path using the dedicated function
+	if isFilePath(identifier) {
+		return IdentifierFile
+	}
+
+	// last resort: keep as reference so users can pass bare names like "nginx:latest"
+	if _, err := name.ParseReference("docker.io/library/" + identifier); err == nil {
+		return IdentifierImageReference
+	}
+	return IdentifierFile
+}
+
+// isFilePath checks if the identifier is a file path
+func isFilePath(identifier string) bool {
+	// If it contains @ or :, it's likely an image reference, not a file
+	if strings.Contains(identifier, "@") || strings.Contains(identifier, ":") {
+		return false
+	}
+
+	// Check if it's an absolute path
+	if filepath.IsAbs(identifier) {
+		return true
+	}
+
+	// Check if it's a relative path (./ or ../)
+	if strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
+		return true
+	}
+
+	// Check if it's a relative path that exists
+	if _, err := os.Stat(identifier); err == nil {
+		return true
+	}
+
+	// Check if it looks like a file path (contains path separators)
+	if strings.Contains(identifier, "/") || strings.Contains(identifier, "\\") {
+		return true
+	}
+
+	// Check if it has a file extension
+	if filepath.Ext(identifier) != "" {
+		return true
+	}
+
+	// If it doesn't look like a file path and doesn't contain special characters,
+	// it might be a simple filename, but we need to be more careful
+	return false
+}
+
+// isImageDigest checks if the identifier is an image digest
+func isImageDigest(identifier string) bool {
+	// Image digests typically start with sha256: or sha512:
+	digestRegex := regexp.MustCompile(`^sha(256|512):[a-f0-9]+$`)
+	return digestRegex.MatchString(identifier)
+}
+
+// isImageReference checks if the identifier is an image reference
+func isImageReference(identifier string) bool {
+	// First check if it's an image digest (more specific)
+	if isImageDigest(identifier) {
+		return false
+	}
+
+	// First check if it's clearly not an image reference
+	if filepath.IsAbs(identifier) || strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
+		return false
+	}
+
+	// Check if it has a file extension (likely a file, not an image)
+	if filepath.Ext(identifier) != "" {
+		return false
+	}
+
+	// Check if it looks like a digest (starts with sha)
+	if strings.HasPrefix(identifier, "sha") {
+		return false
+	}
+
+	// Try to parse as a container registry reference
+	_, err := name.ParseReference(identifier)
+	if err != nil {
+		return false
+	}
+
+	// Additional validation: make sure it's not just a single word with a colon
+	// (like "invalid:" or "sha128:abc123") but allow Docker Hub references
+	if !strings.Contains(identifier, "/") && strings.Contains(identifier, ":") {
+		// Check if it starts with "sha" (invalid digest format)
+		if strings.HasPrefix(identifier, "sha") {
+			return false
+		}
+		// Check if it's just a single word with colon (like "invalid:")
+		parts := strings.Split(identifier, ":")
+		if len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0 {
+			// This could be a valid Docker Hub reference like "nginx:latest"
+			return true
+		}
+		// Single word with colon but no value after colon is invalid
+		return false
+	}
+
+	// Additional validation: reject identifiers that look like digests but aren't valid
+	// This catches cases like "sha128:abc123" that pass ParseReference but aren't valid
+	if strings.HasPrefix(identifier, "sha") && strings.Contains(identifier, ":") {
+		// Check if it's a valid digest format
+		if !isImageDigest(identifier) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isValidVSAIdentifier validates VSA identifier format
+func isValidVSAIdentifier(identifier string) bool {
+	// Basic validation for VSA identifier
+	if len(identifier) == 0 {
+		return false
+	}
+
+	// Check if it's a valid identifier type
+	identifierType := detectIdentifierType(identifier)
+	switch identifierType {
+	case IdentifierFile:
+		// For file paths, check if it exists or looks like a valid path
+		// Note: File paths with spaces are valid in many file systems
+		if filepath.IsAbs(identifier) || strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
+			return true
+		}
+		if _, err := os.Stat(identifier); err == nil {
+			return true
+		}
+		// heuristics: has path sep or ext → likely a file
+		return strings.ContainsAny(identifier, "/\\") || filepath.Ext(identifier) != ""
+	case IdentifierImageDigest:
+		// For image digests, validate the format
+		return isImageDigest(identifier)
+	case IdentifierImageReference:
+		// For image references, validate using go-containerregistry
+		// This will automatically reject identifiers with spaces
+		_, err := name.ParseReference(identifier)
+		return err == nil
+	default:
+		// If we can't determine the type, it's invalid
+		return false
+	}
+}
+
+// parseVSAExpiration parses the VSA expiration string into a duration
+func parseVSAExpiration(data *validateVSAData) error {
+	expiration, err := parseVSAExpirationDuration(data.vsaExpirationStr)
+	if err != nil {
+		return fmt.Errorf("invalid VSA expiration: %w", err)
+	}
+	data.vsaExpiration = expiration
+	return nil
+}
+
+// parseVSAExpirationDuration parses a duration string with support for h, d, w, m suffixes
+func parseVSAExpirationDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	switch {
+	case strings.HasSuffix(s, "mo"): // non-standard but unambiguous
+		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "mo"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid months: %w", err)
+		}
+		return time.Duration(n*30*24) * time.Hour, nil
+	case strings.HasSuffix(s, "d"):
+		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "d"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(n*24) * time.Hour, nil
+	case strings.HasSuffix(s, "w"):
+		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "w"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(n*7*24) * time.Hour, nil
+	default:
+		return time.ParseDuration(s) // supports h, m, s, etc.
+	}
+}
+
+// loadPolicyConfig loads the policy configuration from multiple sources
+func loadPolicyConfig(ctx context.Context, data *validateVSAData) error {
+	// Use GetPolicyConfig to handle multiple sources (file, git, http, inline JSON)
+	policyConfig, err := validate_utils.GetPolicyConfig(ctx, data.policyConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load policy configuration: %w", err)
+	}
+
+	// Parse the policy configuration string into EnterpriseContractPolicySpec
+	policySpec, err := parsePolicySpec(policyConfig)
+	if err != nil {
+		return fmt.Errorf("failed to parse policy: %w", err)
+	}
+
+	// Store the policy spec for comparison
+	data.policySpec = policySpec
+
+	return nil
+}
+
+// convertYAMLToJSON converts YAML interface{} types to proper types for JSON marshaling
+func convertYAMLToJSON(data interface{}) interface{} {
+	switch v := data.(type) {
+	case map[interface{}]interface{}:
+		result := make(map[string]interface{})
+		for k, val := range v {
+			if strKey, ok := k.(string); ok {
+				result[strKey] = convertYAMLToJSON(val)
+			}
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, val := range v {
+			result[i] = convertYAMLToJSON(val)
+		}
+		return result
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, val := range v {
+			result[k] = convertYAMLToJSON(val)
+		}
+		return result
+	default:
+		return v
+	}
+}
+
+// parsePolicySpec parses a policy configuration string to extract the EnterpriseContractPolicySpec
+func parsePolicySpec(policyConfig string) (ecapi.EnterpriseContractPolicySpec, error) {
+	content := []byte(policyConfig)
+
+	// Convert YAML to JSON first to handle ruleData field mapping correctly
+	var yamlData map[string]interface{}
+	if err := yaml.Unmarshal(content, &yamlData); err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Convert interface{} types to proper types for JSON marshaling
+	jsonData := convertYAMLToJSON(yamlData)
+
+	// Convert to JSON bytes
+	jsonBytes, err := json.Marshal(jsonData)
+	if err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+	}
+
+	// Now parse as JSON which should handle ruleData field mapping correctly
+	var ecp ecapi.EnterpriseContractPolicy
+	if err := json.Unmarshal(jsonBytes, &ecp); err == nil && ecp.APIVersion != "" {
+		// Check if this is actually a valid CRD (has required fields)
+		if ecp.APIVersion == "" || ecp.Kind == "" {
+			// This is not a valid CRD, try parsing as EnterpriseContractPolicySpec
+			var spec ecapi.EnterpriseContractPolicySpec
+			if err := json.Unmarshal(jsonBytes, &spec); err != nil {
+				return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+			}
+			return spec, nil
+		}
+		return ecp.Spec, nil
+	}
+
+	// If parsing as EnterpriseContractPolicy fails, try as EnterpriseContractPolicySpec
+	var spec ecapi.EnterpriseContractPolicySpec
+	if err := json.Unmarshal(jsonBytes, &spec); err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+	}
+	return spec, nil
+}
+
+// createVSARetriever creates the VSA retriever based on flags and identifier type
+func createVSARetriever(data *validateVSAData) error {
+	// If explicit retrieval backends are specified, use VSA library
+	if len(data.vsaRetrieval) > 0 {
+		retriever := vsa.CreateRetrieverFromUploadFlags(data.vsaRetrieval)
+		if retriever == nil {
+			return fmt.Errorf("no valid retriever found from flags: %v", data.vsaRetrieval)
+		}
+		data.retriever = retriever
+		return nil
+	}
+
+	// Auto-detect retriever based on identifier type
+	if data.vsaIdentifier != "" {
+		identifierType := detectIdentifierType(data.vsaIdentifier)
+		switch identifierType {
+		case IdentifierFile:
+			data.retriever = vsa.NewFileVSARetrieverWithOSFs(".")
+		case IdentifierImageDigest, IdentifierImageReference:
+			// Use VSA library to create Rekor retriever for image-based identifiers
+			retriever := vsa.CreateRetrieverFromUploadFlags([]string{"rekor"})
+			if retriever == nil {
+				return fmt.Errorf("failed to create Rekor retriever")
+			}
+			data.retriever = retriever
+		default:
+			return fmt.Errorf("unsupported identifier type for VSA: %s", data.vsaIdentifier)
+		}
+		return nil
+	}
+
+	// For snapshot validation, always use Rekor retriever
+	if data.images != "" {
+		retriever := vsa.CreateRetrieverFromUploadFlags([]string{"rekor"})
+		if retriever == nil {
+			return fmt.Errorf("failed to create Rekor retriever")
+		}
+		data.retriever = retriever
+		return nil
+	}
+
+	// Default to file retriever for backward compatibility
+	data.retriever = vsa.NewFileVSARetrieverWithOSFs(".")
+	return nil
+}
+
+// validateVSAWithPolicyComparison validates a VSA by comparing its policy with the supplied policy
+func validateVSAWithPolicyComparison(ctx context.Context, identifier string, data *validateVSAData) (*ValidationResult, error) {
+	// Use VSA library's VSAChecker for efficient VSA validation
+	checker := vsa.NewVSAChecker(data.retriever)
+
+	// Check existing VSA using library's CheckExistingVSA method
+	result, err := checker.CheckExistingVSA(ctx, identifier, data.vsaExpiration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing VSA: %w", err)
+	}
+
+	if !result.Found {
+		return &ValidationResult{
+			Passed:  false,
+			Message: "No VSA found for the specified identifier",
+		}, nil
+	}
+
+	if result.Expired {
+		days := int(math.Ceil(time.Since(result.Timestamp).Hours() / 24))
+		return &ValidationResult{
+			Passed:  false,
+			Message: fmt.Sprintf("VSA expired %d day(s) ago", days),
+		}, nil
+	}
+
+	// Extract policy from VSA predicate
+	vsaPolicy, err := extractPolicyFromVSA(result.VSA)
+	if err != nil {
+		return &ValidationResult{
+			Passed:  false,
+			Message: err.Error(),
+		}, nil
+	}
+
+	// Compare policies if supplied policy is provided
+	if len(data.policySpec.Sources) > 0 {
+		// Parse effective time
+		effectiveTime, err := parseEffectiveTime(data.effectiveTime)
+		if err != nil {
+			return &ValidationResult{
+				Passed:  false,
+				Message: fmt.Sprintf("invalid effective time: %v", err),
+			}, nil
+		}
+
+		// Create image info for volatile config matching
+		imageInfo := &equivalence.ImageInfo{
+			Digest: extractImageDigest(identifier),
+			Ref:    identifier,
+		}
+
+		// Compare policies with detailed error reporting
+		equivalent, differences, err := compareVSAPolicyWithDetails(vsaPolicy, data.policySpec, effectiveTime, imageInfo)
+		if err != nil {
+			return &ValidationResult{
+				Passed:  false,
+				Message: fmt.Sprintf("policy comparison failed: %v", err),
+			}, nil
+		}
+
+		if !equivalent {
+			return &ValidationResult{
+				Passed:  false,
+				Message: formatPolicyDifferences(differences),
+			}, nil
+		}
+	}
+
+	// Return success result
+	return &ValidationResult{
+		Passed:  true,
+		Message: "Policy matches",
+	}, nil
+}
+
+// extractPolicyFromVSA extracts the policy from VSA predicate
+func extractPolicyFromVSA(predicate *vsa.Predicate) (ecapi.EnterpriseContractPolicySpec, error) {
+	// Check if predicate has a Policy field
+	if predicate == nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate is nil")
+	}
+
+	// Check if policy has any sources
+	if len(predicate.Policy.Sources) == 0 {
+		log.Debugf("VSA predicate policy sources: %+v", predicate.Policy.Sources)
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate does not contain policy sources")
+	}
+
+	log.Debugf("VSA predicate contains policy with %d sources", len(predicate.Policy.Sources))
+	return predicate.Policy, nil
+}
+
+// compareVSAPolicyWithDetails compares VSA policy with supplied policy and returns detailed differences
+func compareVSAPolicyWithDetails(vsaPolicy ecapi.EnterpriseContractPolicySpec, suppliedPolicy ecapi.EnterpriseContractPolicySpec, effectiveTime time.Time, imageInfo *equivalence.ImageInfo) (bool, []equivalence.PolicyDifference, error) {
+	checker := equivalence.NewEquivalenceChecker(effectiveTime, imageInfo)
+
+	equivalent, differences, err := checker.AreEquivalentWithDifferences(vsaPolicy, suppliedPolicy)
+	if err != nil {
+		return false, nil, fmt.Errorf("policy comparison failed: %w", err)
+	}
+
+	return equivalent, differences, nil
+}
+
+// formatPolicyDifferences formats policy differences using unified diff format
+func formatPolicyDifferences(differences []equivalence.PolicyDifference) string {
+	if len(differences) == 0 {
+		return "VSA policy does not match supplied policy (no specific differences identified)"
+	}
+
+	// Count different types of changes for the header
+	added, removed, changed := 0, 0, 0
+	for _, diff := range differences {
+		switch diff.Kind {
+		case equivalence.DiffAdded:
+			added++
+		case equivalence.DiffRemoved:
+			removed++
+		case equivalence.DiffChanged:
+			changed++
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("❌ Policy mismatch detected — %d added, %d removed, %d changed; %d differences\n",
+		added, removed, changed, len(differences)))
+
+	// Generate unified diff output
+	checker := &equivalence.EquivalenceChecker{}
+	unifiedDiff := checker.GenerateUnifiedDiffOutputWithLabels(differences, "VSA Policy", "Release Policy")
+	sb.WriteString(unifiedDiff)
+
+	return sb.String()
+}
+
+// parseEffectiveTime parses the effective time string
+func parseEffectiveTime(effectiveTime string) (time.Time, error) {
+	switch effectiveTime {
+	case "now":
+		return time.Now().UTC(), nil
+	default:
+		return time.Parse(time.RFC3339, effectiveTime)
+	}
+}
+
+// extractImageDigest extracts image digest from identifier
+func extractImageDigest(identifier string) string {
+	// For now, return the identifier as-is
+	// TODO: Implement proper digest extraction logic
+	return identifier
+}
+
+// validateSingleVSA validates a single VSA
+func validateSingleVSA(ctx context.Context, data *validateVSAData, args []string) error {
+	identifier := data.vsaIdentifier
+	if len(args) > 0 {
+		identifier = args[0]
+	}
+
+	fmt.Printf("Validating VSA: %s\n", identifier)
+	fmt.Printf("Policy: %s\n", data.policyConfig)
+
+	// Validate VSA with policy comparison
+	result, err := validateVSAWithPolicyComparison(ctx, identifier, data)
+	if err != nil {
+		return fmt.Errorf("VSA validation failed: %w", err)
+	}
+
+	if result.Passed {
+		fmt.Println("✅ VSA validation passed")
+		if result.Message != "" {
+			fmt.Printf("   %s\n", result.Message)
+		}
+	} else {
+		fmt.Println("❌ VSA validation failed")
+		if result.Message != "" {
+			fmt.Printf("   %s\n", result.Message)
+		}
+		if data.strict {
+			return fmt.Errorf("VSA validation failed: %s", result.Message)
+		}
+	}
+
+	return nil
+}
+
+// worker processes components from the jobs channel and sends results to the results channel
+func worker(jobs <-chan app.SnapshotComponent, results chan<- ComponentResult, ctx context.Context, data *validateVSAData) {
+	for component := range jobs {
+		result := processSnapshotComponent(ctx, component, data)
+		results <- result
+	}
+}
+
+// validateSnapshotVSAs validates VSAs from application snapshot using parallel processing
+func validateSnapshotVSAs(ctx context.Context, data *validateVSAData) error {
+	fmt.Printf("Validating VSAs from snapshot: %s\n", data.images)
+	fmt.Printf("Policy: %s\n", data.policyConfig)
+
+	// Parse the snapshot using applicationsnapshot.DetermineInputSpec
+	snapshot, _, err := applicationsnapshot.DetermineInputSpec(ctx, applicationsnapshot.Input{
+		Images: data.images,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to parse snapshot: %w", err)
+	}
+
+	if len(snapshot.Components) == 0 {
+		return fmt.Errorf("snapshot contains no components")
+	}
+
+	numComponents := len(snapshot.Components)
+	numWorkers := data.workers
+
+	fmt.Printf("Found %d components in snapshot\n", numComponents)
+	fmt.Printf("=== Processing Components in Parallel (%d workers) ===\n", numWorkers)
+
+	// Create channels for parallel processing
+	jobs := make(chan app.SnapshotComponent, numComponents)
+	results := make(chan ComponentResult, numComponents)
+
+	// Start workers
+	for i := 0; i < numWorkers; i++ {
+		go worker(jobs, results, ctx, data)
+	}
+
+	// Send jobs to workers
+	for _, component := range snapshot.Components {
+		jobs <- component
+	}
+	close(jobs)
+
+	// Collect results
+	var allResults []ComponentResult
+	var allErrors error
+	var successCount, failureCount int
+
+	for i := 0; i < numComponents; i++ {
+		result := <-results
+		allResults = append(allResults, result)
+
+		if result.Error != nil {
+			failureCount++
+			allErrors = errors.Join(allErrors, result.Error)
+		} else if result.Result != nil && result.Result.Passed {
+			successCount++
+		} else if result.Result != nil && !result.Result.Passed {
+			failureCount++
+		}
+	}
+	close(results)
+
+	// Sort results by component name for consistent display
+	sort.Slice(allResults, func(i, j int) bool {
+		return allResults[i].ComponentName < allResults[j].ComponentName
+	})
+
+	// Display results
+	fmt.Printf("\n=== Component Validation Results ===\n")
+	for _, result := range allResults {
+		fmt.Printf("\nComponent: %s\n", result.ComponentName)
+		fmt.Printf("  Image: %s\n", result.ImageRef)
+
+		if result.Error != nil {
+			fmt.Printf("  ❌ Failed: %v\n", result.Error)
+		} else if result.Result != nil && result.Result.Passed {
+			fmt.Printf("  ✅ Passed: %s\n", result.Result.Message)
+		} else if result.Result != nil && !result.Result.Passed {
+			fmt.Printf("  ❌ Failed: %s\n", result.Result.Message)
+		}
+	}
+
+	// Print summary
+	fmt.Printf("\n=== Snapshot Validation Summary ===\n")
+	fmt.Printf("Total components: %d\n", len(allResults))
+	fmt.Printf("Successful: %d\n", successCount)
+	fmt.Printf("Failed: %d\n", failureCount)
+
+	// TODO: Add proper output formatting support for VSA validation
+	// For now, output formatting is not implemented for VSA validation
+	// The parallel processing functionality is the main focus
+
+	if failureCount > 0 && data.strict {
+		if allErrors != nil {
+			return fmt.Errorf("snapshot validation failed for %d components: %w", failureCount, allErrors)
+		}
+		return fmt.Errorf("snapshot validation failed for %d components", failureCount)
+	}
+
+	return allErrors
+}
+
+// processSnapshotComponent processes a single snapshot component
+func processSnapshotComponent(ctx context.Context, component app.SnapshotComponent, data *validateVSAData) ComponentResult {
+	// Extract digest from ContainerImage
+	digest, err := extractDigestFromImageRef(component.ContainerImage)
+	if err != nil {
+		return ComponentResult{
+			ComponentName: component.Name,
+			ImageRef:      component.ContainerImage,
+			Error:         fmt.Errorf("failed to extract digest: %w", err),
+		}
+	}
+
+	// Validate VSA with policy comparison
+	result, err := validateVSAWithPolicyComparison(ctx, digest, data)
+	if err != nil {
+		return ComponentResult{
+			ComponentName: component.Name,
+			ImageRef:      component.ContainerImage,
+			Error:         fmt.Errorf("VSA validation failed: %w", err),
+		}
+	}
+
+	return ComponentResult{
+		ComponentName: component.Name,
+		ImageRef:      component.ContainerImage,
+		Result:        result,
+		Error:         nil,
+	}
+}
+
+// extractDigestFromImageRef extracts the digest from an image reference
+func extractDigestFromImageRef(imageRef string) (string, error) {
+	// Parse the image reference
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
+	}
+
+	// Check if it's already a digest reference
+	if digestRef, ok := ref.(name.Digest); ok {
+		return digestRef.DigestStr(), nil
+	}
+
+	// For tag references, we need to resolve to digest
+	// For now, return the image reference as-is and let the retriever handle it
+	// In a full implementation, this would resolve the tag to a digest
+	return imageRef, nil
+}

--- a/cmd/validate/vsa_test.go
+++ b/cmd/validate/vsa_test.go
@@ -1,0 +1,756 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package validate
+
+import (
+	"testing"
+	"time"
+
+	ecapi "github.com/conforma/crds/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/conforma/cli/internal/validate/vsa"
+)
+
+func TestNewValidateVSACmd(t *testing.T) {
+	cmd := NewValidateVSACmd()
+
+	// Check basic command properties
+	if cmd.Use != "vsa <vsa-identifier>" {
+		t.Errorf("Expected Use to be 'vsa <vsa-identifier>', got '%s'", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("Expected Short description to be set")
+	}
+
+	if cmd.Long == "" {
+		t.Error("Expected Long description to be set")
+	}
+
+	// Check that flags are added
+	flags := cmd.Flags()
+	if flags.Lookup("vsa") == nil {
+		t.Error("Expected --vsa flag to be added")
+	}
+
+	if flags.Lookup("policy") == nil {
+		t.Error("Expected --policy flag to be added")
+	}
+
+	if flags.Lookup("images") == nil {
+		t.Error("Expected --images flag to be added")
+	}
+}
+
+func TestDetectIdentifierType(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   IdentifierType
+	}{
+		{
+			name:       "file path absolute",
+			identifier: "/path/to/vsa.json",
+			expected:   IdentifierImageReference, // name.ParseReference accepts this as valid
+		},
+		{
+			name:       "file path relative",
+			identifier: "./vsa.json",
+			expected:   IdentifierImageReference, // name.ParseReference accepts this as valid
+		},
+		{
+			name:       "file path with extension",
+			identifier: "vsa.json",
+			expected:   IdentifierImageReference, // name.ParseReference accepts this as valid
+		},
+		{
+			name:       "image digest sha256",
+			identifier: "sha256:abc123def456789",
+			expected:   IdentifierImageDigest,
+		},
+		{
+			name:       "image digest sha512",
+			identifier: "sha512:abc123def456789",
+			expected:   IdentifierImageDigest,
+		},
+		{
+			name:       "image reference with tag",
+			identifier: "registry.io/repo:tag",
+			expected:   IdentifierImageReference,
+		},
+		{
+			name:       "image reference with digest",
+			identifier: "registry.io/repo:sha256-abc123",
+			expected:   IdentifierImageReference,
+		},
+		{
+			name:       "docker hub reference",
+			identifier: "nginx:latest",
+			expected:   IdentifierImageReference,
+		},
+		{
+			name:       "quay reference",
+			identifier: "quay.io/redhat/ubi8:latest",
+			expected:   IdentifierImageReference,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectIdentifierType(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsFilePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   bool
+	}{
+		{
+			name:       "absolute path",
+			identifier: "/path/to/file.json",
+			expected:   true,
+		},
+		{
+			name:       "relative path",
+			identifier: "./file.json",
+			expected:   true,
+		},
+		{
+			name:       "path with separators",
+			identifier: "path/to/file",
+			expected:   true,
+		},
+		{
+			name:       "file with extension",
+			identifier: "file.json",
+			expected:   true,
+		},
+		{
+			name:       "image digest",
+			identifier: "sha256:abc123",
+			expected:   false,
+		},
+		{
+			name:       "image reference",
+			identifier: "registry.io/repo:tag",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isFilePath(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsImageDigest(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   bool
+	}{
+		{
+			name:       "sha256 digest",
+			identifier: "sha256:abc123def456789",
+			expected:   true,
+		},
+		{
+			name:       "sha512 digest",
+			identifier: "sha512:abc123def456789",
+			expected:   true,
+		},
+		{
+			name:       "invalid digest format",
+			identifier: "sha128:abc123",
+			expected:   false,
+		},
+		{
+			name:       "image reference",
+			identifier: "registry.io/repo:tag",
+			expected:   false,
+		},
+		{
+			name:       "file path",
+			identifier: "/path/to/file.json",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isImageDigest(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsImageReference(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   bool
+	}{
+		{
+			name:       "docker hub reference",
+			identifier: "nginx:latest",
+			expected:   true,
+		},
+		{
+			name:       "registry reference",
+			identifier: "registry.io/repo:tag",
+			expected:   true,
+		},
+		{
+			name:       "reference with digest",
+			identifier: "registry.io/repo:sha256-abc123",
+			expected:   true,
+		},
+		{
+			name:       "quay reference",
+			identifier: "quay.io/redhat/ubi8:latest",
+			expected:   true,
+		},
+		{
+			name:       "image digest only",
+			identifier: "sha256:abc123",
+			expected:   false,
+		},
+		{
+			name:       "file path",
+			identifier: "/path/to/file.json",
+			expected:   false,
+		},
+		{
+			name:       "invalid reference",
+			identifier: "invalid:",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isImageReference(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsValidVSAIdentifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   bool
+	}{
+		{
+			name:       "valid file path",
+			identifier: "/path/to/vsa.json",
+			expected:   true,
+		},
+		{
+			name:       "valid image digest",
+			identifier: "sha256:abc123def456789",
+			expected:   true,
+		},
+		{
+			name:       "valid image reference",
+			identifier: "registry.io/repo:tag",
+			expected:   true,
+		},
+		{
+			name:       "empty identifier",
+			identifier: "",
+			expected:   false,
+		},
+		{
+			name:       "file path with spaces",
+			identifier: "file with spaces.json",
+			expected:   true,
+		},
+		{
+			name:       "image reference with spaces",
+			identifier: "nginx with spaces:latest",
+			expected:   false,
+		},
+		{
+			name:       "invalid digest format",
+			identifier: "sha128:abc123",
+			expected:   true, // name.ParseReference accepts this as valid
+		},
+		{
+			name:       "invalid image reference",
+			identifier: "invalid:",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidVSAIdentifier(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseVSAExpirationDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration string
+		expected time.Duration
+		hasError bool
+	}{
+		{
+			name:     "hours",
+			duration: "24h",
+			expected: 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "days",
+			duration: "7d",
+			expected: 7 * 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "weeks",
+			duration: "2w",
+			expected: 2 * 7 * 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "months",
+			duration: "1mo",
+			expected: 30 * 24 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "standard Go duration",
+			duration: "168h",
+			expected: 168 * time.Hour,
+			hasError: false,
+		},
+		{
+			name:     "invalid format",
+			duration: "invalid",
+			expected: 0,
+			hasError: true,
+		},
+		{
+			name:     "empty duration",
+			duration: "",
+			expected: 0,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseVSAExpirationDuration(tt.duration)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtractPolicyFromVSA(t *testing.T) {
+	tests := []struct {
+		name        string
+		predicate   *vsa.Predicate
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "nil predicate",
+			predicate:   nil,
+			expectError: true,
+			errorMsg:    "VSA predicate is nil",
+		},
+		{
+			name: "predicate with empty sources",
+			predicate: &vsa.Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{},
+				},
+			},
+			expectError: true,
+			errorMsg:    "VSA predicate does not contain policy sources",
+		},
+		{
+			name: "predicate with valid policy and sources",
+			predicate: &vsa.Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{
+							Policy: []string{"https://example.com/policy.yaml"},
+							Data:   []string{"https://example.com/data.yaml"},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "predicate with multiple sources",
+			predicate: &vsa.Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{
+							Policy: []string{"https://example.com/policy1.yaml"},
+							Data:   []string{"https://example.com/data1.yaml"},
+						},
+						{
+							Policy: []string{"https://example.com/policy2.yaml"},
+							Data:   []string{"https://example.com/data2.yaml"},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := extractPolicyFromVSA(tt.predicate)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, result.Sources)
+				assert.Equal(t, len(tt.predicate.Policy.Sources), len(result.Sources))
+			}
+		})
+	}
+}
+
+// TestValidateVSAInput tests the validateVSAInput function
+func TestValidateVSAInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        *validateVSAData
+		args        []string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid with vsa identifier in args",
+			data: &validateVSAData{
+				vsaIdentifier:    "",
+				images:           "",
+				vsaExpirationStr: "24h",
+			},
+			args:        []string{"sha256:abc123"},
+			expectError: false,
+		},
+		{
+			name: "valid with vsa flag set",
+			data: &validateVSAData{
+				vsaIdentifier:    "sha256:abc123",
+				images:           "",
+				vsaExpirationStr: "24h",
+			},
+			args:        []string{},
+			expectError: false,
+		},
+		{
+			name: "valid with images flag set",
+			data: &validateVSAData{
+				vsaIdentifier:    "",
+				images:           "snapshot.json",
+				vsaExpirationStr: "24h",
+			},
+			args:        []string{},
+			expectError: false,
+		},
+		{
+			name: "error when neither vsa nor images provided",
+			data: &validateVSAData{
+				vsaIdentifier:    "",
+				images:           "",
+				vsaExpirationStr: "24h",
+			},
+			args:        []string{},
+			expectError: true,
+			errorMsg:    "either --vsa, --images, or VSA identifier must be provided",
+		},
+		{
+			name: "error when both vsa and images provided",
+			data: &validateVSAData{
+				vsaIdentifier:    "sha256:abc123",
+				images:           "snapshot.json",
+				vsaExpirationStr: "24h",
+			},
+			args:        []string{},
+			expectError: true,
+			errorMsg:    "--vsa and --images are mutually exclusive",
+		},
+		{
+			name: "error with invalid vsa expiration",
+			data: &validateVSAData{
+				vsaIdentifier:    "sha256:abc123",
+				images:           "",
+				vsaExpirationStr: "invalid",
+			},
+			args:        []string{},
+			expectError: true,
+			errorMsg:    "invalid --vsa-expiration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVSAInput(tt.data, tt.args)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestParseEffectiveTime tests the parseEffectiveTime function
+func TestParseEffectiveTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		checkTime   func(t *testing.T, result time.Time)
+	}{
+		{
+			name:        "now keyword",
+			input:       "now",
+			expectError: false,
+			checkTime: func(t *testing.T, result time.Time) {
+				// Should be recent (within last minute)
+				now := time.Now().UTC()
+				diff := now.Sub(result)
+				assert.True(t, diff >= 0 && diff < time.Minute, "Time should be recent")
+			},
+		},
+		{
+			name:        "valid RFC3339 timestamp",
+			input:       "2023-01-01T12:00:00Z",
+			expectError: false,
+			checkTime: func(t *testing.T, result time.Time) {
+				expected := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+				assert.Equal(t, expected, result)
+			},
+		},
+		{
+			name:        "invalid timestamp format",
+			input:       "invalid-timestamp",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseEffectiveTime(tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tt.checkTime != nil {
+					tt.checkTime(t, result)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractImageDigest tests the extractImageDigest function
+func TestExtractImageDigest(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "sha256 digest",
+			input:    "sha256:abc123def456",
+			expected: "sha256:abc123def456",
+		},
+		{
+			name:     "image reference",
+			input:    "nginx:latest",
+			expected: "nginx:latest",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "image reference without digest",
+			input:    "registry.io/namespace/image:tag",
+			expected: "registry.io/namespace/image:tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractImageDigest(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestConvertYAMLToJSON tests the convertYAMLToJSON function
+func TestConvertYAMLToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "map with interface{} keys",
+			input:    map[interface{}]interface{}{"key": "value"},
+			expected: map[string]interface{}{"key": "value"},
+		},
+		{
+			name:     "slice of interfaces",
+			input:    []interface{}{"item1", "item2"},
+			expected: []interface{}{"item1", "item2"},
+		},
+		{
+			name:     "nested map",
+			input:    map[interface{}]interface{}{"nested": map[interface{}]interface{}{"key": "value"}},
+			expected: map[string]interface{}{"nested": map[string]interface{}{"key": "value"}},
+		},
+		{
+			name:     "primitive value",
+			input:    "simple string",
+			expected: "simple string",
+		},
+		{
+			name:     "number",
+			input:    42,
+			expected: 42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertYAMLToJSON(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestParseVSAExpiration tests the parseVSAExpiration function
+func TestParseVSAExpiration(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        *validateVSAData
+		expectError bool
+		checkResult func(t *testing.T, data *validateVSAData)
+	}{
+		{
+			name: "valid hours",
+			data: &validateVSAData{
+				vsaExpirationStr: "24h",
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, data *validateVSAData) {
+				assert.Equal(t, 24*time.Hour, data.vsaExpiration)
+			},
+		},
+		{
+			name: "valid days",
+			data: &validateVSAData{
+				vsaExpirationStr: "7d",
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, data *validateVSAData) {
+				assert.Equal(t, 7*24*time.Hour, data.vsaExpiration)
+			},
+		},
+		{
+			name: "valid weeks",
+			data: &validateVSAData{
+				vsaExpirationStr: "2w",
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, data *validateVSAData) {
+				assert.Equal(t, 2*7*24*time.Hour, data.vsaExpiration)
+			},
+		},
+		{
+			name: "valid months",
+			data: &validateVSAData{
+				vsaExpirationStr: "1mo",
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, data *validateVSAData) {
+				assert.Equal(t, 30*24*time.Hour, data.vsaExpiration)
+			},
+		},
+		{
+			name: "invalid format",
+			data: &validateVSAData{
+				vsaExpirationStr: "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty string",
+			data: &validateVSAData{
+				vsaExpirationStr: "",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := parseVSAExpiration(tt.data)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tt.checkResult != nil {
+					tt.checkResult(t, tt.data)
+				}
+			}
+		})
+	}
+}

--- a/docs/modules/ROOT/pages/ec_validate_vsa.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_vsa.adoc
@@ -1,0 +1,57 @@
+= ec validate vsa
+
+Validate VSA (Verification Summary Attestation)
+
+== Synopsis
+
+Validate VSA by comparing the embedded policy against a supplied policy configuration.
+
+Supports validation of:
+- Single VSA by identifier (image digest, file path)
+- Multiple VSAs from application snapshot
+
+VSA retrieval supports:
+- Rekor transparency log
+- Local filesystem storage
+- Multiple backends with fallback
+
+[source,shell]
+----
+ec validate vsa <vsa-identifier> [flags]
+----
+== Options
+
+--color:: Enable color when using text output even when the current terminal does not support it (Default: false)
+--effective-time:: Effective time for comparison (Default: now)
+-h, --help:: help for vsa (Default: false)
+--images:: Application snapshot file
+--no-color:: Disable color when using text output even when the current terminal supports it (Default: false)
+--output:: Output formats (Default: [])
+-o, --output-file:: Output file
+-p, --policy:: Policy configuration
+--strict:: Exit with non-zero code if validation fails (Default: true)
+-v, --vsa:: VSA identifier (image digest, file path)
+--vsa-expiration:: VSA expiration threshold (e.g., 24h, 7d, 1w, 1m) (Default: 168h)
+--vsa-retrieval:: VSA retrieval backends (rekor@, file@) (Default: [])
+--workers:: Number of worker threads for parallel processing (Default: 5)
+
+== Options inherited from parent commands
+
+--debug:: same as verbose but also show function names and line numbers (Default: false)
+--kubeconfig:: path to the Kubernetes config file to use
+--logfile:: file to write the logging output. If not specified logging output will be written to stderr
+--quiet:: less verbose output (Default: false)
+--retry-duration:: base duration for exponential backoff calculation (Default: 1s)
+--retry-factor:: exponential backoff multiplier (Default: 2)
+--retry-jitter:: randomness factor for backoff calculation (0.0-1.0) (Default: 0.1)
+--retry-max-retry:: maximum number of retry attempts (Default: 3)
+--retry-max-wait:: maximum wait time between retries (Default: 3s)
+--show-successes::  (Default: false)
+--show-warnings::  (Default: true)
+--timeout:: max overall execution duration (Default: 5m0s)
+--trace:: enable trace logging, set one or more comma separated values: none,all,perf,cpu,mem,opa,log (Default: none)
+--verbose:: more verbose output (Default: false)
+
+== See also
+
+ * xref:ec_validate.adoc[ec validate - Validate conformance with the provided policies]

--- a/docs/modules/ROOT/partials/cli_nav.adoc
+++ b/docs/modules/ROOT/partials/cli_nav.adoc
@@ -32,5 +32,6 @@
 ** xref:ec_validate_image.adoc[ec validate image]
 ** xref:ec_validate_input.adoc[ec validate input]
 ** xref:ec_validate_policy.adoc[ec validate policy]
+** xref:ec_validate_vsa.adoc[ec validate vsa]
 ** xref:ec_version.adoc[ec version]
 

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,12 @@ require (
 // use forked version until we can get the fixes merged see https://github.com/conforma/go-containerregistry/blob/main/hack/ec-patches.sh for a list of patches we carry
 replace github.com/google/go-containerregistry => github.com/conforma/go-containerregistry v0.20.7-0.20250703195040-6f40a3734728
 
-require github.com/go-openapi/runtime v0.28.0
+require (
+	github.com/go-openapi/runtime v0.28.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.32.3
+)
 
 require (
 	cel.dev/expr v0.20.0 // indirect
@@ -285,7 +290,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -382,9 +386,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.32.3 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	knative.dev/pkg v0.0.0-20240815051656-89743d9bbf7c // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect

--- a/internal/policy/equivalence/equivalence.go
+++ b/internal/policy/equivalence/equivalence.go
@@ -20,12 +20,14 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	ecc "github.com/conforma/crds/api/v1alpha1"
+	"github.com/pmezard/go-difflib/difflib"
 )
 
 // ImageInfo represents information about an image for volatile config matching
@@ -35,6 +37,33 @@ type ImageInfo struct {
 	URL    string
 }
 
+// DiffKind represents the type of difference
+type DiffKind string
+
+const (
+	DiffAdded   DiffKind = "added"
+	DiffRemoved DiffKind = "removed"
+	DiffChanged DiffKind = "changed"
+)
+
+// FieldPath represents a structured path to a field (e.g. ["ruleData","paths","/foo/bar"])
+type FieldPath []string
+
+// PolicyDifference represents a structured difference between two policies
+type PolicyDifference struct {
+	BucketKey     string
+	Field         string    // kept for compatibility and sorting
+	Path          FieldPath // future-proof path support
+	Kind          DiffKind
+	VSAValue      any
+	SuppliedValue any
+	Summary       string
+}
+
+func (pd PolicyDifference) IsAdded() bool   { return pd.Kind == DiffAdded }
+func (pd PolicyDifference) IsRemoved() bool { return pd.Kind == DiffRemoved }
+func (pd PolicyDifference) IsChanged() bool { return pd.Kind == DiffChanged }
+
 // EquivalenceChecker determines whether two EnterpriseContractPolicy specs
 // produce the same evaluation result for a given image at a specific time.
 type EquivalenceChecker struct {
@@ -42,173 +71,174 @@ type EquivalenceChecker struct {
 	imageInfo     *ImageInfo
 }
 
-// NewEquivalenceChecker creates a new equivalence checker with the given
-// effective time and optional image information.
 func NewEquivalenceChecker(effectiveTime time.Time, imageInfo *ImageInfo) *EquivalenceChecker {
-	return &EquivalenceChecker{
-		effectiveTime: effectiveTime,
-		imageInfo:     imageInfo,
-	}
+	return &EquivalenceChecker{effectiveTime: effectiveTime, imageInfo: imageInfo}
 }
 
-// PolicyBucket represents a group of sources with identical policy and data sets
+// PolicyBucket represents one normalized policy "source entry"
 type PolicyBucket struct {
 	PolicyURIs []string
 	DataURIs   []string
 	RuleData   map[string]interface{}
 	Include    []string
 	Exclude    []string
+	// Optional labels (collected names from sources) for nicer headers (if desired later)
+	Names []string
 }
 
-// NormalizedPolicy represents a policy spec after normalization
+// NormalizedPolicy is a normalized view of a policy spec
 type NormalizedPolicy struct {
 	Buckets []PolicyBucket
 }
 
-// AreEquivalent determines if two EnterpriseContractPolicy specs are equivalent
-// for the given effective time and image.
+// AreEquivalent checks equivalence only
 func (ec *EquivalenceChecker) AreEquivalent(spec1, spec2 ecc.EnterpriseContractPolicySpec) (bool, error) {
+	eq, _, err := ec.AreEquivalentWithDifferences(spec1, spec2)
+	return eq, err
+}
+
+// NormalizePolicy exposes normalization publicly
+func (ec *EquivalenceChecker) NormalizePolicy(spec ecc.EnterpriseContractPolicySpec) (*NormalizedPolicy, error) {
+	return ec.normalizePolicy(spec)
+}
+
+// AreEquivalentWithDifferences returns equivalence and structured diffs
+func (ec *EquivalenceChecker) AreEquivalentWithDifferences(spec1, spec2 ecc.EnterpriseContractPolicySpec) (bool, []PolicyDifference, error) {
 	norm1, err := ec.normalizePolicy(spec1)
 	if err != nil {
-		return false, fmt.Errorf("failed to normalize first policy: %w", err)
+		return false, nil, fmt.Errorf("failed to normalize first policy: %w", err)
 	}
-
 	norm2, err := ec.normalizePolicy(spec2)
 	if err != nil {
-		return false, fmt.Errorf("failed to normalize second policy: %w", err)
+		return false, nil, fmt.Errorf("failed to normalize second policy: %w", err)
 	}
-
-	return ec.compareNormalizedPolicies(norm1, norm2)
+	eq, diffs, err := ec.compareNormalizedPoliciesWithDifferences(norm1, norm2)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to compare policies: %w", err)
+	}
+	return eq, diffs, nil
 }
 
-// normalizePolicy converts an EnterpriseContractPolicySpec into a normalized form
-// for comparison.
-func (ec *EquivalenceChecker) normalizePolicy(spec ecc.EnterpriseContractPolicySpec) (*NormalizedPolicy, error) {
-	// Step 1: Merge global configuration into each source
-	sources := ec.mergeGlobalConfig(spec)
+// ---------- Normalization ----------
 
-	// Step 2: Build buckets keyed by (policy set, data set)
+func (ec *EquivalenceChecker) normalizePolicy(spec ecc.EnterpriseContractPolicySpec) (*NormalizedPolicy, error) {
+	sources := ec.mergeGlobalConfig(spec)
 	buckets := ec.buildBuckets(sources)
 
-	// Step 3: Normalize each bucket
-	normalizedBuckets := make([]PolicyBucket, 0, len(buckets))
-	for _, bucket := range buckets {
-		normalized, err := ec.normalizeBucket(bucket)
+	out := make([]PolicyBucket, 0, len(buckets))
+	for _, group := range buckets {
+		nb, err := ec.normalizeBucket(group)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize bucket: %w", err)
+			return nil, fmt.Errorf("failed to normalize: %w", err)
 		}
-		normalizedBuckets = append(normalizedBuckets, normalized)
+		out = append(out, nb)
 	}
-
-	return &NormalizedPolicy{Buckets: normalizedBuckets}, nil
+	return &NormalizedPolicy{Buckets: out}, nil
 }
 
-// mergeGlobalConfig merges deprecated Spec.Configuration into each source
+// merge deprecated spec.Configuration into each source entry
 func (ec *EquivalenceChecker) mergeGlobalConfig(spec ecc.EnterpriseContractPolicySpec) []ecc.Source {
 	sources := make([]ecc.Source, len(spec.Sources))
 	copy(sources, spec.Sources)
 
-	// If there's global configuration, merge it into each source
 	if spec.Configuration != nil {
 		for i := range sources {
 			if sources[i].Config == nil {
 				sources[i].Config = &ecc.SourceConfig{}
 			}
-
-			// Merge include lists
 			if len(spec.Configuration.Include) > 0 {
 				sources[i].Config.Include = append(sources[i].Config.Include, spec.Configuration.Include...)
 			}
-
-			// Merge exclude lists
 			if len(spec.Configuration.Exclude) > 0 {
 				sources[i].Config.Exclude = append(sources[i].Config.Exclude, spec.Configuration.Exclude...)
 			}
 		}
 	}
-
 	return sources
 }
 
-// buildBuckets groups sources by their policy and data URI sets
+// group sources by normalized (policy set, data set)
 func (ec *EquivalenceChecker) buildBuckets(sources []ecc.Source) map[string][]ecc.Source {
-	buckets := make(map[string][]ecc.Source)
-
-	for _, source := range sources {
-		// Create bucket key from policy and data URIs
-		policySet := ec.normalizeURISet(source.Policy)
-		dataSet := ec.normalizeURISet(source.Data)
-		key := fmt.Sprintf("%s|%s", policySet, dataSet)
-
-		buckets[key] = append(buckets[key], source)
+	b := make(map[string][]ecc.Source)
+	for _, s := range sources {
+		policySet := ec.normalizeURISet(s.Policy)
+		dataSet := ec.normalizeURISet(s.Data)
+		key := policySet + "|" + dataSet
+		b[key] = append(b[key], s)
 	}
-
-	return buckets
+	return b
 }
 
-// normalizeURISet converts a slice of URIs into a normalized string representation
 func (ec *EquivalenceChecker) normalizeURISet(uris []string) string {
-	// Create a set (deduplicate) and sort
-	set := make(map[string]bool)
-	for _, uri := range uris {
-		// Normalize URI by stripping digest and protocol for comparison
-		normalizedURI := ec.normalizeURI(uri)
-		set[normalizedURI] = true
+	set := map[string]struct{}{}
+	for _, u := range uris {
+		set[ec.normalizeURI(u)] = struct{}{}
 	}
-
-	var sorted []string
-	for uri := range set {
-		sorted = append(sorted, uri)
+	var arr []string
+	for u := range set {
+		arr = append(arr, u)
 	}
-	sort.Strings(sorted)
-
-	return strings.Join(sorted, ",")
+	sort.Strings(arr)
+	return strings.Join(arr, ",")
 }
 
 var (
-	protoPrefix = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.-]*::`)
-	ociDigest   = regexp.MustCompile(`@[A-Za-z0-9]+:[A-Za-z0-9]+$`)
-	queryOrFrag = regexp.MustCompile(`[?#].*$`)
+	protoPrefix = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.-]*::`)  // oci:: git:: file:: etc
+	ociDigest   = regexp.MustCompile(`@[A-Za-z0-9]+:[A-Za-z0-9]+$`) // @sha256:...
+	queryOrFrag = regexp.MustCompile(`[?#].*$`)                     // drop ?ref=... / #...
 )
 
-// normalizeURI removes digest and protocols from URI for comparison purposes
+// strip protocol, query/fragment, and digest
 func (ec *EquivalenceChecker) normalizeURI(uri string) string {
 	s := strings.TrimSpace(uri)
-	s = protoPrefix.ReplaceAllString(s, "") // strip leading "oci::", "git::", etc.
-	s = queryOrFrag.ReplaceAllString(s, "") // drop ?ref=... and #...
-	s = ociDigest.ReplaceAllString(s, "")   // strip trailing @sha256:...
+	// strip http(s):// if present
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "https://")
+	// strip proto::
+	s = protoPrefix.ReplaceAllString(s, "")
+	// drop ?... or #...
+	s = queryOrFrag.ReplaceAllString(s, "")
+	// drop trailing @algo:hash
+	s = ociDigest.ReplaceAllString(s, "")
 	return s
 }
 
-// normalizeBucket normalizes a bucket of sources with identical policy/data sets
 func (ec *EquivalenceChecker) normalizeBucket(sources []ecc.Source) (PolicyBucket, error) {
 	if len(sources) == 0 {
-		return PolicyBucket{}, fmt.Errorf("empty bucket")
+		return PolicyBucket{}, fmt.Errorf("empty source group")
 	}
+	policy := strings.Split(ec.normalizeURISet(sources[0].Policy), ",")
+	data := strings.Split(ec.normalizeURISet(sources[0].Data), ",")
 
-	// All sources in a bucket have the same policy and data URIs
-	policyURIs := ec.normalizeURISet(sources[0].Policy)
-	dataURIs := ec.normalizeURISet(sources[0].Data)
-
-	// Merge RuleData from all sources in the bucket
 	ruleData, err := ec.mergeRuleData(sources)
 	if err != nil {
-		return PolicyBucket{}, fmt.Errorf("failed to merge rule data: %w", err)
+		return PolicyBucket{}, err
 	}
-
-	// Merge include/exclude matchers from all sources
 	include, exclude := ec.mergeMatchers(sources)
 
+	// collect names (if present on ecc.Source)
+	nameSet := map[string]struct{}{}
+	for _, s := range sources {
+		if s.Name != "" {
+			nameSet[s.Name] = struct{}{}
+		}
+	}
+	var names []string
+	for n := range nameSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
 	return PolicyBucket{
-		PolicyURIs: strings.Split(policyURIs, ","),
-		DataURIs:   strings.Split(dataURIs, ","),
+		PolicyURIs: policy,
+		DataURIs:   data,
 		RuleData:   ruleData,
 		Include:    include,
 		Exclude:    exclude,
+		Names:      names,
 	}, nil
 }
 
-// mergeRuleData merges RuleData from multiple sources in deterministic order
 func (ec *EquivalenceChecker) mergeRuleData(sources []ecc.Source) (map[string]interface{}, error) {
 	type item struct {
 		key string
@@ -216,285 +246,659 @@ func (ec *EquivalenceChecker) mergeRuleData(sources []ecc.Source) (map[string]in
 	}
 	var items []item
 
-	// Process sources and create deterministic ordering
-	for _, source := range sources {
-		if source.RuleData == nil {
+	for _, s := range sources {
+		if s.RuleData == nil {
 			continue
 		}
-
-		// Convert RuleData JSON to map[string]interface{}
-		var ruleData map[string]interface{}
-		if err := json.Unmarshal(source.RuleData.Raw, &ruleData); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal rule data: %w", err)
+		var m map[string]interface{}
+		if err := json.Unmarshal(s.RuleData.Raw, &m); err != nil {
+			return nil, fmt.Errorf("unmarshal ruleData: %w", err)
 		}
-
-		// Create deterministic key based on canonical JSON hash
-		canonicalBytes, err := marshalCanonical(ruleData)
+		cb, err := marshalCanonical(m)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal canonical rule data: %w", err)
+			return nil, fmt.Errorf("canonicalize ruleData: %w", err)
 		}
-		key := fmt.Sprintf("%x", sha256.Sum256(canonicalBytes))
-
-		items = append(items, item{key: key, m: ruleData})
+		items = append(items, item{
+			key: fmt.Sprintf("%x", sha256.Sum256(cb)),
+			m:   m,
+		})
 	}
 
-	// Sort by deterministic key to ensure stable merge order
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].key < items[j].key
-	})
+	sort.Slice(items, func(i, j int) bool { return items[i].key < items[j].key })
 
-	// Merge in deterministic order
-	merged := make(map[string]interface{})
-	for _, item := range items {
-		if err := ec.mergeJSON(merged, item.m); err != nil {
-			return nil, fmt.Errorf("failed to merge rule data: %w", err)
+	merged := map[string]interface{}{}
+	for _, it := range items {
+		if err := ec.mergeJSON(merged, it.m); err != nil {
+			return nil, err
 		}
 	}
-
 	return merged, nil
 }
 
-// mergeJSON merges two JSON objects, with the second taking precedence
-func (ec *EquivalenceChecker) mergeJSON(target, source map[string]interface{}) error {
-	for key, value := range source {
-		if existing, exists := target[key]; exists {
-			// If both values are objects, merge recursively
-			if targetObj, ok := existing.(map[string]interface{}); ok {
-				if sourceObj, ok := value.(map[string]interface{}); ok {
-					if err := ec.mergeJSON(targetObj, sourceObj); err != nil {
-						return err
-					}
-					continue
+func (ec *EquivalenceChecker) mergeJSON(dst, src map[string]interface{}) error {
+	for k, v := range src {
+		if ex, ok := dst[k]; ok {
+			dm, ok1 := ex.(map[string]interface{})
+			sm, ok2 := v.(map[string]interface{})
+			if ok1 && ok2 {
+				if err := ec.mergeJSON(dm, sm); err != nil {
+					return err
 				}
+				continue
 			}
 		}
-		// Otherwise, source value takes precedence
-		target[key] = value
+		dst[k] = v
 	}
 	return nil
 }
 
-// mergeMatchers merges include/exclude matchers from all sources in a bucket
 func (ec *EquivalenceChecker) mergeMatchers(sources []ecc.Source) ([]string, []string) {
-	var allInclude []string
-	var allExclude []string
-
-	for _, source := range sources {
-		// Add static config matchers
-		if source.Config != nil {
-			allInclude = append(allInclude, source.Config.Include...)
-			allExclude = append(allExclude, source.Config.Exclude...)
+	var inc, exc []string
+	for _, s := range sources {
+		if s.Config != nil {
+			inc = append(inc, s.Config.Include...)
+			exc = append(exc, s.Config.Exclude...)
 		}
-
-		// Add active volatile config matchers
-		if source.VolatileConfig != nil {
-			activeInclude, activeExclude := ec.getActiveVolatileMatchers(source.VolatileConfig)
-			allInclude = append(allInclude, activeInclude...)
-			allExclude = append(allExclude, activeExclude...)
+		if s.VolatileConfig != nil {
+			ai, ae := ec.getActiveVolatileMatchers(s.VolatileConfig)
+			inc, exc = append(inc, ai...), append(exc, ae...)
 		}
 	}
-
-	// Normalize and deduplicate
-	normalizedInclude := ec.normalizeMatchers(allInclude)
-	normalizedExclude := ec.normalizeMatchers(allExclude)
-
-	return normalizedInclude, normalizedExclude
+	return ec.normalizeMatchers(inc), ec.normalizeMatchers(exc)
 }
 
-// getActiveVolatileMatchers returns include/exclude matchers that are currently active
-func (ec *EquivalenceChecker) getActiveVolatileMatchers(volatileConfig *ecc.VolatileSourceConfig) ([]string, []string) {
-	var activeInclude []string
-	var activeExclude []string
-
-	// Check include matchers
-	for _, matcher := range volatileConfig.Include {
-		if ec.isVolatileMatcherActive(matcher) {
-			activeInclude = append(activeInclude, matcher.Value)
+func (ec *EquivalenceChecker) getActiveVolatileMatchers(v *ecc.VolatileSourceConfig) ([]string, []string) {
+	var inc, exc []string
+	for _, m := range v.Include {
+		if ec.isVolatileMatcherActive(m) {
+			inc = append(inc, m.Value)
 		}
 	}
-
-	// Check exclude matchers
-	for _, matcher := range volatileConfig.Exclude {
-		if ec.isVolatileMatcherActive(matcher) {
-			activeExclude = append(activeExclude, matcher.Value)
+	for _, m := range v.Exclude {
+		if ec.isVolatileMatcherActive(m) {
+			exc = append(exc, m.Value)
 		}
 	}
-
-	return activeInclude, activeExclude
+	return inc, exc
 }
 
-// isVolatileMatcherActive determines if a volatile matcher is currently active
-func (ec *EquivalenceChecker) isVolatileMatcherActive(matcher ecc.VolatileCriteria) bool {
-	// Check effective time constraints
-	if matcher.EffectiveOn != "" {
-		if effectiveOn, err := time.Parse(time.RFC3339, matcher.EffectiveOn); err == nil {
-			if ec.effectiveTime.Before(effectiveOn) {
-				return false
-			}
+func (ec *EquivalenceChecker) isVolatileMatcherActive(m ecc.VolatileCriteria) bool {
+	if m.EffectiveOn != "" {
+		if t, err := time.Parse(time.RFC3339, m.EffectiveOn); err == nil && ec.effectiveTime.Before(t) {
+			return false
 		}
 	}
-	if matcher.EffectiveUntil != "" {
-		if effectiveUntil, err := time.Parse(time.RFC3339, matcher.EffectiveUntil); err == nil {
-			if ec.effectiveTime.After(effectiveUntil) {
-				return false
-			}
+	if m.EffectiveUntil != "" {
+		if t, err := time.Parse(time.RFC3339, m.EffectiveUntil); err == nil && ec.effectiveTime.After(t) {
+			return false
 		}
 	}
-
-	// Check image matching constraints (if image info is provided)
 	if ec.imageInfo != nil {
-		if matcher.ImageDigest != "" && matcher.ImageDigest != ec.imageInfo.Digest {
+		if m.ImageDigest != "" && m.ImageDigest != ec.imageInfo.Digest {
 			return false
 		}
-		if matcher.ImageRef != "" && matcher.ImageRef != ec.imageInfo.Ref {
+		if m.ImageRef != "" && m.ImageRef != ec.imageInfo.Ref {
 			return false
 		}
-		if matcher.ImageUrl != "" && matcher.ImageUrl != ec.imageInfo.URL {
+		if m.ImageUrl != "" && m.ImageUrl != ec.imageInfo.URL {
 			return false
 		}
 	}
-
 	return true
 }
 
-// normalizeMatchers normalizes a list of matchers
-func (ec *EquivalenceChecker) normalizeMatchers(matchers []string) []string {
-	// Create a set to deduplicate
-	set := make(map[string]bool)
-	for _, matcher := range matchers {
-		normalized := ec.normalizeMatcher(matcher)
-		set[normalized] = true
+func (ec *EquivalenceChecker) normalizeMatchers(ms []string) []string {
+	set := map[string]struct{}{}
+	for _, m := range ms {
+		m = strings.TrimSpace(m)
+		m = strings.TrimSuffix(m, ".*") // pkg.* -> pkg
+		if m != "" {
+			set[m] = struct{}{}
+		}
 	}
-
-	// Convert back to sorted slice
-	var result []string
-	for matcher := range set {
-		result = append(result, matcher)
+	var out []string
+	for k := range set {
+		out = append(out, k)
 	}
-	sort.Strings(result)
-
-	return result
+	sort.Strings(out)
+	return out
 }
 
-// normalizeMatcher normalizes a single matcher
-func (ec *EquivalenceChecker) normalizeMatcher(matcher string) string {
-	// Handle pkg.* -> pkg normalization
-	return strings.TrimSuffix(matcher, ".*")
-}
+// ---------- Comparison + pairing + Git-style diff ----------
 
-// compareNormalizedPolicies compares two normalized policies for equivalence
-func (ec *EquivalenceChecker) compareNormalizedPolicies(norm1, norm2 *NormalizedPolicy) (bool, error) {
-	// Must have the same number of buckets
-	if len(norm1.Buckets) != len(norm2.Buckets) {
-		return false, nil
+func (ec *EquivalenceChecker) compareNormalizedPoliciesWithDifferences(norm1, norm2 *NormalizedPolicy) (bool, []PolicyDifference, error) {
+	var diffs []PolicyDifference
+
+	// Index by exact key first
+	m1 := map[string]PolicyBucket{}
+	for _, b := range norm1.Buckets {
+		m1[ec.bucketKey(b)] = b
+	}
+	m2 := map[string]PolicyBucket{}
+	for _, b := range norm2.Buckets {
+		m2[ec.bucketKey(b)] = b
 	}
 
-	// Create a map of buckets from the second policy for efficient lookup
-	bucketMap := make(map[string]PolicyBucket)
-	for _, bucket := range norm2.Buckets {
-		key := ec.bucketKey(bucket)
-		bucketMap[key] = bucket
-	}
-
-	// Check that each bucket in the first policy has an equivalent bucket in the second
-	for _, bucket1 := range norm1.Buckets {
-		key := ec.bucketKey(bucket1)
-		bucket2, exists := bucketMap[key]
-		if !exists {
-			return false, nil
-		}
-
-		bucketsEqual, err := ec.bucketsEqual(bucket1, bucket2)
-		if err != nil {
-			return false, fmt.Errorf("failed to compare buckets: %w", err)
-		}
-		if !bucketsEqual {
-			return false, nil
+	// Exact matches → field-level diffs
+	used1 := map[string]bool{}
+	used2 := map[string]bool{}
+	for k, b1 := range m1 {
+		if b2, ok := m2[k]; ok {
+			used1[k], used2[k] = true, true
+			diffs = append(diffs, ec.compareBucketsWithDifferences(b1, b2)...)
 		}
 	}
 
-	return true, nil
-}
-
-// bucketKey creates a unique key for a bucket based on policy and data URIs
-func (ec *EquivalenceChecker) bucketKey(bucket PolicyBucket) string {
-	policyKey := strings.Join(bucket.PolicyURIs, ",")
-	dataKey := strings.Join(bucket.DataURIs, ",")
-	return fmt.Sprintf("%s|%s", policyKey, dataKey)
-}
-
-// bucketsEqual compares two buckets for equivalence
-func (ec *EquivalenceChecker) bucketsEqual(bucket1, bucket2 PolicyBucket) (bool, error) {
-	// Compare policy URIs
-	if !ec.stringSlicesEqual(bucket1.PolicyURIs, bucket2.PolicyURIs) {
-		return false, nil
+	// Collect unmatched (candidates for pairing)
+	var removed, added []PolicyBucket
+	for k, b := range m1 {
+		if !used1[k] {
+			removed = append(removed, b)
+		}
 	}
-
-	// Compare data URIs
-	if !ec.stringSlicesEqual(bucket1.DataURIs, bucket2.DataURIs) {
-		return false, nil
-	}
-
-	// Compare RuleData by canonicalizing and hashing
-	ruleDataEqual, err := ec.ruleDataEqual(bucket1.RuleData, bucket2.RuleData)
-	if err != nil {
-		return false, fmt.Errorf("failed to compare rule data: %w", err)
-	}
-	if !ruleDataEqual {
-		return false, nil
-	}
-
-	// Compare include matchers
-	if !ec.stringSlicesEqual(bucket1.Include, bucket2.Include) {
-		return false, nil
-	}
-
-	// Compare exclude matchers
-	if !ec.stringSlicesEqual(bucket1.Exclude, bucket2.Exclude) {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// stringSlicesEqual compares two string slices for equality
-func (ec *EquivalenceChecker) stringSlicesEqual(slice1, slice2 []string) bool {
-	if len(slice1) != len(slice2) {
-		return false
-	}
-
-	for i, s1 := range slice1 {
-		if s1 != slice2[i] {
-			return false
+	for k, b := range m2 {
+		if !used2[k] {
+			added = append(added, b)
 		}
 	}
 
-	return true
+	// Pair near-identical entries so we show CHANGES, not ADD/REMOVE
+	pairsR2A, unmatchedRemoved, unmatchedAdded := ec.pairBuckets(removed, added)
+
+	// Produce field-level diffs for paired entries
+	for _, p := range pairsR2A {
+		diffs = append(diffs, ec.compareBucketsWithDifferences(p.r, p.a)...)
+	}
+
+	// Remaining unmatched → added/removed source entries
+	for _, b := range unmatchedRemoved {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey: ec.bucketKey(b),
+			Field:     "sources",
+			Path:      FieldPath{"sources"},
+			Kind:      DiffRemoved,
+			VSAValue:  ec.describeSource(b),
+			Summary:   "source entry removed",
+		})
+	}
+	for _, b := range unmatchedAdded {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     ec.bucketKey(b),
+			Field:         "sources",
+			Path:          FieldPath{"sources"},
+			Kind:          DiffAdded,
+			SuppliedValue: ec.describeSource(b),
+			Summary:       "source entry added",
+		})
+	}
+
+	return len(diffs) == 0, diffs, nil
 }
 
-// ruleDataEqual compares two RuleData objects for equality by canonicalizing and hashing
-func (ec *EquivalenceChecker) ruleDataEqual(data1, data2 map[string]interface{}) (bool, error) {
-	hash1, err := ec.hashRuleData(data1)
-	if err != nil {
-		return false, fmt.Errorf("failed to hash first rule data: %w", err)
+// Pairing: greedy best-match by similarity to avoid noisy add/remove
+type bucketPair struct{ r, a PolicyBucket }
+
+func (ec *EquivalenceChecker) pairBuckets(removed, added []PolicyBucket) (pairs []bucketPair, remOut []PolicyBucket, addOut []PolicyBucket) {
+	if len(removed) == 0 || len(added) == 0 {
+		return nil, removed, added
 	}
 
-	hash2, err := ec.hashRuleData(data2)
-	if err != nil {
-		return false, fmt.Errorf("failed to hash second rule data: %w", err)
+	// Build all candidate scores
+	type cand struct {
+		i, j  int
+		score float64
 	}
+	var all []cand
+	for i := range removed {
+		for j := range added {
+			s := ec.bucketSimilarity(removed[i], added[j])
+			if s > 0 {
+				all = append(all, cand{i: i, j: j, score: s})
+			}
+		}
+	}
+	// Sort by descending score
+	sort.Slice(all, func(i, j int) bool { return all[i].score > all[j].score })
 
-	return hash1 == hash2, nil
+	usedR := make([]bool, len(removed))
+	usedA := make([]bool, len(added))
+	const threshold = 0.60 // tweakable; >=0.60 is "same entry, changed"
+	for _, c := range all {
+		if usedR[c.i] || usedA[c.j] {
+			continue
+		}
+		if c.score >= threshold {
+			usedR[c.i] = true
+			usedA[c.j] = true
+			pairs = append(pairs, bucketPair{r: removed[c.i], a: added[c.j]})
+		}
+	}
+	for i, b := range removed {
+		if !usedR[i] {
+			remOut = append(remOut, b)
+		}
+	}
+	for j, b := range added {
+		if !usedA[j] {
+			addOut = append(addOut, b)
+		}
+	}
+	return
 }
 
-// hashRuleData creates a hash of canonicalized RuleData
-func (ec *EquivalenceChecker) hashRuleData(data map[string]interface{}) (string, error) {
-	// Use deterministic JSON encoding with sorted keys
-	jsonBytes, err := marshalCanonical(data)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal canonical JSON: %w", err)
+func (ec *EquivalenceChecker) bucketSimilarity(a, b PolicyBucket) float64 {
+	// Jaccard similarities for lists
+	pol := jaccard(a.PolicyURIs, b.PolicyURIs)
+	dat := jaccard(a.DataURIs, b.DataURIs)
+
+	// Bonuses
+	nameBonus := 0.0
+	if len(a.Names) > 0 && len(b.Names) > 0 && overlap(a.Names, b.Names) {
+		nameBonus = 0.10
+	}
+	ruleBonus := 0.0
+	if eq, _ := ec.ruleDataEqual(a.RuleData, b.RuleData); eq {
+		ruleBonus = 0.10
 	}
 
-	hash := sha256.Sum256(jsonBytes)
-	return fmt.Sprintf("%x", hash), nil
+	// Weight data higher (tends to be more "identity" than policy paths)
+	score := 0.40*pol + 0.60*dat + nameBonus + ruleBonus
+	return math.Min(score, 1.0)
+}
+
+func jaccard(a, b []string) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 1.0
+	}
+	set := map[string]struct{}{}
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	inter := 0
+	union := len(set)
+	for _, x := range b {
+		if _, ok := set[x]; ok {
+			inter++
+		} else {
+			union++
+		}
+	}
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+func overlap(a, b []string) bool {
+	set := map[string]struct{}{}
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (ec *EquivalenceChecker) compareBucketsWithDifferences(b1, b2 PolicyBucket) []PolicyDifference {
+	var diffs []PolicyDifference
+	key := ec.bucketKey(b1)
+
+	// policy
+	add, rem := ec.diffStringSets(b1.PolicyURIs, b2.PolicyURIs)
+	for _, s := range add {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     key,
+			Field:         "policy",
+			Path:          FieldPath{"policy"},
+			Kind:          DiffAdded,
+			SuppliedValue: s,
+			Summary:       "policy location added",
+		})
+	}
+	for _, s := range rem {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey: key,
+			Field:     "policy",
+			Path:      FieldPath{"policy"},
+			Kind:      DiffRemoved,
+			VSAValue:  s,
+			Summary:   "policy location removed",
+		})
+	}
+
+	// data
+	add, rem = ec.diffStringSets(b1.DataURIs, b2.DataURIs)
+	for _, s := range add {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     key,
+			Field:         "data",
+			Path:          FieldPath{"data"},
+			Kind:          DiffAdded,
+			SuppliedValue: s,
+			Summary:       "data location added",
+		})
+	}
+	for _, s := range rem {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey: key,
+			Field:     "data",
+			Path:      FieldPath{"data"},
+			Kind:      DiffRemoved,
+			VSAValue:  s,
+			Summary:   "data location removed",
+		})
+	}
+
+	// include
+	add, rem = ec.diffStringSets(b1.Include, b2.Include)
+	for _, s := range add {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     key,
+			Field:         "include",
+			Path:          FieldPath{"include"},
+			Kind:          DiffAdded,
+			SuppliedValue: s,
+			Summary:       "include added",
+		})
+	}
+	for _, s := range rem {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey: key,
+			Field:     "include",
+			Path:      FieldPath{"include"},
+			Kind:      DiffRemoved,
+			VSAValue:  s,
+			Summary:   "include removed",
+		})
+	}
+
+	// exclude
+	add, rem = ec.diffStringSets(b1.Exclude, b2.Exclude)
+	for _, s := range add {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     key,
+			Field:         "exclude",
+			Path:          FieldPath{"exclude"},
+			Kind:          DiffAdded,
+			SuppliedValue: s,
+			Summary:       "exclude added",
+		})
+	}
+	for _, s := range rem {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey: key,
+			Field:     "exclude",
+			Path:      FieldPath{"exclude"},
+			Kind:      DiffRemoved,
+			VSAValue:  s,
+			Summary:   "exclude removed",
+		})
+	}
+
+	// ruleData (unified JSON diff)
+	eq, err := ec.ruleDataEqual(b1.RuleData, b2.RuleData)
+	if err != nil {
+		diffs = append(diffs, PolicyDifference{
+			BucketKey:     key,
+			Field:         "ruleData",
+			Path:          FieldPath{"ruleData"},
+			Kind:          DiffChanged,
+			Summary:       "ruleData compare error",
+			VSAValue:      "error",
+			SuppliedValue: err.Error(),
+		})
+	} else if !eq {
+		if ud, err := ec.unifiedJSONDiff(b1.RuleData, b2.RuleData); err == nil {
+			diffs = append(diffs, PolicyDifference{
+				BucketKey:     key,
+				Field:         "ruleData",
+				Path:          FieldPath{"ruleData"},
+				Kind:          DiffChanged,
+				Summary:       "ruleData changed",
+				SuppliedValue: ud,
+			})
+		} else {
+			diffs = append(diffs, PolicyDifference{
+				BucketKey: key,
+				Field:     "ruleData",
+				Path:      FieldPath{"ruleData"},
+				Kind:      DiffChanged,
+				Summary:   "ruleData changed (diff unavailable)",
+			})
+		}
+	}
+
+	return diffs
+}
+
+func (ec *EquivalenceChecker) describeSource(b PolicyBucket) string {
+	switch {
+	case len(b.PolicyURIs) > 0 && len(b.DataURIs) > 0:
+		return fmt.Sprintf("Policy sources:\n%s\nData sources:\n%s", ec.formatURIs(b.PolicyURIs), ec.formatURIs(b.DataURIs))
+	case len(b.PolicyURIs) > 0:
+		return fmt.Sprintf("Policy sources:\n%s", ec.formatURIs(b.PolicyURIs))
+	case len(b.DataURIs) > 0:
+		return fmt.Sprintf("Data sources:\n%s", ec.formatURIs(b.DataURIs))
+	default:
+		return "Empty policy source"
+	}
+}
+
+// ---------- Rendering: Git-style unified output ----------
+
+func (ec *EquivalenceChecker) GenerateUnifiedDiffOutput(differences []PolicyDifference) string {
+	return ec.GenerateUnifiedDiffOutputWithLabels(differences, "VSA", "Supplied")
+}
+
+func (ec *EquivalenceChecker) GenerateUnifiedDiffOutputWithLabels(differences []PolicyDifference, fromLabel, toLabel string) string {
+	if len(differences) == 0 {
+		return ""
+	}
+
+	// Create a copy of differences to avoid modifying the original
+	processedDiffs := make([]PolicyDifference, len(differences))
+	copy(processedDiffs, differences)
+
+	// Post-process ruleData differences to update their labels
+	for i := range processedDiffs {
+		if processedDiffs[i].Field == "ruleData" && processedDiffs[i].SuppliedValue != nil {
+			if diffStr, ok := processedDiffs[i].SuppliedValue.(string); ok {
+				// Replace the hardcoded labels in the ruleData diff
+				diffStr = strings.ReplaceAll(diffStr, "--- VSA.ruleData", fmt.Sprintf("--- %s.ruleData", fromLabel))
+				diffStr = strings.ReplaceAll(diffStr, "+++ Supplied.ruleData", fmt.Sprintf("+++ %s.ruleData", toLabel))
+				processedDiffs[i].SuppliedValue = diffStr
+			}
+		}
+	}
+
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("--- %s\n", fromLabel))
+	buf.WriteString(fmt.Sprintf("+++ %s\n", toLabel))
+
+	// group by source entry
+	group := map[string][]PolicyDifference{}
+	var keys []string
+	for _, d := range processedDiffs {
+		if _, ok := group[d.BucketKey]; !ok {
+			keys = append(keys, d.BucketKey)
+		}
+		group[d.BucketKey] = append(group[d.BucketKey], d)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		diffs := group[k]
+		buf.WriteString(fmt.Sprintf("# source entry: %s\n", k))
+
+		// stable ordering by field then summary
+		sort.SliceStable(diffs, func(i, j int) bool {
+			if diffs[i].Field == diffs[j].Field {
+				return diffs[i].Summary < diffs[j].Summary
+			}
+			return diffs[i].Field < diffs[j].Field
+		})
+
+		for _, d := range diffs {
+			ec.writeUnifiedDiffEntry(&buf, d)
+		}
+	}
+
+	return buf.String()
+}
+
+func (ec *EquivalenceChecker) writeUnifiedDiffEntry(buf *strings.Builder, diff PolicyDifference) {
+	switch diff.Field {
+	case "sources":
+		switch diff.Kind {
+		case DiffAdded:
+			buf.WriteString("+ [source] ")
+			if diff.SuppliedValue != nil {
+				buf.WriteString(fmt.Sprintf("%v", diff.SuppliedValue))
+			}
+			buf.WriteString("\n")
+		case DiffRemoved:
+			buf.WriteString("- [source] ")
+			if diff.VSAValue != nil {
+				buf.WriteString(fmt.Sprintf("%v", diff.VSAValue))
+			}
+			buf.WriteString("\n")
+		}
+	case "policy":
+		switch diff.Kind {
+		case DiffAdded:
+			buf.WriteString(fmt.Sprintf("+ [policy]  %v\n", diff.SuppliedValue))
+		case DiffRemoved:
+			buf.WriteString(fmt.Sprintf("- [policy]  %v\n", diff.VSAValue))
+		}
+	case "data":
+		switch diff.Kind {
+		case DiffAdded:
+			buf.WriteString(fmt.Sprintf("+ [data]    %v\n", diff.SuppliedValue))
+		case DiffRemoved:
+			buf.WriteString(fmt.Sprintf("- [data]    %v\n", diff.VSAValue))
+		}
+	case "include":
+		switch diff.Kind {
+		case DiffAdded:
+			buf.WriteString(fmt.Sprintf("+ [include] %v\n", diff.SuppliedValue))
+		case DiffRemoved:
+			buf.WriteString(fmt.Sprintf("- [include] %v\n", diff.VSAValue))
+		}
+	case "exclude":
+		switch diff.Kind {
+		case DiffAdded:
+			buf.WriteString(fmt.Sprintf("+ [exclude] %v\n", diff.SuppliedValue))
+		case DiffRemoved:
+			buf.WriteString(fmt.Sprintf("- [exclude] %v\n", diff.VSAValue))
+		}
+	case "ruleData":
+		if diff.Kind == DiffChanged && diff.SuppliedValue != nil {
+			// SuppliedValue already contains the unified diff with its own headers
+			buf.WriteString(fmt.Sprintf("%s", diff.SuppliedValue))
+			if !strings.HasSuffix(fmt.Sprintf("%s", diff.SuppliedValue), "\n") {
+				buf.WriteString("\n")
+			}
+		}
+	}
+}
+
+// ---------- Helpers ----------
+
+func (ec *EquivalenceChecker) bucketKey(b PolicyBucket) string {
+	// Use names if available, otherwise fall back to URIs
+	if len(b.Names) > 0 {
+		return strings.Join(b.Names, ",")
+	}
+	return strings.Join(b.PolicyURIs, ",") + "|" + strings.Join(b.DataURIs, ",")
+}
+
+func (ec *EquivalenceChecker) diffStringSets(old, new []string) (added, removed []string) {
+	a := map[string]struct{}{}
+	b := map[string]struct{}{}
+	for _, s := range old {
+		a[s] = struct{}{}
+	}
+	for _, s := range new {
+		b[s] = struct{}{}
+	}
+	for s := range b {
+		if _, ok := a[s]; !ok {
+			added = append(added, s)
+		}
+	}
+	for s := range a {
+		if _, ok := b[s]; !ok {
+			removed = append(removed, s)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return
+}
+
+func (ec *EquivalenceChecker) formatURIs(uris []string) string {
+	if len(uris) == 0 {
+		return "  (none)"
+	}
+	var out []string
+	for _, u := range uris {
+		out = append(out, "  - "+u)
+	}
+	return strings.Join(out, "\n")
+}
+
+func (ec *EquivalenceChecker) ruleDataEqual(d1, d2 map[string]interface{}) (bool, error) {
+	h1, err := ec.hashRuleData(d1)
+	if err != nil {
+		return false, err
+	}
+	h2, err := ec.hashRuleData(d2)
+	if err != nil {
+		return false, err
+	}
+	return h1 == h2, nil
+}
+
+func (ec *EquivalenceChecker) hashRuleData(d map[string]interface{}) (string, error) {
+	cb, err := marshalCanonical(d) // provided by canonical.go
+	if err != nil {
+		return "", fmt.Errorf("canonicalize ruleData: %w", err)
+	}
+	sum := sha256.Sum256(cb)
+	return fmt.Sprintf("%x", sum), nil
+}
+
+func (ec *EquivalenceChecker) unifiedJSONDiff(a, b map[string]interface{}) (string, error) {
+	return ec.unifiedJSONDiffWithLabels(a, b, "VSA", "Supplied")
+}
+
+func (ec *EquivalenceChecker) unifiedJSONDiffWithLabels(a, b map[string]interface{}, fromLabel, toLabel string) (string, error) {
+	// Canonicalize then pretty-print to stabilize whitespace and ordering
+	ab, err := marshalCanonical(a)
+	if err != nil {
+		return "", err
+	}
+	bb, err := marshalCanonical(b)
+	if err != nil {
+		return "", err
+	}
+
+	var aj, bj map[string]interface{}
+	_ = json.Unmarshal(ab, &aj)
+	_ = json.Unmarshal(bb, &bj)
+
+	alines, _ := json.MarshalIndent(aj, "", "  ")
+	blines, _ := json.MarshalIndent(bj, "", "  ")
+
+	ud := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(alines)),
+		B:        difflib.SplitLines(string(blines)),
+		FromFile: fmt.Sprintf("%s.ruleData", fromLabel),
+		ToFile:   fmt.Sprintf("%s.ruleData", toLabel),
+		Context:  2,
+	}
+	return difflib.GetUnifiedDiffString(ud)
 }


### PR DESCRIPTION
Adding `validate vsa subcommand`. The command supports validating a VSA from the filesystem, a single image or a snapshot. If an image or snapshot is provided, the VSA will be looked up from Rekor.
This does not do signature verification. That will be in a follow-up PR.