### PR TITLE
Fix premature Codecov status checks

### DIFF
--- a/.github/workflows/checks-codecov.yaml
+++ b/.github/workflows/checks-codecov.yaml
@@ -85,32 +85,15 @@ jobs:
       - name: Test
         run: make test
 
-      - name: Upload unit test coverage report
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test coverage artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.0
         with:
-          files: ./coverage-unit.out
-          disable_search: true
-          flags: unit
-
-      - name: Upload generative test coverage report
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./coverage-generative.out
-          disable_search: true
-          flags: generative
-
-      - name: Upload integration test coverage report
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./coverage-integration.out
-          disable_search: true
-          flags: integration
+          name: coverage-test
+          path: |
+            ./coverage-unit.out
+            ./coverage-generative.out
+            ./coverage-integration.out
+          retention-days: 1
 
   Acceptance:
     runs-on: ubuntu-latest
@@ -149,12 +132,75 @@ jobs:
         id: acceptance_test
         run: E2E_INSTRUMENTATION=true make acceptance
 
-      - name: Upload coverage report
+      - name: Upload acceptance coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.0
+        with:
+          name: coverage-acceptance
+          path: ./coverage-acceptance.out
+          retention-days: 1
+
+  Upload:
+    name: "Upload Coverage Statistics"
+    runs-on: ubuntu-latest
+    needs: [Test, Acceptance]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+          disable-telemetry: true
+
+        # checkout is required for codecov to map the coverage data back to files in the repo
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Download test coverage artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: coverage-test
+          path: ./coverage
+
+      - name: Download acceptance coverage artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: coverage-acceptance
+          path: ./coverage
+
+      - name: Upload unit test coverage report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./coverage-acceptance.out
+          files: ./coverage/coverage-unit.out
+          disable_search: true
+          flags: unit
+
+      - name: Upload generative test coverage report
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage/coverage-generative.out
+          disable_search: true
+          flags: generative
+
+      - name: Upload integration test coverage report
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage/coverage-integration.out
+          disable_search: true
+          flags: integration
+
+      - name: Upload acceptance test coverage report
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage/coverage-acceptance.out
           disable_search: true
           flags: acceptance
 


### PR DESCRIPTION
### **User description**
Restructure the workflow so that Test and Acceptance jobs save coverage as artifacts, then a new Upload job waits for both to complete before uploading all reports together, ensuring Codecov receives complete data in a single batch instead of calculating status prematurely.


___

### **PR Type**
Enhancement


___

### **Description**
- Restructure workflow to defer Codecov uploads until both jobs complete

- Test and Acceptance jobs now save coverage as artifacts instead of uploading

- New Upload job waits for both jobs, downloads artifacts, and uploads together

- Prevents premature Codecov status calculation with incomplete coverage data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Test["Test Job<br/>Save coverage artifacts"]
  Acceptance["Acceptance Job<br/>Save coverage artifacts"]
  Upload["Upload Job<br/>Download artifacts & upload to Codecov"]
  Test -- "coverage-test artifact" --> Upload
  Acceptance -- "coverage-acceptance artifact" --> Upload
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>checks-codecov.yaml</strong><dd><code>Restructure workflow for batched Codecov uploads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/checks-codecov.yaml

<ul><li>Removed direct Codecov uploads from Test job, replaced with artifact <br>upload for all three coverage files<br> <li> Removed direct Codecov upload from Acceptance job, replaced with <br>artifact upload<br> <li> Added new Upload job that depends on both Test and Acceptance jobs<br> <li> Upload job downloads artifacts and performs all Codecov uploads with <br>proper file paths</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3069/files#diff-0df5ee2e513d974ad6a0ff361dacc63d799cd3db00cfd0eb045122d7515a9f2c">+73/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

