### PR TITLE
enable Konflux cache proxy for builds

### DIFF
--- a/.tekton/cli-main-pull-request.yaml
+++ b/.tekton/cli-main-pull-request.yaml
@@ -40,6 +40,8 @@ spec:
     value: main-pre-merge-build-args.conf
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -115,6 +117,10 @@ spec:
       description: List of platforms to build the container images on
       name: build-platforms
       type: array
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -240,6 +246,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/cli-main-push.yaml
+++ b/.tekton/cli-main-push.yaml
@@ -39,6 +39,8 @@ spec:
     value: main-build-args.conf
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -117,6 +119,10 @@ spec:
       description: List of platforms to build the container images on
       name: build-platforms
       type: array
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -242,6 +248,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
Enable the cache proxy in the Tekton pipeline definitions to improve build performance by caching dependencies.

Ref: EC-1614