### PR TITLE
fix: avoid truncating snapshot when paths match

### DIFF
--- a/hack/reduce-snapshot.sh
+++ b/hack/reduce-snapshot.sh
@@ -31,10 +31,12 @@ set -o pipefail
 
 
 # Make sure to move snapshot contents to the WORKING_SNAPSHOT location. Then allow jq to
-# work with it there. This avoids having to read SNAPSHOT to memory.
+# work with it there and prevent truncating the original. This avoids having to read
+# SNAPSHOT to memory.
 
 if [[ -f "$SNAPSHOT" ]]; then
-  WORKING_SNAPSHOT="$SNAPSHOT"
+  WORKING_SNAPSHOT="$(mktemp "${HOME:-/tmp}/snapshot.XXXXXX")"
+  cp "$SNAPSHOT" "$WORKING_SNAPSHOT"
 else
   WORKING_SNAPSHOT="$(mktemp "${HOME:-/tmp}/snapshot.XXXXXX")"
   printf "%s" "$SNAPSHOT" > "$WORKING_SNAPSHOT"


### PR DESCRIPTION
### **User description**
When SNAPSHOT_PATH==SNAPSHOT, tee truncates the file before jq finishes reading it, leaving an empty snapshot.

ref: RELEASE-1922
Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1763045856544599?thread_ts=1762874206.783809&cid=C04PZ7H0VA8


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent snapshot truncation when SNAPSHOT_PATH equals SNAPSHOT

- Copy snapshot to temporary file before processing with jq

- Avoid race condition where tee truncates file during read


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SNAPSHOT file exists"] --> B["Create temp file"]
  B --> C["Copy SNAPSHOT to temp"]
  C --> D["Process with jq safely"]
  E["SNAPSHOT not found"] --> F["Create temp file"]
  F --> G["Write SNAPSHOT content"]
  G --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reduce-snapshot.sh</strong><dd><code>Copy snapshot to temp file to prevent truncation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hack/reduce-snapshot.sh

<ul><li>Changed WORKING_SNAPSHOT assignment from direct reference to temporary <br>file copy<br> <li> Added <code>cp</code> command to copy SNAPSHOT contents to temporary location<br> <li> Updated comment to clarify prevention of truncation<br> <li> Ensures jq processes from temp file while preserving original SNAPSHOT</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3039/files#diff-5f67b4a9f9e48a1cf860b3da4dd1b953b48aa63cf8ebda87ce2fc9c23e9e19a4">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

