### PR TITLE
Fix mediaType in config for track bundle

### DIFF
--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -72,7 +72,6 @@ const (
 )
 
 const (
-	unknownConfig       = "application/vnd.unknown.config.v1+json"
 	openPolicyAgentData = "application/vnd.cncf.openpolicyagent.data.layer.v1+json"
 	title               = "org.opencontainers.image.title"
 )
@@ -856,7 +855,7 @@ func createAndPushKeylessImage(ctx context.Context, imageName string) (context.C
 // layers
 func createAndPushPolicyBundle(ctx context.Context, imageName string, files *godog.Table) (context.Context, error) {
 	bundle := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
-	bundle = mutate.ConfigMediaType(bundle, unknownConfig)
+	bundle = mutate.ConfigMediaType(bundle, types.OCIConfigJSON)
 
 	// add each row as a layer to the bundle
 	for _, row := range files.Rows {

--- a/internal/tracker/oci.go
+++ b/internal/tracker/oci.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	unknownConfig       = "application/vnd.unknown.config.v1+json"
 	openPolicyAgentData = "application/vnd.cncf.openpolicyagent.data.layer.v1+json"
 	title               = "org.opencontainers.image.title"
 	dataFileTitle       = "data/data/trusted_tekton_tasks.yml"
@@ -117,7 +116,7 @@ func PushImage(ctx context.Context, imageRef string, data []byte, invocation str
 	}
 
 	bundle := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
-	bundle = mutate.ConfigMediaType(bundle, unknownConfig)
+	bundle = mutate.ConfigMediaType(bundle, types.OCIConfigJSON)
 	if bundle, err = mutate.Append(bundle, mutate.Addendum{
 		History: v1.History{
 			CreatedBy: invocation,

--- a/internal/tracker/oci_test.go
+++ b/internal/tracker/oci_test.go
@@ -117,7 +117,7 @@ func TestPullImage(t *testing.T) {
 	yaml := []byte("data: blah")
 
 	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
-	img = mutate.ConfigMediaType(img, unknownConfig)
+	img = mutate.ConfigMediaType(img, types.OCIConfigJSON)
 	img, err := mutate.Append(img, mutate.Addendum{
 		MediaType: openPolicyAgentData,
 		Layer:     static.NewLayer(yaml, openPolicyAgentData),


### PR DESCRIPTION
### **User description**
A command like 
```
ec track bundle --freshen --bundle <bundle> --input oci:<trust-bundle>
```
produces and OCI image with the following manifest:
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.unknown.config.v1+json",
    "size": 467,
    "digest": "sha256:b1d034b3d9773504ede9ca5008933b290824fdf3ce2b52067f72f614fee8f517"
  },
  "layers": [
    {
      "mediaType": "application/vnd.cncf.openpolicyagent.data.layer.v1+json",
      "size": 397,
      "digest": "sha256:515c2845b43250e4b4eaea11d56a36cfae19db779030c5d8a040d21859a8f911",
      "annotations": {
        "org.opencontainers.image.title": "data/data/trusted_tekton_tasks.yml"
      }
    }
  ]
}
```
Note, `config.mediaType` is `application/vnd.unknown.config.v1+json` which cause many tools (`podman`, `docker`, `scopeo`, etc.) to refuse to work with such a bundle, e.g.
```
$ skopeo inspect docker://quay.io/redhat-user-workloads/mmorhun-tenant/main-component@sha256:39d176ed46745dd18f817ecb538ad6b93c16856a3719604cc75bf4646c508548
FATA[0001] unsupported image-specific operation on artifact with type "application/vnd.unknown.config.v1+json" 
```

With the fix applied:
```
$ skopeo inspect --no-tags docker://quay.io/redhat-user-workloads/mmorhun-tenant/main-component@sha256:88af899480338819ab2e9591ecb0e9abb5285a3da061441fb1d925d68c95562e
{
    "Name": "quay.io/redhat-user-workloads/mmorhun-tenant/main-component",
    "Digest": "sha256:88af899480338819ab2e9591ecb0e9abb5285a3da061441fb1d925d68c95562e",
    "RepoTags": [],
    "Created": "0001-01-01T00:00:00Z",
    "DockerVersion": "",
    "Labels": null,
    "Architecture": "",
    "Os": "",
    "Layers": [
        "sha256:dac62e1353dc29da1111368f28b0f3cbcffd945b1eb7a6b8b8be1969d56a54c3"
    ],
    "LayersData": [
        {
            "MIMEType": "application/vnd.cncf.openpolicyagent.data.layer.v1+json",
            "Digest": "sha256:dac62e1353dc29da1111368f28b0f3cbcffd945b1eb7a6b8b8be1969d56a54c3",
            "Size": 149,
            "Annotations": {
                "org.opencontainers.image.title": "data/data/trusted_tekton_tasks.yml"
            }
        }
    ],
    "Env": null
}
```
and the manifest is the following:
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "size": 487,
    "digest": "sha256:86ecabfecfb19ef534a32f7591ead91f1659fce2772b5a1d28c2fbee6bf5892b"
  },
  "layers": [
    {
      "mediaType": "application/vnd.cncf.openpolicyagent.data.layer.v1+json",
      "size": 149,
      "digest": "sha256:dac62e1353dc29da1111368f28b0f3cbcffd945b1eb7a6b8b8be1969d56a54c3",
      "annotations": {
        "org.opencontainers.image.title": "data/data/trusted_tekton_tasks.yml"
      }
    }
  ]
}
```


___

### **PR Type**
Bug fix


___

### **Description**
- Replace incorrect `application/vnd.unknown.config.v1+json` with standard OCI config mediaType

- Use `types.OCIConfigJSON` constant for proper OCI image compatibility

- Fix affects track bundle creation in both main code and tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["unknownConfig constant<br/>vnd.unknown.config.v1+json"] -->|removed| B["types.OCIConfigJSON<br/>vnd.oci.image.config.v1+json"]
  B -->|enables| C["OCI tool compatibility<br/>skopeo, podman, docker"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>image.go</strong><dd><code>Replace unknown config mediaType with OCI standard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

acceptance/image/image.go

<ul><li>Removed <code>unknownConfig</code> constant definition<br> <li> Updated <code>createAndPushPolicyBundle</code> to use <code>types.OCIConfigJSON</code> instead <br>of <code>unknownConfig</code></ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3092/files#diff-ca2e8bbbc398fa7ca05dc83cd99ead5a99674c28faa62f883778513b98c98049">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oci.go</strong><dd><code>Replace unknown config mediaType with OCI standard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tracker/oci.go

<ul><li>Removed <code>unknownConfig</code> constant definition<br> <li> Updated <code>PushImage</code> function to use <code>types.OCIConfigJSON</code> instead of <br><code>unknownConfig</code></ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3092/files#diff-aa604c270fcf24ac2f6223c97e2f2eec4680e25c9e7792cb60a609151d824819">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_test.go</strong><dd><code>Update test to use correct OCI config mediaType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tracker/oci_test.go

<ul><li>Updated <code>TestPullImage</code> test to use <code>types.OCIConfigJSON</code> instead of <br><code>unknownConfig</code></ul>


</details>


  </td>
  <td><a href="https://github.com/conforma/cli/pull/3092/files#diff-038aeb2d9b1a2b1310befeab26090bb827fde126b5b20e3a5ac96f75ab58b8e3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

