### PR TITLE
Remove obsolete rekor entry acceptance test steps

### DIFF
--- a/features/vsa.feature
+++ b/features/vsa.feature
@@ -110,9 +110,7 @@ Feature: VSA generation and storage
     Given a key pair named "vsa-expiration"
     Given an image named "acceptance/vsa-expiration-image"
     Given a valid image signature of "acceptance/vsa-expiration-image" image signed by the "vsa-expiration" key
-    Given a valid Rekor entry for image signature of "acceptance/vsa-expiration-image"
     Given a valid attestation of "acceptance/vsa-expiration-image" signed by the "vsa-expiration" key
-    Given a valid Rekor entry for attestation of "acceptance/vsa-expiration-image"
     Given VSA index search should return no results
     Given a git repository named "vsa-expiration-policy" with
       | main.rego | examples/happy_day.rego |
@@ -136,9 +134,7 @@ Feature: VSA generation and storage
     Given a key pair named "vsa-existing"
     Given an image named "acceptance/vsa-existing-image"
     Given a valid image signature of "acceptance/vsa-existing-image" image signed by the "vsa-existing" key
-    Given a valid Rekor entry for image signature of "acceptance/vsa-existing-image"
     Given a valid attestation of "acceptance/vsa-existing-image" signed by the "vsa-existing" key
-    Given a valid Rekor entry for attestation of "acceptance/vsa-existing-image"
     Given VSA index search should return valid VSA
     Given a git repository named "vsa-existing-policy" with
       | main.rego | examples/happy_day.rego |
@@ -168,9 +164,7 @@ Feature: VSA generation and storage
     Given a key pair named "vsa-no-upload"
     Given an image named "acceptance/vsa-no-upload-image"
     Given a valid image signature of "acceptance/vsa-no-upload-image" image signed by the "vsa-no-upload" key
-    Given a valid Rekor entry for image signature of "acceptance/vsa-no-upload-image"
     Given a valid attestation of "acceptance/vsa-no-upload-image" signed by the "vsa-no-upload" key
-    Given a valid Rekor entry for attestation of "acceptance/vsa-no-upload-image"
     Given a git repository named "vsa-no-upload-policy" with
       | main.rego | examples/happy_day.rego |
     Given policy configuration named "vsa-no-upload-ec-policy" with specification
@@ -194,9 +188,7 @@ Feature: VSA generation and storage
     Given a key pair named "vsa-upload-fail"
     Given an image named "acceptance/vsa-upload-fail-image"
     Given a valid image signature of "acceptance/vsa-upload-fail-image" image signed by the "vsa-upload-fail" key
-    Given a valid Rekor entry for image signature of "acceptance/vsa-upload-fail-image"
     Given a valid attestation of "acceptance/vsa-upload-fail-image" signed by the "vsa-upload-fail" key
-    Given a valid Rekor entry for attestation of "acceptance/vsa-upload-fail-image"
     Given a git repository named "vsa-upload-fail-policy" with
       | main.rego | examples/happy_day.rego |
     Given policy configuration named "vsa-upload-fail-ec-policy" with specification


### PR DESCRIPTION
### **User description**
After PR #2948 was merged, we don't need these steps any more. IIUC the rekor entries get created automatically in a more realistic way.

The PR for EC-1210 was accidentally left unmerged for a long time, which explains why the new VSA feature testing still had the obsolete step.

Related to...
Ref: https://issues.redhat.com/browse/EC-1210


___

### **PR Type**
Tests


___

### **Description**
- Remove obsolete Rekor entry creation steps from VSA acceptance tests

- Rekor entries now created automatically after PR #2948 merge

- Simplifies test setup by removing manual entry creation

- Affects four VSA test scenarios with signature and attestation steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VSA Acceptance Tests"] -->|Remove obsolete steps| B["Rekor entry creation"]
  B -->|Auto-created now| C["Simplified test setup"]
  A -->|Affects 4 scenarios| D["VSA expiration, existing VSA, no upload, upload failure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vsa.feature</strong><dd><code>Remove manual Rekor entry creation from VSA tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

features/vsa.feature

<ul><li>Removed 8 obsolete Rekor entry creation steps across 4 test scenarios<br> <li> Deleted "Given a valid Rekor entry for image signature" steps<br> <li> Deleted "Given a valid Rekor entry for attestation" steps<br> <li> Rekor entries now created automatically by the system</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3068/files#diff-8914d6690515011a8d61f20a7b3c280d6da61b5976f6c4f1bb65449cac675248">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

