### PR TITLE
remove extraneous go mod downloads for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,8 +104,7 @@ jobs:
       - name: Download go dependencies
         run: |
           go mod download
-          (cd tools && go mod download)
-          (cd acceptance && go mod download)
+          (cd tools/kubectl && go mod download)
 
       - name: Build distribution
         run: make dist


### PR DESCRIPTION
### **User description**
We are currently experiencing a situation where we're running out of disk space during our release process. This commit removes extraneous downloads for unnecessary subdirectories, the `tools` and `acceptance` directories specifically, which aren't used for the release process.

Ref: EC-1585


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize release workflow disk space usage

- Remove unnecessary go mod downloads from tools and acceptance directories

- Keep only essential kubectl dependency downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Workflow"] -->|Previously| B["Download go mods<br/>root + tools + acceptance"]
  A -->|Now| C["Download go mods<br/>root + tools/kubectl"]
  B -->|Result| D["High disk usage"]
  C -->|Result| E["Reduced disk usage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yaml</strong><dd><code>Streamline go mod downloads in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yaml

<ul><li>Removed <code>go mod download</code> from tools directory root<br> <li> Removed <code>go mod download</code> from acceptance directory entirely<br> <li> Added <code>go mod download</code> for tools/kubectl subdirectory only<br> <li> Reduces unnecessary dependency downloads during release process</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3054/files#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

