### PR TITLE
update multi-arch build matrix

### DIFF
--- a/.tekton/cli-main-push.yaml
+++ b/.tekton/cli-main-push.yaml
@@ -112,6 +112,8 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on
       name: build-platforms
       type: array

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS+=-j --no-print-directory
 VERSION_FILE=./VERSION
 VERSION:=$$(hack/derive-version.sh)
 # a list of "dist/ec_{platform}_{arch}" that we support
-ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select((.FirstClass == true or .GOARCH == "ppc64le") and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
+ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select((.FirstClass == true or .GOARCH == "ppc64le" or .GOARCH == "s390x") and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 # a list of image_* targets that we do not support
 UNSUPPORTED_OS_ARCH_IMG:=image_windows_amd64 image_darwin_amd64 image_darwin_arm64 image_linux_arm
 # a list of image_* targets that we do support generated from
@@ -252,6 +252,7 @@ $(ALL_SUPPORTED_IMG_OS_ARCH):
 #  image_linux_amd64
 #  image_linux_arm64
 #  image_linux_ppc64le
+#  image_linux_s390x
 show-supported-builds:
 	@for b in $(ALL_SUPPORTED_IMG_OS_ARCH); do echo $$b; done
 

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -24,6 +24,7 @@ arches:
   - x86_64
   - aarch64
   - ppc64le
+  - s390x
 contentOrigin:
   # ubi.repo is extracted from the base image by the hack/update-rpm-lock.sh
   repofiles:


### PR DESCRIPTION
This commit updates the multi-arch build matrix to include support for `ppc64le` and `s390x` subsequent to work from #2704 which added support for multi-arch builds.

Ref: EC-1519