### PR TITLE
enable no-unused-param tekton-lint rule

### DIFF
--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -33,11 +33,7 @@ rules: # error | warning | off
   no-latest-image: off
   prefer-beta: warning
   prefer-kebab-case: warning
-  # We have two intentionally unused params currently, TIMEOUT and
-  # WORKERS. This lint check should be renabled once those
-  # are removed. See https://issues.redhat.com/browse/EC-1371 and
-  # https://issues.redhat.com/browse/EC-1425
-  no-unused-param: off
+  no-unused-param: error
   no-missing-resource: error
   no-undefined-param: error
   prefer-when-expression: warning

--- a/docs/modules/ROOT/pages/verify-conforma-vsa-release-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-vsa-release-ta.adoc
@@ -48,7 +48,7 @@ registries/Rekor. Multiple paths can be provided using `:`.
 *EFFECTIVE_TIME* (`string`):: Run policy checks with the provided time.
 +
 *Default*: `now`
-*EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Syntax: key=val,key2=val2
+*EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Syntax: key=val,key2=val2. Note: pipeline_intention=release is always included.
 
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +

--- a/tasks/verify-conforma-konflux-vsa-ta/0.1/verify-conforma-konflux-vsa-ta.yaml
+++ b/tasks/verify-conforma-konflux-vsa-ta/0.1/verify-conforma-konflux-vsa-ta.yaml
@@ -129,7 +129,7 @@ spec:
       type: string
       description: >
         Merge additional Rego variables into the policy data. Syntax:
-        key=val,key2=val2
+        key=val,key2=val2. Note: pipeline_intention=release is always included.
       default: ""
 
     - name: WORKERS
@@ -338,6 +338,7 @@ spec:
         - "--show-successes"
         - "--effective-time=$(params.EFFECTIVE_TIME)"
         - "--extra-rule-data=pipeline_intention=release"
+        - "--extra-rule-data=$(params.EXTRA_RULE_DATA)"
         - "--retry-max-wait"
         - "$(params.RETRY_MAX_WAIT)"
         - "--retry-max-retry"


### PR DESCRIPTION
### **User description**
This commit re-enables the `no-unused-param` tekton-lint rule which was previously disabled due to unused parameters in the tasks.

To satisfy the lint rule, the `verify-conforma-konflux-vsa-ta` task was updated to use the `EXTRA_RULE_DATA` parameter. A second `--extra-rule-data` flag was added so the parameter is used while preserving the existing `pipeline_intention=release` behavior.

The parameter description and documentation were updated to note that `pipeline_intention=release` is always included.

Ref: EC-1635


___

### **PR Type**
Enhancement


___

### **Description**
- Re-enable `no-unused-param` tekton-lint rule by fixing unused parameters

- Update `verify-conforma-konflux-vsa-ta` task to use `EXTRA_RULE_DATA` parameter

- Add second `--extra-rule-data` flag to preserve `pipeline_intention=release` behavior

- Update parameter documentation to clarify `pipeline_intention=release` inclusion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lint Rule Disabled"] -->|"Re-enable no-unused-param"| B["Lint Rule Enabled"]
  C["Unused EXTRA_RULE_DATA Parameter"] -->|"Add flag usage"| D["Parameter Utilized"]
  E["Incomplete Documentation"] -->|"Update descriptions"| F["Clear Documentation"]
  B --> G["Task Compliance"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.tektonlintrc.yaml</strong><dd><code>Enable no-unused-param lint rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.tektonlintrc.yaml

<ul><li>Changed <code>no-unused-param</code> rule from <code>off</code> to <code>error</code><br> <li> Removed outdated comment referencing EC-1371 and EC-1425<br> <li> Rule now enforces detection of unused parameters in tasks</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3090/files#diff-f51abf200c6ca42c95ed53f07ceefa2bae79ef2df66a0dc3d5517e51c05b2270">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify-conforma-vsa-release-ta.adoc</strong><dd><code>Clarify EXTRA_RULE_DATA parameter documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/modules/ROOT/pages/verify-conforma-vsa-release-ta.adoc

<ul><li>Updated <code>EXTRA_RULE_DATA</code> parameter documentation<br> <li> Added note clarifying that <code>pipeline_intention=release</code> is always <br>included<br> <li> Improves clarity on parameter behavior and default values</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3090/files#diff-e08a5c2f48fb8eddf75a39d680446b805b4f3c4bb8160480cad2fe42ca3289f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify-conforma-konflux-vsa-ta.yaml</strong><dd><code>Use EXTRA_RULE_DATA parameter in task command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tasks/verify-conforma-konflux-vsa-ta/0.1/verify-conforma-konflux-vsa-ta.yaml

<ul><li>Updated <code>EXTRA_RULE_DATA</code> parameter description with clarification note<br> <li> Added second <code>--extra-rule-data=$(params.EXTRA_RULE_DATA)</code> flag to <br>command<br> <li> Ensures <code>EXTRA_RULE_DATA</code> parameter is actually used in task execution<br> <li> Preserves existing <code>pipeline_intention=release</code> behavior with dual flags</ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3090/files#diff-f27c6844c17a37520a07e939480a3273e84003b5cfc3034cc2a1014ecacea340">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

