### PR TITLE
Mention VSA secret keyRef in load error

### DIFF
--- a/internal/validate/vsa/attest.go
+++ b/internal/validate/vsa/attest.go
@@ -73,7 +73,7 @@ func NewSigner(ctx context.Context, keyRef string, fs afero.Fs) (*Signer, error)
 
 	signerVerifier, err := LoadPrivateKey(keyBytes, password)
 	if err != nil {
-		return nil, fmt.Errorf("load private key: %w", err)
+		return nil, fmt.Errorf("load private key %q: %w", keyRef, err)
 	}
 
 	return &Signer{


### PR DESCRIPTION
### **User description**
This should help with some knative-service debugging.


___

### **PR Type**
Enhancement


___

### **Description**
- Include keyRef in load private key error message

- Improves debugging for VSA secret key resolution failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Error Message"] -->|"Add keyRef parameter"| B["Enhanced Debugging Info"]
  B -->|"Shows which key failed"| C["Better VSA Troubleshooting"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attest.go</strong><dd><code>Add keyRef to private key load error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/validate/vsa/attest.go

<ul><li>Modified error message in <code>NewSigner</code> function to include <code>keyRef</code> <br>parameter<br> <li> Changed from generic "load private key" error to include the specific <br>key reference<br> <li> Improves debugging visibility when private key loading fails</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3071/files#diff-65697cd9f3d2212213c3b699281ed537f9ac100ec6f3b6ea8e48542fd6dd8d95">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

