### PR TITLE
Performance enhancing image fetching

### DIFF
--- a/docs/modules/ROOT/pages/ec_oci_image_manifests.adoc
+++ b/docs/modules/ROOT/pages/ec_oci_image_manifests.adoc
@@ -1,0 +1,20 @@
+= ec.oci.image_manifests
+
+Fetch Image Manifests from an OCI registry in parallel.
+
+== Usage
+
+  manifests = ec.oci.image_manifests(refs: set[string])
+
+== Parameters
+
+* `refs` (`set[string]`): set of OCI image references
+
+== Return
+
+`manifests` (`object`): object mapping refs to their Image Manifest objects
+
+The object contains dynamic attributes.
+The attributes are of `string` type and represent the OCI image reference.
+The values are of `object<annotations: object[string: string], config: object<annotations: object[string: string], artifactType: string, data: string, digest: string, mediaType: string, platform: object<architecture: string, features: array<string>, os: string, os.features: array<string>, os.version: string, variant: string>, size: number, urls: array<string>>, layers: array<object<annotations: object[string: string], artifactType: string, data: string, digest: string, mediaType: string, platform: object<architecture: string, features: array<string>, os: string, os.features: array<string>, os.version: string, variant: string>, size: number, urls: array<string>>>, mediaType: string, schemaVersion: number, subject: object<annotations: object[string: string], artifactType: string, data: string, digest: string, mediaType: string, platform: object<architecture: string, features: array<string>, os: string, os.features: array<string>, os.version: string, variant: string>, size: number, urls: array<string>>>` type and hold the Image Manifest object.
+

--- a/docs/modules/ROOT/pages/rego_builtins.adoc
+++ b/docs/modules/ROOT/pages/rego_builtins.adoc
@@ -18,6 +18,8 @@ information.
 |Fetch an Image Index from an OCI registry.
 |xref:ec_oci_image_manifest.adoc[ec.oci.image_manifest]
 |Fetch an Image Manifest from an OCI registry.
+|xref:ec_oci_image_manifests.adoc[ec.oci.image_manifests]
+|Fetch Image Manifests from an OCI registry in parallel.
 |xref:ec_purl_is_valid.adoc[ec.purl.is_valid]
 |Determine whether or not a given PURL is valid.
 |xref:ec_purl_parse.adoc[ec.purl.parse]

--- a/docs/modules/ROOT/partials/rego_nav.adoc
+++ b/docs/modules/ROOT/partials/rego_nav.adoc
@@ -4,6 +4,7 @@
 ** xref:ec_oci_image_files.adoc[ec.oci.image_files]
 ** xref:ec_oci_image_index.adoc[ec.oci.image_index]
 ** xref:ec_oci_image_manifest.adoc[ec.oci.image_manifest]
+** xref:ec_oci_image_manifests.adoc[ec.oci.image_manifests]
 ** xref:ec_purl_is_valid.adoc[ec.purl.is_valid]
 ** xref:ec_purl_parse.adoc[ec.purl.parse]
 ** xref:ec_sigstore_verify_attestation.adoc[ec.sigstore.verify_attestation]


### PR DESCRIPTION
### **User description**
This adds parallel fetching of image manifests and caching for each function call that fetches from a registry.

https://issues.redhat.com/browse/EC-1600

Assisted-by: Claude Opus 4.5


___

### **PR Type**
Enhancement


___

### **Description**
- Add parallel manifest fetching with `ec.oci.image_manifests` function

- Implement per-function caching using `sync.Map` and `singleflight.Group`

- Add concurrency control limiting parallel fetches to `GOMAXPROCS * 4`

- Refactor existing OCI functions to use caching and singleflight deduplication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OCI Functions<br/>blob, descriptor, manifest, etc."] -->|"Add caching<br/>& singleflight"| B["sync.Map<br/>+ singleflight.Group"]
  C["New Function<br/>ociImageManifestsBatch"] -->|"Parallel fetch<br/>with errgroup"| D["Multiple Manifests<br/>Concurrent"]
  B -->|"Prevent<br/>thundering herd"| E["Optimized<br/>Registry Access"]
  D -->|"Bounded by<br/>GOMAXPROCS*4"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci.go</strong><dd><code>Implement caching and parallel manifest fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rego/oci/oci.go

<ul><li>Add imports for concurrency primitives (<code>sync</code>, <code>runtime</code>, <code>errgroup</code>, <br><code>singleflight</code>)<br> <li> Introduce package-level caches (<code>sync.Map</code>) and singleflight groups for <br>blob, descriptor, manifest, image files, and image index operations<br> <li> Implement new <code>ociImageManifestsBatch</code> function that fetches multiple <br>manifests in parallel with bounded concurrency<br> <li> Refactor all existing OCI functions (<code>ociBlob</code>, <code>ociDescriptor</code>, <br><code>ociImageManifest</code>, <code>ociImageFiles</code>, <code>ociImageIndex</code>) to use caching and <br>singleflight deduplication<br> <li> Add <code>maxParallelManifestFetches</code> variable set to <code>GOMAXPROCS * 4</code> to <br>control concurrency<br> <li> Register new batch function in <code>init()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3073/files#diff-231bce3061f82262da0c654b4abe53cdd1aadc0b001329c1203ccb3bf6adf0f8">+563/-202</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_test.go</strong><dd><code>Add tests for batch manifest fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rego/oci/oci_test.go

<ul><li>Add comprehensive test cases for <code>ociImageManifestsBatch</code> covering <br>single ref, multiple refs, empty array, invalid input, and error <br>scenarios<br> <li> Add <code>TestOCIImageManifestsBatchConcurrency</code> to verify bounded <br>concurrency behavior with configurable limits<br> <li> Update <code>TestFunctionsRegistered</code> to include the new <br><code>ociImageManifestsBatchName</code> function<br> <li> Add <code>fmt</code> import for test string formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3073/files#diff-158b76516241c6bc10d6d2b56d60c4ecf6396442d802d063e14718262b344b3d">+165/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ec_oci_image_manifests.adoc</strong><dd><code>Document new parallel manifest function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/modules/ROOT/pages/ec_oci_image_manifests.adoc

<ul><li>Create new documentation file for <code>ec.oci.image_manifests</code> function<br> <li> Document function signature, parameters, and return type<br> <li> Describe the function as fetching Image Manifests from OCI registry in <br>parallel</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3073/files#diff-9a9c72e8f38f2d1add7932c9a9366c660f16fdaa67afc1b1353861063d605071">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rego_builtins.adoc</strong><dd><code>Update builtins reference table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/modules/ROOT/pages/rego_builtins.adoc

<ul><li>Add entry for <code>ec.oci.image_manifests</code> in the builtins reference table<br> <li> Include cross-reference to the new function documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3073/files#diff-92c7da1dfdfd1a75d8ef055eb578bee6b9a6ef172cefabcd70f504895f84fb68">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rego_nav.adoc</strong><dd><code>Update navigation sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/modules/ROOT/partials/rego_nav.adoc

<ul><li>Add navigation entry for <code>ec.oci.image_manifests</code> in the Rego reference <br>sidebar</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3073/files#diff-f03104c3f71ec803e4eb08c6df92c7f3ea9bf94719d5e5d51a1b057ffc4a1e18">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

