### PR TITLE
add `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Exclude pre-built binaries to prevent copying host's dist/ into the build stage.
+# This is critical for multi-arch builds where each architecture should only have
+# its own built binaries, not all binaries from the host.
+dist/
+
+# Exclude coverage output files
+*.out
+
+# Exclude node modules (used for tekton-lint)
+node_modules/
+
+# Exclude IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Exclude test artifacts
+acceptance/testenv/
+


### PR DESCRIPTION
### **User description**
This commit adds a `.dockerignore` which ignores the `dist/` directory when executing the `COPY . .` command in the `Dockerfile` and `Dockerfile.dist` file when building images. The expectation is that this will resolve the disk usage issues we're seeing.

Ref: EC-1585


___

### **PR Type**
Enhancement


___

### **Description**
- Add `.dockerignore` file to exclude unnecessary build artifacts

- Prevents `dist/` directory from being copied into Docker images

- Excludes coverage, node modules, IDE files, and test artifacts

- Resolves disk usage issues in multi-arch Docker builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Build Process"] -- "COPY . ." --> B["Image Layer"]
  C[".dockerignore File"] -- "Excludes dist/, node_modules/, etc." --> B
  B -- "Reduced Image Size" --> D["Optimized Docker Image"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.dockerignore</strong><dd><code>Create .dockerignore with build artifact exclusions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.dockerignore

<ul><li>Created new <code>.dockerignore</code> file with Apache 2.0 license header<br> <li> Excludes <code>dist/</code> directory to prevent host binaries from being copied<br> <li> Excludes coverage files (<code>*.out</code>), node modules, IDE files, and test <br>artifacts<br> <li> Includes explanatory comments for multi-arch build compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3066/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

