### PR TITLE
Verify VSA signature

### DIFF
--- a/.cursor/rules/vsa_functionality.mdc
+++ b/.cursor/rules/vsa_functionality.mdc
@@ -1,0 +1,542 @@
+# VSA (Verification Summary Attestation) Functionality
+
+## Overview
+
+VSA (Verification Summary Attestation) is a critical feature that creates cryptographically signed attestations containing validation metadata and policy information after successful image validation. VSAs provide tamper-evident records of what policies were used and what validation results were achieved.
+
+## Architecture
+
+The VSA implementation follows a layered architecture with clear separation of concerns:
+
+### Layer 1: Core Interfaces (`interfaces.go`)
+Defines the fundamental VSA interfaces for predicate generation, writing, and attestation.
+
+### Layer 2: Service Layer (`service.go`)
+High-level VSA processing orchestration for components and snapshots.
+
+### Layer 3: Core Logic (`vsa.go`)
+VSA data structures, predicate generation, and core validation logic.
+
+### Layer 4: Attestation (`attest.go`)
+DSSE envelope creation and cryptographic signing.
+
+### Layer 5: Storage (`storage*.go`)
+Abstract storage backends for VSA upload and retrieval.
+
+### Layer 6: Retrieval (`*_retriever.go`)
+VSA retrieval mechanisms from various backends.
+
+### Layer 7: Orchestration (`orchestrator.go`)
+Complex VSA processing workflows.
+
+### Layer 8: Validation (`validator.go`)
+VSA validation with policy comparison and signature verification.
+
+### Layer 9: Command Interface (`cmd/validate/vsa.go`)
+CLI for VSA validation and management.
+
+## Core Concepts
+
+### VSA Structure
+- **Predicate**: Contains the actual validation metadata (policy, results, timestamps)
+- **DSSE Envelope**: Cryptographically signed wrapper around the predicate
+- **In-toto Statement**: Standardized format for supply chain attestations
+- **Subject**: The image being validated (with digest)
+
+### Key Components
+- **Policy Information**: The complete policy specification used for validation
+- **Validation Results**: Success/failure status, violations, warnings, successes
+- **Metadata**: Timestamps, verifier information, image references
+- **Public Key**: The key used for validation (embedded in VSA)
+
+## Core Data Structures
+
+### Predicate Structure
+```go
+type Predicate struct {
+    Policy       ecapi.EnterpriseContractPolicySpec `json:"policy"`       // Complete policy used
+    PolicySource string                             `json:"policySource"` // Original policy location
+    ImageRefs    []string                           `json:"imageRefs"`    // All image references
+    Timestamp    string                             `json:"timestamp"`    // RFC3339 timestamp
+    Status       string                             `json:"status"`       // "passed" or "failed"
+    Verifier     string                             `json:"verifier"`     // "conforma"
+    Summary      VSASummary                         `json:"summary"`      // Validation results
+    PublicKey    string                             `json:"publicKey"`    // PEM-encoded public key
+}
+
+type VSASummary struct {
+    Violations int               `json:"violations"`
+    Warnings   int               `json:"warnings"`
+    Successes  int               `json:"successes"`
+    Components []ComponentDetail `json:"Components"`
+    Component  ComponentSummary  `json:"component"`
+}
+
+type ComponentSummary struct {
+    Name           string      `json:"name"`
+    ContainerImage string      `json:"containerImage"`
+    Source         interface{} `json:"source"`
+}
+
+type ComponentDetail struct {
+    Name       string `json:"Name"`
+    ImageRef   string `json:"ImageRef"`
+    Violations int    `json:"Violations"`
+    Warnings   int    `json:"Warnings"`
+    Successes  int    `json:"Successes"`
+}
+```
+
+### Validation and Lookup Results
+```go
+type ValidationResult struct {
+    Passed            bool   `json:"passed"`
+    Message           string `json:"message,omitempty"`
+    SignatureVerified bool   `json:"signature_verified,omitempty"`
+}
+
+type VSALookupResult struct {
+    Found             bool
+    Expired           bool
+    VSA               *Predicate
+    Timestamp         time.Time
+    Envelope          *ssldsse.Envelope // Store the envelope for signature verification
+    SignatureVerified bool              // Whether signature verification was performed and succeeded
+}
+
+type ComponentResult struct {
+    ComponentName string
+    ImageRef      string
+    Result        *ValidationResult
+    Error         error
+}
+```
+
+### Identifier Types
+```go
+type IdentifierType int
+
+const (
+    IdentifierFile            IdentifierType = iota // Local file path
+    IdentifierImageDigest                           // Container image digest (e.g., sha256:abc123...)
+    IdentifierImageReference                        // Container image reference (e.g., nginx:latest)
+)
+```
+
+## Core Interfaces
+
+### PredicateGenerator Interface
+```go
+type PredicateGenerator[T any] interface {
+    GeneratePredicate(ctx context.Context) (T, error)
+}
+```
+
+### PredicateWriter Interface
+```go
+type PredicateWriter[T any] interface {
+    WritePredicate(pred T) (string, error)
+}
+```
+
+### PredicateAttestor Interface
+```go
+type PredicateAttestor interface {
+    AttestPredicate(ctx context.Context) ([]byte, error)
+    WriteEnvelope(data []byte) (string, error)
+    TargetDigest() string
+}
+```
+
+## Service Layer API
+
+### VSA Service (`service.go`)
+
+The `Service` struct encapsulates all VSA processing logic:
+
+```go
+type Service struct {
+    signer       *Signer
+    fs           afero.Fs
+    policySource string
+    policy       PublicKeyProvider
+}
+```
+
+#### Key Methods:
+
+**ProcessComponentVSA** - Creates VSA for individual components:
+```go
+func (s *Service) ProcessComponentVSA(ctx context.Context, report applicationsnapshot.Report, comp applicationsnapshot.Component, gitURL, digest string) (string, error)
+```
+
+**ProcessSnapshotVSA** - Creates VSA for application snapshots:
+```go
+func (s *Service) ProcessSnapshotVSA(ctx context.Context, report applicationsnapshot.Report) (string, error)
+```
+
+**ProcessAllVSAs** - Processes VSAs for all components and snapshot:
+```go
+func (s *Service) ProcessAllVSAs(ctx context.Context, report applicationsnapshot.Report, getGitURL func(applicationsnapshot.Component) string, getDigest func(applicationsnapshot.Component) (string, error)) (*VSAProcessingResult, error)
+```
+
+## VSA Generation Workflow
+
+### 1. Component VSA Generation
+
+**Steps:**
+1. **Create Generator**: `NewGenerator(report, comp, policySource, policy)`
+2. **Generate Predicate**: `GenerateAndWritePredicate(ctx, generator, writer)`
+3. **Create Attestor**: `NewAttestor(predicatePath, imageRef, digest, signer)`
+4. **Attest VSA**: `AttestVSA(ctx, attestor)`
+5. **Return Envelope Path**: Path to the signed VSA envelope
+
+### 2. Snapshot VSA Generation
+
+**Steps:**
+1. **Create Snapshot Generator**: `applicationsnapshot.NewSnapshotPredicateGenerator(report)`
+2. **Generate Snapshot Predicate**: `GenerateAndWriteSnapshotPredicate(ctx, generator, writer)`
+3. **Calculate Digest**: `applicationsnapshot.GetVSAPredicateDigest(fs, writtenPath)`
+4. **Create Attestor**: `NewAttestor(predicatePath, snapshotName, digest, signer)`
+5. **Attest VSA**: `AttestVSA(ctx, attestor)`
+6. **Return Envelope Path**: Path to the signed snapshot VSA
+
+## Attestation Layer (`attest.go`)
+
+### Signer Creation
+```go
+func NewSigner(ctx context.Context, keyRef string, fs afero.Fs) (*Signer, error)
+```
+
+**Features:**
+- Supports file paths and Kubernetes secret references
+- Handles encrypted private keys with `COSIGN_PASSWORD` environment variable
+- Creates DSSE wrapper for in-toto payload type
+
+### Attestor Creation
+```go
+func NewAttestor(predicatePath, repo, digest string, signer *Signer) (*Attestor, error)
+```
+
+**Features:**
+- Configurable predicate type URL
+- Image reference and digest handling
+- DSSE envelope creation
+
+### VSA Attestation
+```go
+func (a Attestor) AttestPredicate(ctx context.Context) ([]byte, error)
+```
+
+**Process:**
+1. Reads predicate from file
+2. Creates in-toto statement with subject information
+3. Signs the statement using DSSE envelope format
+4. Returns signed DSSE envelope
+
+## Storage Backends
+
+### Storage Interface (`storage.go`)
+
+```go
+type StorageBackend interface {
+    Name() string
+    Upload(ctx context.Context, envelopeContent []byte) error
+}
+
+type SignerAwareUploader interface {
+    StorageBackend
+    UploadWithSigner(ctx context.Context, envelopeContent []byte, signer *Signer) (string, error)
+}
+```
+
+### Local Filesystem Storage (`storage_local.go`)
+
+**Format:** `local@/path/to/directory`
+**Example:** `--vsa-upload local@/tmp/vsa-output`
+
+**Features:**
+- Stores VSA envelopes as files
+- Creates organized directory structure
+- Supports custom base paths
+- No external dependencies
+
+### Rekor Transparency Log Storage (`storage_rekor.go`)
+
+**Format:** `rekor@https://rekor.sigstore.dev`
+**Example:** `--vsa-upload rekor@https://rekor.sigstore.dev`
+
+**Features:**
+- Stores VSAs in public transparency log
+- Provides tamper-evidence through public logging
+- Supports custom Rekor server URLs
+- Requires signer access for public key extraction
+- Handles in-toto 0.0.2 entry format
+
+### Storage Configuration
+
+```go
+func ParseStorageFlag(storageFlag string) (*StorageConfig, error)
+```
+
+**Supported formats:**
+- `rekor@https://rekor.sigstore.dev`
+- `local@/path/to/directory`
+- `rekor?server=custom.rekor.com&timeout=30s`
+
+## Retrieval Mechanisms
+
+### VSA Retriever Interface
+
+```go
+type VSARetriever interface {
+    RetrieveVSA(ctx context.Context, identifier string) (*ssldsse.Envelope, error)
+}
+```
+
+### File-based Retrieval (`file_retriever.go`)
+
+**Purpose:** Retrieve VSAs from local filesystem
+**Features:**
+- Direct file path access
+- No network dependencies
+- Fast local access
+
+### Rekor-based Retrieval (`rekor_retriever.go`)
+
+**Purpose:** Retrieve VSAs from Rekor transparency log
+**Features:**
+- Searches by image digest
+- Handles in-toto 0.0.2 entries
+- Selects latest entry by IntegratedTime
+- Builds DSSE envelopes from Rekor entries
+
+## VSA Validation and Checking
+
+### VSA Checker (`vsa.go`)
+
+```go
+type VSAChecker struct {
+    retriever VSARetriever
+}
+```
+
+**Key Methods:**
+
+**CheckExistingVSAWithVerification** - Looks up existing VSAs with optional signature verification:
+```go
+func (c *VSAChecker) CheckExistingVSAWithVerification(ctx context.Context, imageRef string, expirationThreshold time.Duration, verifySignature bool, publicKeyPath string) (*VSALookupResult, error)
+```
+
+**CheckExistingVSA** - Looks up existing VSAs and determines validity (backward compatibility):
+```go
+func (c *VSAChecker) CheckExistingVSA(ctx context.Context, imageRef string, expirationThreshold time.Duration) (*VSALookupResult, error)
+```
+
+**IsValidVSA** - Checks if VSA exists and is not expired:
+```go
+func (c *VSAChecker) IsValidVSA(ctx context.Context, imageRef string, expirationThreshold time.Duration) (bool, error)
+```
+
+### VSA Validation with Policy Comparison (`validator.go`)
+
+**ValidateVSAWithPolicyComparison** - Comprehensive VSA validation with policy comparison:
+```go
+func ValidateVSAWithPolicyComparison(ctx context.Context, identifier string, data *ValidationData) (*ValidationResult, error)
+```
+
+**ValidationData** - Configuration for VSA validation:
+```go
+type ValidationData struct {
+    Retriever                   VSARetriever
+    VSAExpiration               time.Duration
+    IgnoreSignatureVerification bool
+    PublicKeyPath               string
+    PolicySpec                  ecapi.EnterpriseContractPolicySpec
+    EffectiveTime               string
+}
+```
+
+### Policy Comparison Features
+
+- **Policy Equivalence Checking**: Compares VSA policy with supplied policy using detailed equivalence checking
+- **Signature Verification**: Optional DSSE envelope signature verification using public keys
+- **Expiration Checking**: Validates VSA age against configurable thresholds
+- **Detailed Error Reporting**: Provides specific policy differences and validation failures
+- **Multi-format Support**: Handles both in-toto statements and direct predicate formats
+
+## Command-Line Interface
+
+### VSA Validation Command (`cmd/validate/vsa.go`)
+
+**Usage:**
+```bash
+ec validate vsa <vsa-identifier> [flags]
+```
+
+**Supported Identifiers:**
+- Image digests: `registry/image@sha256:abc123...`
+- Image references: `registry/image:tag`
+- File paths: `/path/to/vsa.json`
+
+**Key Flags:**
+- `--policy` - Policy configuration for comparison (required)
+- `--vsa-expiration` - VSA expiration threshold (default: 168h, supports h, d, w, mo)
+- `--effective-time` - Effective time for policy comparison (default: "now")
+- `--workers` - Number of parallel workers (default: 5)
+- `--output` - Output format specification
+- `--strict` - Exit with non-zero code on validation failure (default: true)
+- `--vsa-retrieval` - VSA retrieval backends (rekor@, file@)
+- `--images` - Application snapshot file (alternative to single VSA)
+- `--public-key` - Path to public key for signature verification (required by default)
+- `--ignore-signature-verification` - Disable signature verification (default: false)
+
+**Features:**
+- Single VSA validation by identifier
+- Batch VSA validation from application snapshots with parallel processing
+- Multiple retrieval backends with auto-detection
+- Policy comparison and validation with detailed differences
+- DSSE envelope signature verification
+- VSA expiration checking
+- Comprehensive error reporting with unified diff format
+- Support for multiple identifier types with automatic detection
+
+## VSA Processing Workflows
+
+### 1. VSA Generation Workflow
+
+```
+1. Create Service with signer and policy
+2. For each component:
+   a. Generate predicate using Generator
+   b. Write predicate using Writer
+   c. Create Attestor with signer
+   d. Attest predicate to create DSSE envelope
+   e. Upload envelope to configured storage backends
+3. For application snapshot:
+   a. Generate snapshot predicate
+   b. Calculate digest
+   c. Create snapshot attestor
+   d. Attest snapshot predicate
+   e. Upload snapshot envelope
+```
+
+### 2. VSA Validation Workflow
+
+```
+1. Parse VSA identifier (image digest, file path, etc.)
+2. Create appropriate retriever (file, Rekor, etc.)
+3. Retrieve VSA envelope from backend
+4. Optional: Verify DSSE envelope signature using public key
+5. Extract predicate from envelope (supports in-toto statements and direct predicates)
+6. Check VSA expiration against threshold
+7. Compare policies using detailed equivalence checking (if provided)
+8. Return validation result with signature verification status
+```
+
+### 3. VSA Retrieval Workflow
+
+```
+1. Determine identifier type (digest, reference, file path)
+2. Create appropriate retriever
+3. Search for VSA entries
+4. Select latest entry (for Rekor)
+5. Build DSSE envelope from entry
+6. Return envelope for validation
+```
+
+## Security Considerations
+
+### Signing
+- Use strong cryptographic keys for VSA signing
+- Protect private keys appropriately
+- Consider key rotation strategies
+- **DSSE envelope signature verification is implemented and enabled by default**
+
+### Storage
+- Use HTTPS for remote storage backends
+- Validate storage backend certificates
+- Consider access controls for sensitive VSAs
+- Implement audit logging for VSA operations
+
+### Retrieval
+- **DSSE envelope signature verification is implemented and enabled by default**
+- Validate policy information integrity
+- Check VSA expiration times
+- Implement proper access controls
+- Support for multiple signature verification methods
+- Public key validation and verification
+
+## Testing Strategy
+
+### Unit Tests
+- Test each layer independently
+- Mock external dependencies
+- Test error conditions and edge cases
+
+### Integration Tests
+- Test end-to-end VSA workflows
+- Test with real storage backends
+- Test retrieval from multiple sources
+
+### Acceptance Tests
+- Test VSA generation with real images
+- Test storage with multiple backends
+- Test retrieval from transparency logs
+- Test policy comparison workflows
+
+## Future Enhancements
+
+### Signature Verification
+- ✅ **DSSE envelope signature verification is implemented**
+- ✅ **Public key validation is implemented**
+- ✅ **Support for multiple signature verification methods is implemented**
+- Enhanced signature verification with multiple key support
+- Support for different signature algorithms
+
+### Additional Storage Backends
+- OCI registry storage
+- Cloud storage backends (S3, GCS, Azure)
+- Custom storage implementations
+- Enhanced Rekor integration with custom servers
+
+### Enhanced Retrieval
+- Caching mechanisms for improved performance
+- Parallel retrieval from multiple sources
+- Conflict resolution strategies
+- Enhanced identifier type detection
+- Support for additional VSA formats
+
+## API Reference
+
+### Service Layer
+- `NewServiceWithFS(signer, fs, policySource, policy) *Service`
+- `ProcessComponentVSA(ctx, report, comp, gitURL, digest) (string, error)`
+- `ProcessSnapshotVSA(ctx, report) (string, error)`
+- `ProcessAllVSAs(ctx, report, getGitURL, getDigest) (*VSAProcessingResult, error)`
+
+### Storage Layer
+- `ParseStorageFlag(flag) (*StorageConfig, error)`
+- `NewLocalBackend(basePath) *LocalBackend`
+- `NewRekorBackend(baseURL, options) *RekorBackend`
+
+### Retrieval Layer
+- `NewFileVSARetriever(fs) *FileVSARetriever`
+- `NewRekorVSARetriever(baseURL, options) *RekorVSARetriever`
+
+### Validation Layer
+- `NewVSAChecker(retriever) *VSAChecker`
+- `CheckExistingVSAWithVerification(ctx, imageRef, expiration, verifySignature, publicKeyPath) (*VSALookupResult, error)`
+- `CheckExistingVSA(ctx, imageRef, expiration) (*VSALookupResult, error)`
+- `IsValidVSA(ctx, imageRef, expiration) (bool, error)`
+- `ValidateVSAWithPolicyComparison(ctx, identifier, data) (*ValidationResult, error)`
+
+### Utility Functions
+- `DetectIdentifierType(identifier) IdentifierType`
+- `IsValidVSAIdentifier(identifier) bool`
+- `ParseVSAExpirationDuration(s) (time.Duration, error)`
+- `ParseVSAContent(envelope) (*Predicate, error)`
+- `ExtractDigestFromImageRef(imageRef) (string, error)`
+- `CreateVSARetriever(vsaRetrieval, vsaIdentifier, images) (VSARetriever, error)`
+
+This documentation accurately reflects the actual VSA implementation with its layered architecture, comprehensive API surface, sophisticated workflow management, and advanced signature verification capabilities.

