### PR TITLE
Avoid truncation issues

### DIFF
--- a/hack/reduce-snapshot.sh
+++ b/hack/reduce-snapshot.sh
@@ -32,13 +32,16 @@ set -o pipefail
 
 # Make sure to move snapshot contents to the WORKING_SNAPSHOT location. Then allow jq to
 # work with it there. This avoids having to read SNAPSHOT to memory.
+# Always use a temp file for WORKING_SNAPSHOT to avoid truncation issues when writing
+# the final output to SNAPSHOT_PATH (which may be the same file as SNAPSHOT).
 
+WORKING_SNAPSHOT="$(mktemp "${HOME:-/tmp}/snapshot.XXXXXX")"
 if [[ -f "$SNAPSHOT" ]]; then
-  WORKING_SNAPSHOT="$SNAPSHOT"
+  cp "$SNAPSHOT" "$WORKING_SNAPSHOT"
 else
-  WORKING_SNAPSHOT="$(mktemp "${HOME:-/tmp}/snapshot.XXXXXX")"
   printf "%s" "$SNAPSHOT" > "$WORKING_SNAPSHOT"
 fi
+
 jq empty "$WORKING_SNAPSHOT" || { echo "JSON is invalid"; exit 1; }
 
 echo "Single Component mode? ${SINGLE_COMPONENT}"


### PR DESCRIPTION
### **User description**
When WORKING_SNAPSHOT equals SNAPSHOT_PATH teetruncates SNAPSHOT_PATH. Creating a temp file for WORKING_SNAPSHOT fixes this.


___

### **PR Type**
Bug fix


___

### **Description**
- Always use temporary file for WORKING_SNAPSHOT to prevent truncation

- Fixes issue when WORKING_SNAPSHOT equals SNAPSHOT_PATH

- Copies existing snapshot to temp file instead of direct assignment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SNAPSHOT file exists"] --> B["Create temp file"]
  B --> C["Copy SNAPSHOT to temp"]
  C --> D["Process with jq safely"]
  D --> E["Write to SNAPSHOT_PATH"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reduce-snapshot.sh</strong><dd><code>Use temporary file for snapshot processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hack/reduce-snapshot.sh

<ul><li>Changed WORKING_SNAPSHOT assignment to always use a temporary file<br> <li> Added explicit copy of SNAPSHOT to temporary file when snapshot exists<br> <li> Added clarifying comments explaining truncation issue prevention<br> <li> Ensures safe file handling when SNAPSHOT and SNAPSHOT_PATH are <br>identical</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3038/files#diff-5f67b4a9f9e48a1cf860b3da4dd1b953b48aa63cf8ebda87ce2fc9c23e9e19a4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

