### PR TITLE
Remove home directory option

### DIFF
--- a/hack/reduce-snapshot.sh
+++ b/hack/reduce-snapshot.sh
@@ -35,7 +35,7 @@ set -o pipefail
 # Always use a temp file for WORKING_SNAPSHOT to avoid truncation issues when writing
 # the final output to SNAPSHOT_PATH (which may be the same file as SNAPSHOT).
 
-WORKING_SNAPSHOT="$(mktemp "${HOME:-/tmp}/snapshot.XXXXXX")"
+WORKING_SNAPSHOT="$(mktemp /tmp/snapshot.XXXXXX)"
 if [[ -f "$SNAPSHOT" ]]; then
   cp "$SNAPSHOT" "$WORKING_SNAPSHOT"
 else


### PR DESCRIPTION
### **User description**
Using HOME is causing issues with release service CI. So writing directly to tmp.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove HOME directory fallback from temp file creation

- Write snapshot directly to /tmp instead of HOME

- Fixes CI issues with release service environment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mktemp with HOME fallback"] -- "Remove HOME option" --> B["mktemp /tmp directly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reduce-snapshot.sh</strong><dd><code>Remove HOME fallback from mktemp command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hack/reduce-snapshot.sh

<ul><li>Changed <code>mktemp</code> command to write directly to <code>/tmp</code> instead of using <br><code>${HOME:-/tmp}</code> fallback<br> <li> Removes conditional HOME directory logic that was causing CI issues<br> <li> Simplifies temp file creation for snapshot processing</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3040/files#diff-5f67b4a9f9e48a1cf860b3da4dd1b953b48aa63cf8ebda87ce2fc9c23e9e19a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