--- a/cmd/validate/vsa.go
+++ b/cmd/validate/vsa.go
@@ -18,57 +18,21 @@ package validate
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
-	"os"
-	"path/filepath"
-	"regexp"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	hd "github.com/MakeNowJust/heredoc"
 	ecapi "github.com/conforma/crds/api/v1alpha1"
-	"github.com/google/go-containerregistry/pkg/name"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/conforma/cli/internal/applicationsnapshot"
-	"github.com/conforma/cli/internal/policy/equivalence"
 	validate_utils "github.com/conforma/cli/internal/validate"
 	"github.com/conforma/cli/internal/validate/vsa"
 )
-
-// ValidationResult represents the result of VSA validation
-type ValidationResult struct {
-	Passed  bool   `json:"passed"`
-	Message string `json:"message,omitempty"`
-}
-
-// IdentifierType represents the type of VSA identifier
-type IdentifierType int
-
-const (
-	// IdentifierFile represents a local file path (absolute, relative, or files with extensions)
-	IdentifierFile IdentifierType = iota
-	// IdentifierImageDigest represents a container image digest (e.g., sha256:abc123...)
-	IdentifierImageDigest
-	// IdentifierImageReference represents a container image reference (e.g., nginx:latest, registry.io/repo:tag)
-	IdentifierImageReference
-)
-
-// ComponentResult represents the validation result for a snapshot component
-type ComponentResult struct {
-	ComponentName string
-	ImageRef      string
-	Result        *ValidationResult
-	Error         error
-}
 
 // validateVSAData holds the command data
 type validateVSAData struct {
@@ -87,6 +51,10 @@ type validateVSAData struct {
 	// VSA options
 	vsaExpirationStr string        // VSA expiration threshold as string
 	vsaExpiration    time.Duration // VSA expiration threshold as duration
+
+	// Signature verification options
+	ignoreSignatureVerification bool   // Whether to ignore signature verification (default: false, so signature is verified by default)
+	publicKeyPath               string // Path to public key for verification
 
 	// Output options
 	output     []string // Output formats
@@ -120,6 +88,9 @@ func NewValidateVSACmd() *cobra.Command {
 		Long: hd.Doc(`
 			Validate VSA by comparing the embedded policy against a supplied policy configuration.
 			
+			By default, VSA signature verification is enabled and requires a public key.
+			Use --ignore-signature-verification to disable signature verification.
+			
 			Supports validation of:
 			- Single VSA by identifier (image digest, file path)
 			- Multiple VSAs from application snapshot
@@ -130,7 +101,7 @@ func NewValidateVSACmd() *cobra.Command {
 			- Multiple backends with fallback
 		`),
 		// Check positional arguments
-		// Example: ec validate vsa image1@sha256:abc123 --policy policy.yaml
+		// Example: ec validate vsa image1@sha256:abc123 --policy policy.yaml --public-key key.pub
 		Args: func(cmd *cobra.Command, args []string) error {
 			// Custom argument validation using Cobra's Args field
 			if len(args) > 1 {
@@ -140,7 +111,7 @@ func NewValidateVSACmd() *cobra.Command {
 			// Validate VSA identifier format if provided
 			if len(args) == 1 {
 				identifier := args[0]
-				if !isValidVSAIdentifier(identifier) {
+				if !vsa.IsValidVSAIdentifier(identifier) {
 					return fmt.Errorf("invalid VSA identifier format: %s", identifier)
 				}
 			}
@@ -160,45 +131,25 @@ func NewValidateVSACmd() *cobra.Command {
 	return cmd
 }
 
-// addVSAFlags adds all the command flags with enhanced validation
+// addVSAFlags adds all the command flags with Cobra's built-in validation
 func addVSAFlags(cmd *cobra.Command, data *validateVSAData) {
 	// Input options
 	cmd.Flags().StringVarP(&data.vsaIdentifier, "vsa", "v", "", "VSA identifier (image digest, file path)")
 	cmd.Flags().StringVar(&data.images, "images", "", "Application snapshot file")
 	cmd.Flags().StringVarP(&data.policyConfig, "policy", "p", "", "Policy configuration")
 
-	// Mark required flags
-	if err := cmd.MarkFlagRequired("policy"); err != nil {
-		log.Warnf("Failed to mark policy flag as required: %v", err)
-	}
-
-	// Add flag validation annotations for better error messages
-	if err := cmd.Flags().SetAnnotation("vsa", "validation", []string{"identifier"}); err != nil {
-		log.Warnf("Failed to set annotation for vsa flag: %v", err)
-	}
-	if err := cmd.Flags().SetAnnotation("images", "validation", []string{"file"}); err != nil {
-		log.Warnf("Failed to set annotation for images flag: %v", err)
-	}
-	if err := cmd.Flags().SetAnnotation("policy", "validation", []string{"required"}); err != nil {
-		log.Warnf("Failed to set annotation for policy flag: %v", err)
-	}
-
 	// VSA retrieval options
 	cmd.Flags().StringSliceVar(&data.vsaRetrieval, "vsa-retrieval", []string{}, "VSA retrieval backends (rekor@, file@)")
-
-	// Add validation for VSA retrieval backends
-	if err := cmd.Flags().SetAnnotation("vsa-retrieval", "validation", []string{"backend"}); err != nil {
-		log.Warnf("Failed to set annotation for vsa-retrieval flag: %v", err)
-	}
 
 	// Policy comparison options
 	cmd.Flags().StringVar(&data.effectiveTime, "effective-time", "now", "Effective time for comparison")
 
-	// VSA options with custom validation
+	// VSA options
 	cmd.Flags().StringVar(&data.vsaExpirationStr, "vsa-expiration", "168h", "VSA expiration threshold (e.g., 24h, 7d, 1w, 1m)")
-	if err := cmd.Flags().SetAnnotation("vsa-expiration", "validation", []string{"duration"}); err != nil {
-		log.Warnf("Failed to set annotation for vsa-expiration flag: %v", err)
-	}
+
+	// Signature verification options
+	cmd.Flags().BoolVar(&data.ignoreSignatureVerification, "ignore-signature-verification", false, "Ignore VSA signature verification (signature verification is enabled by default)")
+	cmd.Flags().StringVar(&data.publicKeyPath, "public-key", "", "Path to public key for signature verification (required by default)")
 
 	// Output options
 	cmd.Flags().StringSliceVar(&data.output, "output", []string{}, "Output formats")
@@ -211,6 +162,17 @@ func addVSAFlags(cmd *cobra.Command, data *validateVSAData) {
 	// Output formatting options
 	cmd.Flags().BoolVar(&data.noColor, "no-color", false, "Disable color when using text output even when the current terminal supports it")
 	cmd.Flags().BoolVar(&data.forceColor, "color", false, "Enable color when using text output even when the current terminal does not support it")
+
+	// ===== COBRA BUILT-IN VALIDATION =====
+
+	// 1. Required flags
+	if err := cmd.MarkFlagRequired("policy"); err != nil {
+		log.Warnf("Failed to mark policy flag as required: %v", err)
+	}
+
+	// 2. Mutual exclusivity: --vsa and --images are mutually exclusive
+	cmd.MarkFlagsMutuallyExclusive("vsa", "images")
+
 }
 
 // runValidateVSA is the main command execution function
@@ -228,9 +190,11 @@ func runValidateVSA(cmd *cobra.Command, data *validateVSAData, args []string) er
 	}
 
 	// Create VSA retriever
-	if err := createVSARetriever(data); err != nil {
+	retriever, err := vsa.CreateVSARetriever(data.vsaRetrieval, data.vsaIdentifier, data.images)
+	if err != nil {
 		return err
 	}
+	data.retriever = retriever
 
 	// Process validation
 	// Images is a snapshot
@@ -249,14 +213,9 @@ func validateVSAInput(data *validateVSAData, args []string) error {
 		data.vsaIdentifier = args[0]
 	}
 
-	// Check if we have either VSA identifier or images (mutual exclusivity validation)
+	// Check if we have either VSA identifier, --vsa, or --images
 	if data.vsaIdentifier == "" && data.images == "" {
 		return fmt.Errorf("either --vsa, --images, or VSA identifier must be provided")
-	}
-
-	// Check mutual exclusivity: can't have both --vsa and --images
-	if data.vsaIdentifier != "" && data.images != "" {
-		return fmt.Errorf("--vsa and --images are mutually exclusive")
 	}
 
 	// Validate VSA expiration format early
@@ -264,203 +223,23 @@ func validateVSAInput(data *validateVSAData, args []string) error {
 		return fmt.Errorf("invalid --vsa-expiration: %w", err)
 	}
 
+	// Validate signature verification flags
+	// By default, signature verification is enabled, so public-key is required unless --ignore-signature-verification is set
+	if !data.ignoreSignatureVerification && data.publicKeyPath == "" {
+		return fmt.Errorf("--public-key is required for signature verification (use --ignore-signature-verification to disable signature verification)")
+	}
+
 	return nil
-}
-
-// detectIdentifierType detects the type of VSA identifier
-func detectIdentifierType(identifier string) IdentifierType {
-	if isImageDigest(identifier) {
-		return IdentifierImageDigest
-	}
-
-	// Try image reference parse first; it's authoritative for registries
-	if _, err := name.ParseReference(identifier); err == nil {
-		return IdentifierImageReference
-	}
-
-	// Check if it's a file path using the dedicated function
-	if isFilePath(identifier) {
-		return IdentifierFile
-	}
-
-	// last resort: keep as reference so users can pass bare names like "nginx:latest"
-	if _, err := name.ParseReference("docker.io/library/" + identifier); err == nil {
-		return IdentifierImageReference
-	}
-	return IdentifierFile
-}
-
-// isFilePath checks if the identifier is a file path
-func isFilePath(identifier string) bool {
-	// If it contains @ or :, it's likely an image reference, not a file
-	if strings.Contains(identifier, "@") || strings.Contains(identifier, ":") {
-		return false
-	}
-
-	// Check if it's an absolute path
-	if filepath.IsAbs(identifier) {
-		return true
-	}
-
-	// Check if it's a relative path (./ or ../)
-	if strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
-		return true
-	}
-
-	// Check if it's a relative path that exists
-	if _, err := os.Stat(identifier); err == nil {
-		return true
-	}
-
-	// Check if it looks like a file path (contains path separators)
-	if strings.Contains(identifier, "/") || strings.Contains(identifier, "\\") {
-		return true
-	}
-
-	// Check if it has a file extension
-	if filepath.Ext(identifier) != "" {
-		return true
-	}
-
-	// If it doesn't look like a file path and doesn't contain special characters,
-	// it might be a simple filename, but we need to be more careful
-	return false
-}
-
-// isImageDigest checks if the identifier is an image digest
-func isImageDigest(identifier string) bool {
-	// Image digests typically start with sha256: or sha512:
-	digestRegex := regexp.MustCompile(`^sha(256|512):[a-f0-9]+$`)
-	return digestRegex.MatchString(identifier)
-}
-
-// isImageReference checks if the identifier is an image reference
-func isImageReference(identifier string) bool {
-	// First check if it's an image digest (more specific)
-	if isImageDigest(identifier) {
-		return false
-	}
-
-	// First check if it's clearly not an image reference
-	if filepath.IsAbs(identifier) || strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
-		return false
-	}
-
-	// Check if it has a file extension (likely a file, not an image)
-	if filepath.Ext(identifier) != "" {
-		return false
-	}
-
-	// Check if it looks like a digest (starts with sha)
-	if strings.HasPrefix(identifier, "sha") {
-		return false
-	}
-
-	// Try to parse as a container registry reference
-	_, err := name.ParseReference(identifier)
-	if err != nil {
-		return false
-	}
-
-	// Additional validation: make sure it's not just a single word with a colon
-	// (like "invalid:" or "sha128:abc123") but allow Docker Hub references
-	if !strings.Contains(identifier, "/") && strings.Contains(identifier, ":") {
-		// Check if it starts with "sha" (invalid digest format)
-		if strings.HasPrefix(identifier, "sha") {
-			return false
-		}
-		// Check if it's just a single word with colon (like "invalid:")
-		parts := strings.Split(identifier, ":")
-		if len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0 {
-			// This could be a valid Docker Hub reference like "nginx:latest"
-			return true
-		}
-		// Single word with colon but no value after colon is invalid
-		return false
-	}
-
-	// Additional validation: reject identifiers that look like digests but aren't valid
-	// This catches cases like "sha128:abc123" that pass ParseReference but aren't valid
-	if strings.HasPrefix(identifier, "sha") && strings.Contains(identifier, ":") {
-		// Check if it's a valid digest format
-		if !isImageDigest(identifier) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isValidVSAIdentifier validates VSA identifier format
-func isValidVSAIdentifier(identifier string) bool {
-	// Basic validation for VSA identifier
-	if len(identifier) == 0 {
-		return false
-	}
-
-	// Check if it's a valid identifier type
-	identifierType := detectIdentifierType(identifier)
-	switch identifierType {
-	case IdentifierFile:
-		// For file paths, check if it exists or looks like a valid path
-		// Note: File paths with spaces are valid in many file systems
-		if filepath.IsAbs(identifier) || strings.HasPrefix(identifier, "./") || strings.HasPrefix(identifier, "../") {
-			return true
-		}
-		if _, err := os.Stat(identifier); err == nil {
-			return true
-		}
-		// heuristics: has path sep or ext → likely a file
-		return strings.ContainsAny(identifier, "/\\") || filepath.Ext(identifier) != ""
-	case IdentifierImageDigest:
-		// For image digests, validate the format
-		return isImageDigest(identifier)
-	case IdentifierImageReference:
-		// For image references, validate using go-containerregistry
-		// This will automatically reject identifiers with spaces
-		_, err := name.ParseReference(identifier)
-		return err == nil
-	default:
-		// If we can't determine the type, it's invalid
-		return false
-	}
 }
 
 // parseVSAExpiration parses the VSA expiration string into a duration
 func parseVSAExpiration(data *validateVSAData) error {
-	expiration, err := parseVSAExpirationDuration(data.vsaExpirationStr)
+	expiration, err := vsa.ParseVSAExpirationDuration(data.vsaExpirationStr)
 	if err != nil {
 		return fmt.Errorf("invalid VSA expiration: %w", err)
 	}
 	data.vsaExpiration = expiration
 	return nil
-}
-
-// parseVSAExpirationDuration parses a duration string with support for h, d, w, m suffixes
-func parseVSAExpirationDuration(s string) (time.Duration, error) {
-	s = strings.TrimSpace(s)
-	switch {
-	case strings.HasSuffix(s, "mo"): // non-standard but unambiguous
-		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "mo"), 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid months: %w", err)
-		}
-		return time.Duration(n*30*24) * time.Hour, nil
-	case strings.HasSuffix(s, "d"):
-		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "d"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return time.Duration(n*24) * time.Hour, nil
-	case strings.HasSuffix(s, "w"):
-		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "w"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return time.Duration(n*7*24) * time.Hour, nil
-	default:
-		return time.ParseDuration(s) // supports h, m, s, etc.
-	}
 }
 
 // loadPolicyConfig loads the policy configuration from multiple sources
@@ -472,7 +251,7 @@ func loadPolicyConfig(ctx context.Context, data *validateVSAData) error {
 	}
 
 	// Parse the policy configuration string into EnterpriseContractPolicySpec
-	policySpec, err := parsePolicySpec(policyConfig)
+	policySpec, err := vsa.ParsePolicySpec(policyConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse policy: %w", err)
 	}
@@ -481,275 +260,6 @@ func loadPolicyConfig(ctx context.Context, data *validateVSAData) error {
 	data.policySpec = policySpec
 
 	return nil
-}
-
-// convertYAMLToJSON converts YAML interface{} types to proper types for JSON marshaling
-func convertYAMLToJSON(data interface{}) interface{} {
-	switch v := data.(type) {
-	case map[interface{}]interface{}:
-		result := make(map[string]interface{})
-		for k, val := range v {
-			if strKey, ok := k.(string); ok {
-				result[strKey] = convertYAMLToJSON(val)
-			}
-		}
-		return result
-	case []interface{}:
-		result := make([]interface{}, len(v))
-		for i, val := range v {
-			result[i] = convertYAMLToJSON(val)
-		}
-		return result
-	case map[string]interface{}:
-		result := make(map[string]interface{})
-		for k, val := range v {
-			result[k] = convertYAMLToJSON(val)
-		}
-		return result
-	default:
-		return v
-	}
-}
-
-// parsePolicySpec parses a policy configuration string to extract the EnterpriseContractPolicySpec
-func parsePolicySpec(policyConfig string) (ecapi.EnterpriseContractPolicySpec, error) {
-	content := []byte(policyConfig)
-
-	// Convert YAML to JSON first to handle ruleData field mapping correctly
-	var yamlData map[string]interface{}
-	if err := yaml.Unmarshal(content, &yamlData); err != nil {
-		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to parse YAML: %w", err)
-	}
-
-	// Convert interface{} types to proper types for JSON marshaling
-	jsonData := convertYAMLToJSON(yamlData)
-
-	// Convert to JSON bytes
-	jsonBytes, err := json.Marshal(jsonData)
-	if err != nil {
-		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to convert YAML to JSON: %w", err)
-	}
-
-	// Now parse as JSON which should handle ruleData field mapping correctly
-	var ecp ecapi.EnterpriseContractPolicy
-	if err := json.Unmarshal(jsonBytes, &ecp); err == nil && ecp.APIVersion != "" {
-		// Check if this is actually a valid CRD (has required fields)
-		if ecp.APIVersion == "" || ecp.Kind == "" {
-			// This is not a valid CRD, try parsing as EnterpriseContractPolicySpec
-			var spec ecapi.EnterpriseContractPolicySpec
-			if err := json.Unmarshal(jsonBytes, &spec); err != nil {
-				return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
-			}
-			return spec, nil
-		}
-		return ecp.Spec, nil
-	}
-
-	// If parsing as EnterpriseContractPolicy fails, try as EnterpriseContractPolicySpec
-	var spec ecapi.EnterpriseContractPolicySpec
-	if err := json.Unmarshal(jsonBytes, &spec); err != nil {
-		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
-	}
-	return spec, nil
-}
-
-// createVSARetriever creates the VSA retriever based on flags and identifier type
-func createVSARetriever(data *validateVSAData) error {
-	// If explicit retrieval backends are specified, use VSA library
-	if len(data.vsaRetrieval) > 0 {
-		retriever := vsa.CreateRetrieverFromUploadFlags(data.vsaRetrieval)
-		if retriever == nil {
-			return fmt.Errorf("no valid retriever found from flags: %v", data.vsaRetrieval)
-		}
-		data.retriever = retriever
-		return nil
-	}
-
-	// Auto-detect retriever based on identifier type
-	if data.vsaIdentifier != "" {
-		identifierType := detectIdentifierType(data.vsaIdentifier)
-		switch identifierType {
-		case IdentifierFile:
-			data.retriever = vsa.NewFileVSARetrieverWithOSFs(".")
-		case IdentifierImageDigest, IdentifierImageReference:
-			// Use VSA library to create Rekor retriever for image-based identifiers
-			retriever := vsa.CreateRetrieverFromUploadFlags([]string{"rekor"})
-			if retriever == nil {
-				return fmt.Errorf("failed to create Rekor retriever")
-			}
-			data.retriever = retriever
-		default:
-			return fmt.Errorf("unsupported identifier type for VSA: %s", data.vsaIdentifier)
-		}
-		return nil
-	}
-
-	// For snapshot validation, always use Rekor retriever
-	if data.images != "" {
-		retriever := vsa.CreateRetrieverFromUploadFlags([]string{"rekor"})
-		if retriever == nil {
-			return fmt.Errorf("failed to create Rekor retriever")
-		}
-		data.retriever = retriever
-		return nil
-	}
-
-	// Default to file retriever for backward compatibility
-	data.retriever = vsa.NewFileVSARetrieverWithOSFs(".")
-	return nil
-}
-
-// validateVSAWithPolicyComparison validates a VSA by comparing its policy with the supplied policy
-func validateVSAWithPolicyComparison(ctx context.Context, identifier string, data *validateVSAData) (*ValidationResult, error) {
-	// Use VSA library's VSAChecker for efficient VSA validation
-	checker := vsa.NewVSAChecker(data.retriever)
-
-	// Check existing VSA using library's CheckExistingVSA method
-	result, err := checker.CheckExistingVSA(ctx, identifier, data.vsaExpiration)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check existing VSA: %w", err)
-	}
-
-	if !result.Found {
-		return &ValidationResult{
-			Passed:  false,
-			Message: "No VSA found for the specified identifier",
-		}, nil
-	}
-
-	if result.Expired {
-		days := int(math.Ceil(time.Since(result.Timestamp).Hours() / 24))
-		return &ValidationResult{
-			Passed:  false,
-			Message: fmt.Sprintf("VSA expired %d day(s) ago", days),
-		}, nil
-	}
-
-	// Extract policy from VSA predicate
-	vsaPolicy, err := extractPolicyFromVSA(result.VSA)
-	if err != nil {
-		return &ValidationResult{
-			Passed:  false,
-			Message: err.Error(),
-		}, nil
-	}
-
-	// Compare policies if supplied policy is provided
-	if len(data.policySpec.Sources) > 0 {
-		// Parse effective time
-		effectiveTime, err := parseEffectiveTime(data.effectiveTime)
-		if err != nil {
-			return &ValidationResult{
-				Passed:  false,
-				Message: fmt.Sprintf("invalid effective time: %v", err),
-			}, nil
-		}
-
-		// Create image info for volatile config matching
-		imageInfo := &equivalence.ImageInfo{
-			Digest: extractImageDigest(identifier),
-			Ref:    identifier,
-		}
-
-		// Compare policies with detailed error reporting
-		equivalent, differences, err := compareVSAPolicyWithDetails(vsaPolicy, data.policySpec, effectiveTime, imageInfo)
-		if err != nil {
-			return &ValidationResult{
-				Passed:  false,
-				Message: fmt.Sprintf("policy comparison failed: %v", err),
-			}, nil
-		}
-
-		if !equivalent {
-			return &ValidationResult{
-				Passed:  false,
-				Message: formatPolicyDifferences(differences),
-			}, nil
-		}
-	}
-
-	// Return success result
-	return &ValidationResult{
-		Passed:  true,
-		Message: "Policy matches",
-	}, nil
-}
-
-// extractPolicyFromVSA extracts the policy from VSA predicate
-func extractPolicyFromVSA(predicate *vsa.Predicate) (ecapi.EnterpriseContractPolicySpec, error) {
-	// Check if predicate has a Policy field
-	if predicate == nil {
-		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate is nil")
-	}
-
-	// Check if policy has any sources
-	if len(predicate.Policy.Sources) == 0 {
-		log.Debugf("VSA predicate policy sources: %+v", predicate.Policy.Sources)
-		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate does not contain policy sources")
-	}
-
-	log.Debugf("VSA predicate contains policy with %d sources", len(predicate.Policy.Sources))
-	return predicate.Policy, nil
-}
-
-// compareVSAPolicyWithDetails compares VSA policy with supplied policy and returns detailed differences
-func compareVSAPolicyWithDetails(vsaPolicy ecapi.EnterpriseContractPolicySpec, suppliedPolicy ecapi.EnterpriseContractPolicySpec, effectiveTime time.Time, imageInfo *equivalence.ImageInfo) (bool, []equivalence.PolicyDifference, error) {
-	checker := equivalence.NewEquivalenceChecker(effectiveTime, imageInfo)
-
-	equivalent, differences, err := checker.AreEquivalentWithDifferences(vsaPolicy, suppliedPolicy)
-	if err != nil {
-		return false, nil, fmt.Errorf("policy comparison failed: %w", err)
-	}
-
-	return equivalent, differences, nil
-}
-
-// formatPolicyDifferences formats policy differences using unified diff format
-func formatPolicyDifferences(differences []equivalence.PolicyDifference) string {
-	if len(differences) == 0 {
-		return "VSA policy does not match supplied policy (no specific differences identified)"
-	}
-
-	// Count different types of changes for the header
-	added, removed, changed := 0, 0, 0
-	for _, diff := range differences {
-		switch diff.Kind {
-		case equivalence.DiffAdded:
-			added++
-		case equivalence.DiffRemoved:
-			removed++
-		case equivalence.DiffChanged:
-			changed++
-		}
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("❌ Policy mismatch detected — %d added, %d removed, %d changed; %d differences\n",
-		added, removed, changed, len(differences)))
-
-	// Generate unified diff output
-	checker := &equivalence.EquivalenceChecker{}
-	unifiedDiff := checker.GenerateUnifiedDiffOutputWithLabels(differences, "VSA Policy", "Release Policy")
-	sb.WriteString(unifiedDiff)
-
-	return sb.String()
-}
-
-// parseEffectiveTime parses the effective time string
-func parseEffectiveTime(effectiveTime string) (time.Time, error) {
-	switch effectiveTime {
-	case "now":
-		return time.Now().UTC(), nil
-	default:
-		return time.Parse(time.RFC3339, effectiveTime)
-	}
-}
-
-// extractImageDigest extracts image digest from identifier
-func extractImageDigest(identifier string) string {
-	// For now, return the identifier as-is
-	// TODO: Implement proper digest extraction logic
-	return identifier
 }
 
 // validateSingleVSA validates a single VSA
@@ -763,7 +273,15 @@ func validateSingleVSA(ctx context.Context, data *validateVSAData, args []string
 	fmt.Printf("Policy: %s\n", data.policyConfig)
 
 	// Validate VSA with policy comparison
-	result, err := validateVSAWithPolicyComparison(ctx, identifier, data)
+	validationData := &vsa.ValidationData{
+		Retriever:                   data.retriever,
+		VSAExpiration:               data.vsaExpiration,
+		IgnoreSignatureVerification: data.ignoreSignatureVerification,
+		PublicKeyPath:               data.publicKeyPath,
+		PolicySpec:                  data.policySpec,
+		EffectiveTime:               data.effectiveTime,
+	}
+	result, err := vsa.ValidateVSAWithPolicyComparison(ctx, identifier, validationData)
 	if err != nil {
 		return fmt.Errorf("VSA validation failed: %w", err)
 	}
@@ -772,6 +290,11 @@ func validateSingleVSA(ctx context.Context, data *validateVSAData, args []string
 		fmt.Println("✅ VSA validation passed")
 		if result.Message != "" {
 			fmt.Printf("   %s\n", result.Message)
+		}
+		if result.SignatureVerified {
+			fmt.Println("   🔐 Signature verified")
+		} else if !data.ignoreSignatureVerification {
+			fmt.Println("   ⚠️  Signature verification requested but not performed")
 		}
 	} else {
 		fmt.Println("❌ VSA validation failed")
@@ -787,7 +310,7 @@ func validateSingleVSA(ctx context.Context, data *validateVSAData, args []string
 }
 
 // worker processes components from the jobs channel and sends results to the results channel
-func worker(jobs <-chan app.SnapshotComponent, results chan<- ComponentResult, ctx context.Context, data *validateVSAData) {
+func worker(jobs <-chan app.SnapshotComponent, results chan<- vsa.ComponentResult, ctx context.Context, data *validateVSAData) {
 	for component := range jobs {
 		result := processSnapshotComponent(ctx, component, data)
 		results <- result
@@ -819,7 +342,7 @@ func validateSnapshotVSAs(ctx context.Context, data *validateVSAData) error {
 
 	// Create channels for parallel processing
 	jobs := make(chan app.SnapshotComponent, numComponents)
-	results := make(chan ComponentResult, numComponents)
+	results := make(chan vsa.ComponentResult, numComponents)
 
 	// Start workers
 	for i := 0; i < numWorkers; i++ {
@@ -833,7 +356,7 @@ func validateSnapshotVSAs(ctx context.Context, data *validateVSAData) error {
 	close(jobs)
 
 	// Collect results
-	var allResults []ComponentResult
+	var allResults []vsa.ComponentResult
 	var allErrors error
 	var successCount, failureCount int
 
@@ -867,7 +390,17 @@ func validateSnapshotVSAs(ctx context.Context, data *validateVSAData) error {
 			fmt.Printf("  ❌ Failed: %v\n", result.Error)
 		} else if result.Result != nil && result.Result.Passed {
 			fmt.Printf("  ✅ Passed: %s\n", result.Result.Message)
+			if result.Result.SignatureVerified {
+				fmt.Println("   🔐 Signature verified")
+			} else if !data.ignoreSignatureVerification {
+				fmt.Println("   ⚠️  Signature verification requested but not performed")
+			}
 		} else if result.Result != nil && !result.Result.Passed {
+			if result.Result.SignatureVerified {
+				fmt.Println("  🔐 Signature verified")
+			} else if !data.ignoreSignatureVerification {
+				fmt.Println("  ⚠️  Signature verification requested but not performed")
+			}
 			fmt.Printf("  ❌ Failed: %s\n", result.Result.Message)
 		}
 	}
@@ -893,11 +426,11 @@ func validateSnapshotVSAs(ctx context.Context, data *validateVSAData) error {
 }
 
 // processSnapshotComponent processes a single snapshot component
-func processSnapshotComponent(ctx context.Context, component app.SnapshotComponent, data *validateVSAData) ComponentResult {
+func processSnapshotComponent(ctx context.Context, component app.SnapshotComponent, data *validateVSAData) vsa.ComponentResult {
 	// Extract digest from ContainerImage
-	digest, err := extractDigestFromImageRef(component.ContainerImage)
+	digest, err := vsa.ExtractDigestFromImageRef(component.ContainerImage)
 	if err != nil {
-		return ComponentResult{
+		return vsa.ComponentResult{
 			ComponentName: component.Name,
 			ImageRef:      component.ContainerImage,
 			Error:         fmt.Errorf("failed to extract digest: %w", err),
@@ -905,38 +438,27 @@ func processSnapshotComponent(ctx context.Context, component app.SnapshotCompone
 	}
 
 	// Validate VSA with policy comparison
-	result, err := validateVSAWithPolicyComparison(ctx, digest, data)
+	validationData := &vsa.ValidationData{
+		Retriever:                   data.retriever,
+		VSAExpiration:               data.vsaExpiration,
+		IgnoreSignatureVerification: data.ignoreSignatureVerification,
+		PublicKeyPath:               data.publicKeyPath,
+		PolicySpec:                  data.policySpec,
+		EffectiveTime:               data.effectiveTime,
+	}
+	result, err := vsa.ValidateVSAWithPolicyComparison(ctx, digest, validationData)
 	if err != nil {
-		return ComponentResult{
+		return vsa.ComponentResult{
 			ComponentName: component.Name,
 			ImageRef:      component.ContainerImage,
 			Error:         fmt.Errorf("VSA validation failed: %w", err),
 		}
 	}
 
-	return ComponentResult{
+	return vsa.ComponentResult{
 		ComponentName: component.Name,
 		ImageRef:      component.ContainerImage,
 		Result:        result,
 		Error:         nil,
 	}
-}
-
-// extractDigestFromImageRef extracts the digest from an image reference
-func extractDigestFromImageRef(imageRef string) (string, error) {
-	// Parse the image reference
-	ref, err := name.ParseReference(imageRef)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
-	}
-
-	// Check if it's already a digest reference
-	if digestRef, ok := ref.(name.Digest); ok {
-		return digestRef.DigestStr(), nil
-	}
-
-	// For tag references, we need to resolve to digest
-	// For now, return the image reference as-is and let the retriever handle it
-	// In a full implementation, this would resolve the tag to a digest
-	return imageRef, nil
 }

--- a/docs/modules/ROOT/pages/ec_validate_vsa.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_vsa.adoc
@@ -6,6 +6,9 @@ Validate VSA (Verification Summary Attestation)
 
 Validate VSA by comparing the embedded policy against a supplied policy configuration.
 
+By default, VSA signature verification is enabled and requires a public key.
+Use --ignore-signature-verification to disable signature verification.
+
 Supports validation of:
 - Single VSA by identifier (image digest, file path)
 - Multiple VSAs from application snapshot
@@ -24,11 +27,13 @@ ec validate vsa <vsa-identifier> [flags]
 --color:: Enable color when using text output even when the current terminal does not support it (Default: false)
 --effective-time:: Effective time for comparison (Default: now)
 -h, --help:: help for vsa (Default: false)
+--ignore-signature-verification:: Ignore VSA signature verification (signature verification is enabled by default) (Default: false)
 --images:: Application snapshot file
 --no-color:: Disable color when using text output even when the current terminal supports it (Default: false)
 --output:: Output formats (Default: [])
 -o, --output-file:: Output file
 -p, --policy:: Policy configuration
+--public-key:: Path to public key for signature verification (required by default)
 --strict:: Exit with non-zero code if validation fails (Default: true)
 -v, --vsa:: VSA identifier (image digest, file path)
 --vsa-expiration:: VSA expiration threshold (e.g., 24h, 7d, 1w, 1m) (Default: 168h)

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ replace github.com/google/go-containerregistry => github.com/conforma/go-contain
 require (
 	github.com/go-openapi/runtime v0.28.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.3
 )
 
@@ -386,7 +386,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	knative.dev/pkg v0.0.0-20240815051656-89743d9bbf7c // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect

--- a/internal/validate/vsa/policy.go
+++ b/internal/validate/vsa/policy.go
@@ -1,0 +1,67 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"encoding/json"
+	"fmt"
+
+	ecapi "github.com/conforma/crds/api/v1alpha1"
+	"gopkg.in/yaml.v3"
+)
+
+// ParsePolicySpec parses a policy configuration string to extract the EnterpriseContractPolicySpec
+func ParsePolicySpec(policyConfig string) (ecapi.EnterpriseContractPolicySpec, error) {
+	content := []byte(policyConfig)
+
+	// Convert YAML to JSON first to handle ruleData field mapping correctly
+	var yamlData map[string]interface{}
+	if err := yaml.Unmarshal(content, &yamlData); err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Convert interface{} types to proper types for JSON marshaling
+	jsonData := ConvertYAMLToJSON(yamlData)
+
+	// Convert to JSON bytes
+	jsonBytes, err := json.Marshal(jsonData)
+	if err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+	}
+
+	// Now parse as JSON which should handle ruleData field mapping correctly
+	var ecp ecapi.EnterpriseContractPolicy
+	if err := json.Unmarshal(jsonBytes, &ecp); err == nil && ecp.APIVersion != "" {
+		// Check if this is actually a valid CRD (has required fields)
+		if ecp.APIVersion == "" || ecp.Kind == "" {
+			// This is not a valid CRD, try parsing as EnterpriseContractPolicySpec
+			var spec ecapi.EnterpriseContractPolicySpec
+			if err := json.Unmarshal(jsonBytes, &spec); err != nil {
+				return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+			}
+			return spec, nil
+		}
+		return ecp.Spec, nil
+	}
+
+	// If parsing as EnterpriseContractPolicy fails, try as EnterpriseContractPolicySpec
+	var spec ecapi.EnterpriseContractPolicySpec
+	if err := json.Unmarshal(jsonBytes, &spec); err != nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("unable to parse EnterpriseContractPolicySpec: %w", err)
+	}
+	return spec, nil
+}

--- a/internal/validate/vsa/policy_test.go
+++ b/internal/validate/vsa/policy_test.go
@@ -1,0 +1,110 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParsePolicySpec tests the ParsePolicySpec function
+func TestParsePolicySpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		policyConfig string
+		expectError  bool
+		checkResult  func(t *testing.T, result interface{})
+	}{
+		{
+			name: "valid YAML policy spec",
+			policyConfig: `
+sources:
+  - name: policy
+`,
+			expectError: false,
+			checkResult: func(t *testing.T, result interface{}) {
+				// Just verify it parsed successfully
+				assert.NotNil(t, result)
+			},
+		},
+		{
+			name: "valid JSON policy spec",
+			policyConfig: `{
+  "sources": [
+    {
+      "name": "policy"
+    }
+  ]
+}`,
+			expectError: false,
+			checkResult: func(t *testing.T, result interface{}) {
+				assert.NotNil(t, result)
+			},
+		},
+		{
+			name: "valid YAML with CRD wrapper",
+			policyConfig: `
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: test-policy
+spec:
+  sources:
+    - name: policy
+`,
+			expectError: false,
+			checkResult: func(t *testing.T, result interface{}) {
+				assert.NotNil(t, result)
+			},
+		},
+		{
+			name: "invalid YAML",
+			policyConfig: `
+invalid: yaml: content: [unclosed
+`,
+			expectError: true,
+		},
+		{
+			name: "invalid JSON",
+			policyConfig: `{
+  "sources": [
+    {
+      "name": "policy"
+    }
+  ]
+  // missing closing brace
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParsePolicySpec(tt.policyConfig)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/validate/vsa/rekor_retriever_test.go
+++ b/internal/validate/vsa/rekor_retriever_test.go
@@ -258,12 +258,14 @@ func TestRekorVSARetriever_RetrieveVSA(t *testing.T) {
 	vsaStatement := `{"_type":"https://in-toto.io/Statement/v0.1","subject":[{"name":"test-image","digest":{"sha256":"abc123def456"}}],"predicateType":"https://conforma.dev/verification_summary/v1","predicate":{"test":"data"}}`
 
 	// Create in-toto 0.0.2 entry body
+	// The signature needs to be double-base64 encoded for the implementation
+	doubleEncodedSig := base64.StdEncoding.EncodeToString([]byte(base64.StdEncoding.EncodeToString([]byte("test"))))
 	intotoV002Body := `{
 		"spec": {
 			"content": {
 				"envelope": {
 					"payloadType": "application/vnd.in-toto+json",
-					"signatures": [{"sig": "dGVzdA==", "keyid": "test-key-id"}]
+					"signatures": [{"sig": "` + doubleEncodedSig + `", "keyid": "test-key-id"}]
 				}
 			}
 		}
@@ -276,7 +278,7 @@ func TestRekorVSARetriever_RetrieveVSA(t *testing.T) {
 				LogID:    &[]string{"intoto-v002-uuid"}[0],
 				Body:     base64.StdEncoding.EncodeToString([]byte(intotoV002Body)),
 				Attestation: &models.LogEntryAnonAttestation{
-					Data: strfmt.Base64(base64.StdEncoding.EncodeToString([]byte(vsaStatement))),
+					Data: strfmt.Base64([]byte(vsaStatement)), // Raw JSON, not base64 encoded
 				},
 			},
 		},

--- a/internal/validate/vsa/retriever.go
+++ b/internal/validate/vsa/retriever.go
@@ -1,0 +1,63 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"fmt"
+)
+
+// CreateVSARetriever creates the VSA retriever based on flags and identifier type
+func CreateVSARetriever(vsaRetrieval []string, vsaIdentifier string, images string) (VSARetriever, error) {
+	// If explicit retrieval backends are specified, use VSA library
+	if len(vsaRetrieval) > 0 {
+		retriever := CreateRetrieverFromUploadFlags(vsaRetrieval)
+		if retriever == nil {
+			return nil, fmt.Errorf("no valid retriever found from flags: %v", vsaRetrieval)
+		}
+		return retriever, nil
+	}
+
+	// Auto-detect retriever based on identifier type
+	if vsaIdentifier != "" {
+		identifierType := DetectIdentifierType(vsaIdentifier)
+		switch identifierType {
+		case IdentifierFile:
+			return NewFileVSARetrieverWithOSFs("."), nil
+		case IdentifierImageDigest, IdentifierImageReference:
+			// Use VSA library to create Rekor retriever for image-based identifiers
+			retriever := CreateRetrieverFromUploadFlags([]string{"rekor"})
+			if retriever == nil {
+				return nil, fmt.Errorf("failed to create Rekor retriever")
+			}
+			return retriever, nil
+		default:
+			return nil, fmt.Errorf("unsupported identifier type for VSA: %s", vsaIdentifier)
+		}
+	}
+
+	// For snapshot validation, always use Rekor retriever
+	if images != "" {
+		retriever := CreateRetrieverFromUploadFlags([]string{"rekor"})
+		if retriever == nil {
+			return nil, fmt.Errorf("failed to create Rekor retriever")
+		}
+		return retriever, nil
+	}
+
+	// Default to file retriever for backward compatibility
+	return NewFileVSARetrieverWithOSFs("."), nil
+}

--- a/internal/validate/vsa/retriever_test.go
+++ b/internal/validate/vsa/retriever_test.go
@@ -1,0 +1,132 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateVSARetriever tests the CreateVSARetriever function
+func TestCreateVSARetriever(t *testing.T) {
+	tests := []struct {
+		name           string
+		vsaRetrieval   []string
+		vsaIdentifier  string
+		images         string
+		expectError    bool
+		checkRetriever func(t *testing.T, retriever VSARetriever)
+	}{
+		{
+			name:          "explicit rekor retrieval",
+			vsaRetrieval:  []string{"rekor"},
+			vsaIdentifier: "",
+			images:        "",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "explicit file retrieval",
+			vsaRetrieval:  []string{"file"},
+			vsaIdentifier: "",
+			images:        "",
+			expectError:   true, // "file" is not a valid retrieval backend
+		},
+		{
+			name:          "file identifier auto-detection",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "/path/to/vsa.json",
+			images:        "",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "image digest identifier auto-detection",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "sha256:abc123def456789",
+			images:        "",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "image reference identifier auto-detection",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "registry.io/repo:tag",
+			images:        "",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "snapshot validation with images",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "",
+			images:        "snapshot.yaml",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "default file retriever",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "",
+			images:        "",
+			expectError:   false,
+			checkRetriever: func(t *testing.T, retriever VSARetriever) {
+				assert.NotNil(t, retriever)
+			},
+		},
+		{
+			name:          "invalid retrieval backend",
+			vsaRetrieval:  []string{"invalid"},
+			vsaIdentifier: "",
+			images:        "",
+			expectError:   true,
+		},
+		{
+			name:          "unsupported identifier type",
+			vsaRetrieval:  []string{},
+			vsaIdentifier: "invalid-identifier-format",
+			images:        "",
+			expectError:   false, // This will be detected as a file path
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			retriever, err := CreateVSARetriever(tt.vsaRetrieval, tt.vsaIdentifier, tt.images)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.checkRetriever != nil {
+					tt.checkRetriever(t, retriever)
+				}
+			}
+		})
+	}
+}

--- a/internal/validate/vsa/validator.go
+++ b/internal/validate/vsa/validator.go
@@ -1,0 +1,214 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	ecapi "github.com/conforma/crds/api/v1alpha1"
+
+	"github.com/conforma/cli/internal/policy/equivalence"
+)
+
+// ValidationData represents the data needed for VSA validation
+type ValidationData struct {
+	Retriever                   VSARetriever
+	VSAExpiration               time.Duration
+	IgnoreSignatureVerification bool
+	PublicKeyPath               string
+	PolicySpec                  ecapi.EnterpriseContractPolicySpec
+	EffectiveTime               string
+}
+
+// ValidateVSAWithPolicyComparison validates a VSA by comparing its policy with the supplied policy
+func ValidateVSAWithPolicyComparison(ctx context.Context, identifier string, data *ValidationData) (*ValidationResult, error) {
+	if data == nil {
+		return nil, fmt.Errorf("validation data cannot be nil")
+	}
+
+	if data.Retriever == nil {
+		return nil, fmt.Errorf("VSA retriever cannot be nil")
+	}
+
+	// Use VSA library's VSAChecker for efficient VSA validation
+	checker := NewVSAChecker(data.Retriever)
+
+	// SINGLE VSA RETRIEVAL with optional signature verification
+	result, err := checker.CheckExistingVSAWithVerification(
+		ctx,
+		identifier,
+		data.VSAExpiration,
+		!data.IgnoreSignatureVerification, // Whether to verify signature (inverse of ignore flag)
+		data.PublicKeyPath,                // Public key path (if signature verification requested)
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing VSA: %w", err)
+	}
+
+	if !result.Found {
+		return &ValidationResult{
+			Passed:            false,
+			Message:           "No VSA found for the specified identifier",
+			SignatureVerified: result.SignatureVerified,
+		}, nil
+	}
+
+	if result.Expired {
+		days := int(math.Ceil(time.Since(result.Timestamp).Hours() / 24))
+		return &ValidationResult{
+			Passed:            false,
+			Message:           fmt.Sprintf("VSA expired %d day(s) ago", days),
+			SignatureVerified: result.SignatureVerified,
+		}, nil
+	}
+
+	// If signature verification was requested and failed, the error would have been returned above
+	// If signature verification was requested and succeeded, we continue with policy comparison
+
+	// Extract policy from VSA predicate
+	vsaPolicy, err := ExtractPolicyFromVSA(result.VSA)
+	if err != nil {
+		return &ValidationResult{
+			Passed:            false,
+			Message:           err.Error(),
+			SignatureVerified: result.SignatureVerified,
+		}, nil
+	}
+
+	// Compare policies if supplied policy is provided
+	if len(data.PolicySpec.Sources) > 0 {
+		// Parse effective time
+		effectiveTime, err := ParseEffectiveTime(data.EffectiveTime)
+		if err != nil {
+			return &ValidationResult{
+				Passed:            false,
+				Message:           fmt.Sprintf("invalid effective time: %v", err),
+				SignatureVerified: result.SignatureVerified,
+			}, nil
+		}
+
+		// Create image info for volatile config matching
+		imageInfo := &equivalence.ImageInfo{
+			Digest: ExtractImageDigest(identifier),
+			Ref:    identifier,
+		}
+
+		// Compare policies with detailed error reporting
+		equivalent, differences, err := CompareVSAPolicyWithDetails(vsaPolicy, data.PolicySpec, effectiveTime, imageInfo)
+		if err != nil {
+			return &ValidationResult{
+				Passed:            false,
+				Message:           fmt.Sprintf("policy comparison failed: %v", err),
+				SignatureVerified: result.SignatureVerified,
+			}, nil
+		}
+
+		if !equivalent {
+			return &ValidationResult{
+				Passed:            false,
+				Message:           FormatPolicyDifferences(differences),
+				SignatureVerified: result.SignatureVerified,
+			}, nil
+		}
+	}
+
+	// Return success result
+	return &ValidationResult{
+		Passed:            true,
+		Message:           "Policy matches",
+		SignatureVerified: result.SignatureVerified,
+	}, nil
+}
+
+// ExtractPolicyFromVSA extracts the policy from VSA predicate
+func ExtractPolicyFromVSA(predicate *Predicate) (ecapi.EnterpriseContractPolicySpec, error) {
+	// Check if predicate has a Policy field
+	if predicate == nil {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate is nil")
+	}
+
+	// Check if policy has any sources
+	if len(predicate.Policy.Sources) == 0 {
+		return ecapi.EnterpriseContractPolicySpec{}, fmt.Errorf("VSA predicate does not contain policy sources")
+	}
+
+	return predicate.Policy, nil
+}
+
+// CompareVSAPolicyWithDetails compares VSA policy with supplied policy and returns detailed differences
+func CompareVSAPolicyWithDetails(vsaPolicy ecapi.EnterpriseContractPolicySpec, suppliedPolicy ecapi.EnterpriseContractPolicySpec, effectiveTime time.Time, imageInfo *equivalence.ImageInfo) (bool, []equivalence.PolicyDifference, error) {
+	checker := equivalence.NewEquivalenceChecker(effectiveTime, imageInfo)
+
+	equivalent, differences, err := checker.AreEquivalentWithDifferences(vsaPolicy, suppliedPolicy)
+	if err != nil {
+		return false, nil, fmt.Errorf("policy comparison failed: %w", err)
+	}
+
+	return equivalent, differences, nil
+}
+
+// FormatPolicyDifferences formats policy differences using unified diff format
+func FormatPolicyDifferences(differences []equivalence.PolicyDifference) string {
+	if len(differences) == 0 {
+		return "VSA policy does not match supplied policy (no specific differences identified)"
+	}
+
+	// Count different types of changes for the header
+	added, removed, changed := 0, 0, 0
+	for _, diff := range differences {
+		switch diff.Kind {
+		case equivalence.DiffAdded:
+			added++
+		case equivalence.DiffRemoved:
+			removed++
+		case equivalence.DiffChanged:
+			changed++
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("❌ Policy mismatch detected — %d added, %d removed, %d changed; %d differences\n",
+		added, removed, changed, len(differences)))
+
+	// Generate unified diff output
+	checker := &equivalence.EquivalenceChecker{}
+	unifiedDiff := checker.GenerateUnifiedDiffOutputWithLabels(differences, "VSA Policy", "Release Policy")
+	sb.WriteString(unifiedDiff)
+
+	return sb.String()
+}
+
+// ParseEffectiveTime parses the effective time string
+func ParseEffectiveTime(effectiveTime string) (time.Time, error) {
+	switch effectiveTime {
+	case "now":
+		return time.Now().UTC(), nil
+	default:
+		return time.Parse(time.RFC3339, effectiveTime)
+	}
+}
+
+// ExtractImageDigest extracts image digest from identifier
+func ExtractImageDigest(identifier string) string {
+	// For now, return the identifier as-is
+	// TODO: Implement proper digest extraction logic
+	return identifier
+}

--- a/internal/validate/vsa/validator_test.go
+++ b/internal/validate/vsa/validator_test.go
@@ -1,0 +1,745 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	ecapi "github.com/conforma/crds/api/v1alpha1"
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conforma/cli/internal/policy/equivalence"
+)
+
+// TestValidateVSAWithPolicyComparison tests the ValidateVSAWithPolicyComparison function
+func TestValidateVSAWithPolicyComparison(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		identifier    string
+		data          *ValidationData
+		mockRetriever *enhancedMockVSARetriever
+		expectError   bool
+		expectPassed  bool
+		expectMessage string
+	}{
+		{
+			name:        "nil validation data",
+			identifier:  "test-identifier",
+			data:        nil,
+			expectError: true,
+		},
+		{
+			name:       "nil retriever",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever: nil,
+			},
+			expectError: true,
+		},
+		{
+			name:       "VSA not found",
+			identifier: "not-found-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError: true, // The function returns an error when retriever fails
+		},
+		{
+			name:       "VSA expired",
+			identifier: "expired-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: true},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError:   false,
+			expectPassed:  false,
+			expectMessage: "VSA expired",
+		},
+		{
+			name:       "VSA found and valid - no policy comparison",
+			identifier: "valid-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+				PolicySpec:                  ecapi.EnterpriseContractPolicySpec{}, // Empty policy
+			},
+			expectError:   false,
+			expectPassed:  true,
+			expectMessage: "Policy matches",
+		},
+		{
+			name:       "VSA found with policy comparison - policies match",
+			identifier: "valid-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false, shouldMatchPolicy: true},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+				PolicySpec: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{Name: "test-source", Policy: []string{"test-policy"}},
+					},
+				},
+				EffectiveTime: "now",
+			},
+			expectError:   false,
+			expectPassed:  true,
+			expectMessage: "Policy matches",
+		},
+		{
+			name:       "VSA found with policy comparison - policies don't match",
+			identifier: "valid-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false, shouldMatchPolicy: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+				PolicySpec: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{Name: "test-source", Policy: []string{"different-policy"}},
+					},
+				},
+				EffectiveTime: "now",
+			},
+			expectError:   false,
+			expectPassed:  false,
+			expectMessage: "Policy mismatch detected",
+		},
+		{
+			name:       "invalid effective time",
+			identifier: "valid-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+				PolicySpec: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{Name: "test-source", Policy: []string{"test-policy"}},
+					},
+				},
+				EffectiveTime: "invalid-time",
+			},
+			expectError:   false,
+			expectPassed:  false,
+			expectMessage: "invalid effective time",
+		},
+		{
+			name:       "signature verification enabled",
+			identifier: "valid-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false, shouldVerifySignature: true},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: false,
+				PublicKeyPath:               "/path/to/public.key",
+			},
+			expectError: true, // This will fail because the public key file doesn't exist
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ValidateVSAWithPolicyComparison(ctx, tt.identifier, tt.data)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expectPassed, result.Passed)
+
+			if tt.expectMessage != "" {
+				assert.Contains(t, result.Message, tt.expectMessage)
+			}
+		})
+	}
+}
+
+// enhancedMockVSARetriever is an enhanced mock implementation of VSARetriever for testing
+type enhancedMockVSARetriever struct {
+	shouldFind            bool
+	shouldExpire          bool
+	shouldMatchPolicy     bool
+	shouldVerifySignature bool
+	shouldReturnError     bool
+	errorMessage          string
+}
+
+func (m *enhancedMockVSARetriever) RetrieveVSA(ctx context.Context, identifier string) (*ssldsse.Envelope, error) {
+	if m.shouldReturnError {
+		return nil, fmt.Errorf("%s", m.errorMessage)
+	}
+
+	if !m.shouldFind {
+		return nil, fmt.Errorf("no VSA found")
+	}
+
+	// Create a mock VSA predicate
+	predicate := &Predicate{
+		Policy: ecapi.EnterpriseContractPolicySpec{
+			Sources: []ecapi.Source{
+				{Name: "test-source", Policy: []string{"test-policy"}},
+			},
+		},
+		Timestamp: time.Now().Add(-25 * time.Hour).Format(time.RFC3339), // 25 hours ago
+	}
+
+	if !m.shouldExpire {
+		predicate.Timestamp = time.Now().Add(-1 * time.Hour).Format(time.RFC3339) // 1 hour ago
+	}
+
+	// Create mock DSSE envelope with proper base64-encoded payload
+	payload := `{"_type":"https://in-toto.io/Statement/v0.1","subject":[{"name":"test-image","digest":{"sha256":"abc123def456"}}],"predicateType":"https://conforma.dev/verification_summary/v1","predicate":{"policy":{"sources":[{"name":"test-source","policy":["test-policy"]}]},"timestamp":"` + predicate.Timestamp + `"}}`
+	encodedPayload := base64.StdEncoding.EncodeToString([]byte(payload))
+
+	envelope := &ssldsse.Envelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     encodedPayload,
+		Signatures: []ssldsse.Signature{
+			{
+				KeyID: "test-key-id",
+				Sig:   "test-signature",
+			},
+		},
+	}
+
+	return envelope, nil
+}
+
+// TestCompareVSAPolicyWithDetails tests the CompareVSAPolicyWithDetails function
+func TestCompareVSAPolicyWithDetails(t *testing.T) {
+	now := time.Now()
+	imageInfo := &equivalence.ImageInfo{
+		Digest: "sha256:test",
+		Ref:    "test-image:latest",
+	}
+
+	vsaPolicy := ecapi.EnterpriseContractPolicySpec{
+		Sources: []ecapi.Source{
+			{Name: "test-source", Policy: []string{"test-policy"}},
+		},
+	}
+
+	suppliedPolicy := ecapi.EnterpriseContractPolicySpec{
+		Sources: []ecapi.Source{
+			{Name: "test-source", Policy: []string{"test-policy"}},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		vsaPolicy      ecapi.EnterpriseContractPolicySpec
+		suppliedPolicy ecapi.EnterpriseContractPolicySpec
+		effectiveTime  time.Time
+		imageInfo      *equivalence.ImageInfo
+		expectError    bool
+		expectMatch    bool
+	}{
+		{
+			name:           "matching policies",
+			vsaPolicy:      vsaPolicy,
+			suppliedPolicy: suppliedPolicy,
+			effectiveTime:  now,
+			imageInfo:      imageInfo,
+			expectError:    false,
+			expectMatch:    true,
+		},
+		{
+			name:      "different policies",
+			vsaPolicy: vsaPolicy,
+			suppliedPolicy: ecapi.EnterpriseContractPolicySpec{
+				Sources: []ecapi.Source{
+					{Name: "different-source", Policy: []string{"different-policy"}},
+				},
+			},
+			effectiveTime: now,
+			imageInfo:     imageInfo,
+			expectError:   false,
+			expectMatch:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equivalent, differences, err := CompareVSAPolicyWithDetails(tt.vsaPolicy, tt.suppliedPolicy, tt.effectiveTime, tt.imageInfo)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectMatch, equivalent)
+
+			if !tt.expectMatch {
+				assert.NotEmpty(t, differences)
+			}
+		})
+	}
+}
+
+// TestFormatPolicyDifferences tests the FormatPolicyDifferences function
+func TestFormatPolicyDifferences(t *testing.T) {
+	tests := []struct {
+		name         string
+		differences  []equivalence.PolicyDifference
+		expectOutput string
+	}{
+		{
+			name:         "empty differences",
+			differences:  []equivalence.PolicyDifference{},
+			expectOutput: "VSA policy does not match supplied policy (no specific differences identified)",
+		},
+		{
+			name: "single difference",
+			differences: []equivalence.PolicyDifference{
+				{
+					Kind:    equivalence.DiffAdded,
+					Path:    equivalence.FieldPath{"test", "path"},
+					Summary: "test message",
+				},
+			},
+			expectOutput: "❌ Policy mismatch detected — 1 added, 0 removed, 0 changed; 1 differences",
+		},
+		{
+			name: "multiple differences",
+			differences: []equivalence.PolicyDifference{
+				{Kind: equivalence.DiffAdded, Path: equivalence.FieldPath{"test", "added"}, Summary: "added"},
+				{Kind: equivalence.DiffRemoved, Path: equivalence.FieldPath{"test", "removed"}, Summary: "removed"},
+				{Kind: equivalence.DiffChanged, Path: equivalence.FieldPath{"test", "changed"}, Summary: "changed"},
+			},
+			expectOutput: "❌ Policy mismatch detected — 1 added, 1 removed, 1 changed; 3 differences",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatPolicyDifferences(tt.differences)
+			assert.Contains(t, result, tt.expectOutput)
+		})
+	}
+}
+
+// TestValidateVSAWithPolicyComparison_EdgeCases tests edge cases for ValidateVSAWithPolicyComparison
+func TestValidateVSAWithPolicyComparison_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		identifier    string
+		data          *ValidationData
+		expectError   bool
+		expectPassed  bool
+		expectMessage string
+	}{
+		{
+			name:       "empty identifier",
+			identifier: "",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError: true, // The function returns an error when retriever fails
+		},
+		{
+			name:       "zero expiration threshold",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false},
+				VSAExpiration:               0, // No expiration
+				IgnoreSignatureVerification: true,
+			},
+			expectError:   false,
+			expectPassed:  true,
+			expectMessage: "Policy matches",
+		},
+		{
+			name:       "very long expiration threshold",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false},
+				VSAExpiration:               365 * 24 * time.Hour, // 1 year
+				IgnoreSignatureVerification: true,
+			},
+			expectError:   false,
+			expectPassed:  true,
+			expectMessage: "Policy matches",
+		},
+		{
+			name:       "retriever returns error",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldReturnError: true, errorMessage: "network error"},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError: true,
+		},
+		{
+			name:       "malformed VSA data",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false, shouldReturnError: true, errorMessage: "malformed VSA"},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError: true,
+		},
+		{
+			name:       "policy extraction fails",
+			identifier: "test-identifier",
+			data: &ValidationData{
+				Retriever:                   &enhancedMockVSARetriever{shouldFind: true, shouldExpire: false},
+				VSAExpiration:               24 * time.Hour,
+				IgnoreSignatureVerification: true,
+			},
+			expectError:   false,
+			expectPassed:  true, // The mock returns valid data, so this should pass
+			expectMessage: "Policy matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ValidateVSAWithPolicyComparison(ctx, tt.identifier, tt.data)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expectPassed, result.Passed)
+
+			if tt.expectMessage != "" {
+				assert.Contains(t, result.Message, tt.expectMessage)
+			}
+		})
+	}
+}
+
+// TestExtractPolicyFromVSA_EdgeCases tests edge cases for ExtractPolicyFromVSA
+func TestExtractPolicyFromVSA_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		predicate   *Predicate
+		expectError bool
+		expectEmpty bool
+	}{
+		{
+			name:        "predicate with nil policy",
+			predicate:   &Predicate{Policy: ecapi.EnterpriseContractPolicySpec{}},
+			expectError: true,
+		},
+		{
+			name: "predicate with empty sources",
+			predicate: &Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "predicate with valid policy",
+			predicate: &Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{Name: "test-source", Policy: []string{"test-policy"}},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "predicate with multiple sources",
+			predicate: &Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{
+					Sources: []ecapi.Source{
+						{Name: "source1", Policy: []string{"policy1"}},
+						{Name: "source2", Policy: []string{"policy2"}},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := ExtractPolicyFromVSA(tt.predicate)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, policy)
+
+			if !tt.expectEmpty {
+				assert.NotEmpty(t, policy.Sources)
+			}
+		})
+	}
+}
+
+// TestParseEffectiveTime_EdgeCases tests edge cases for ParseEffectiveTime
+func TestParseEffectiveTime_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		effectiveTime string
+		expectError   bool
+		checkResult   func(t *testing.T, result time.Time)
+	}{
+		{
+			name:          "whitespace around 'now'",
+			effectiveTime: "  now  ",
+			expectError:   true, // Should be exact match
+		},
+		{
+			name:          "case sensitive 'now'",
+			effectiveTime: "NOW",
+			expectError:   true, // Should be case sensitive
+		},
+		{
+			name:          "RFC3339 with nanoseconds",
+			effectiveTime: "2023-01-01T00:00:00.123456789Z",
+			expectError:   false,
+			checkResult: func(t *testing.T, result time.Time) {
+				expected := time.Date(2023, 1, 1, 0, 0, 0, 123456789, time.UTC)
+				assert.Equal(t, expected, result)
+			},
+		},
+		{
+			name:          "RFC3339 with timezone offset",
+			effectiveTime: "2023-01-01T00:00:00+05:00",
+			expectError:   false,
+			checkResult: func(t *testing.T, result time.Time) {
+				// Should be converted to UTC
+				expected := time.Date(2022, 12, 31, 19, 0, 0, 0, time.UTC)
+				assert.Equal(t, expected, result.UTC())
+			},
+		},
+		{
+			name:          "invalid date format",
+			effectiveTime: "01/01/2023",
+			expectError:   true,
+		},
+		{
+			name:          "future date",
+			effectiveTime: "2030-01-01T00:00:00Z",
+			expectError:   false,
+			checkResult: func(t *testing.T, result time.Time) {
+				expected := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+				assert.Equal(t, expected, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseEffectiveTime(tt.effectiveTime)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractImageDigest_EdgeCases tests edge cases for ExtractImageDigest
+func TestExtractImageDigest_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   string
+	}{
+		{
+			name:       "identifier with special characters",
+			identifier: "registry.io/repo:tag@sha256:abc123",
+			expected:   "registry.io/repo:tag@sha256:abc123",
+		},
+		{
+			name:       "identifier with port",
+			identifier: "registry.io:5000/repo:tag",
+			expected:   "registry.io:5000/repo:tag",
+		},
+		{
+			name:       "identifier with namespace",
+			identifier: "registry.io/namespace/repo:tag",
+			expected:   "registry.io/namespace/repo:tag",
+		},
+		{
+			name:       "identifier with digest and tag",
+			identifier: "registry.io/repo:tag@sha256:abc123def456",
+			expected:   "registry.io/repo:tag@sha256:abc123def456",
+		},
+		{
+			name:       "very long identifier",
+			identifier: "very-long-registry-name.example.com/very-long-namespace/very-long-repository-name:very-long-tag-name",
+			expected:   "very-long-registry-name.example.com/very-long-namespace/very-long-repository-name:very-long-tag-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractImageDigest(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestExtractPolicyFromVSA tests the ExtractPolicyFromVSA function
+func TestExtractPolicyFromVSA(t *testing.T) {
+	tests := []struct {
+		name        string
+		predicate   *Predicate
+		expectError bool
+	}{
+		{
+			name:        "nil predicate",
+			predicate:   nil,
+			expectError: true,
+		},
+		{
+			name: "predicate with empty sources",
+			predicate: &Predicate{
+				Policy: ecapi.EnterpriseContractPolicySpec{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ExtractPolicyFromVSA(tt.predicate)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestParseEffectiveTime tests the ParseEffectiveTime function
+func TestParseEffectiveTime(t *testing.T) {
+	tests := []struct {
+		name          string
+		effectiveTime string
+		expectError   bool
+		checkResult   func(t *testing.T, result time.Time)
+	}{
+		{
+			name:          "now keyword",
+			effectiveTime: "now",
+			expectError:   false,
+			checkResult: func(t *testing.T, result time.Time) {
+				// Should be recent (within last minute)
+				assert.True(t, time.Since(result) < time.Minute)
+			},
+		},
+		{
+			name:          "valid RFC3339 timestamp",
+			effectiveTime: "2023-01-01T00:00:00Z",
+			expectError:   false,
+			checkResult: func(t *testing.T, result time.Time) {
+				expected := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+				assert.Equal(t, expected, result)
+			},
+		},
+		{
+			name:          "invalid timestamp format",
+			effectiveTime: "invalid-timestamp",
+			expectError:   true,
+		},
+		{
+			name:          "empty string",
+			effectiveTime: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseEffectiveTime(tt.effectiveTime)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractImageDigest tests the ExtractImageDigest function
+func TestExtractImageDigest(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		expected   string
+	}{
+		{
+			name:       "sha256 digest",
+			identifier: "sha256:abc123def456789",
+			expected:   "sha256:abc123def456789",
+		},
+		{
+			name:       "image reference",
+			identifier: "registry.io/repo:tag",
+			expected:   "registry.io/repo:tag",
+		},
+		{
+			name:       "empty string",
+			identifier: "",
+			expected:   "",
+		},
+		{
+			name:       "image reference without digest",
+			identifier: "registry.io/repo:latest",
+			expected:   "registry.io/repo:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractImageDigest(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
The `validate vsa` subcommand can now verify the signature of a VSA. By default it is required, but can be ignored with the --ignore-signature-verification` flag.