### PR TITLE
remove deprecated TIMEOUT parameter from tasks

### DIFF
--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -53,8 +53,6 @@ paths can be provided by using the `:` separator.
 +
 *Default*: `now`
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
-*TIMEOUT* (`string`):: This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
-
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 
 +

--- a/docs/modules/ROOT/pages/verify-conforma-vsa-release-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-vsa-release-ta.adoc
@@ -50,8 +50,6 @@ registries/Rekor. Multiple paths can be provided using `:`.
 *Default*: `now`
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Syntax: key=val,key2=val2
 
-*TIMEOUT* (`string`):: Deprecated; ignored by the task. EC is run without a timeout (use Tekton timeouts).
-
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
 *Default*: `4`

--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -64,8 +64,6 @@ paths can be provided by using the `:` separator.
 +
 *Default*: `now`
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
-*TIMEOUT* (`string`):: This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
-
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
 *Default*: `1`

--- a/tasks/verify-conforma-konflux-ta/0.1/README.md
+++ b/tasks/verify-conforma-konflux-ta/0.1/README.md
@@ -31,7 +31,6 @@ kubectl apply -f https://raw.githubusercontent.com/conforma/cli/main/tasks/verif
 * **HOMEDIR**: Value for the HOME environment variable. (default: "/tekton/home")
 * **EFFECTIVE_TIME**: Run policy checks with the provided time. (default: "now")
 * **EXTRA_RULE_DATA**: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..." (default: "")
-* **TIMEOUT**: This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.) (default: "")
 * **WORKERS**: Number of parallel workers to use for policy evaluation. This parameter is currently not used. All policy evaluations are run with 35 workers. (default: "35")
 * **SINGLE_COMPONENT**: Reduce the Snapshot to only the component whose build caused the Snapshot to be created (default: "false")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE**: Name, including kind, of the Kubernetes resource to query for labels when single component mode is enabled, e.g. pr/somepipeline. (default: "unknown")

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -118,13 +118,6 @@ spec:
       description: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
       default: ""
 
-    - name: TIMEOUT
-      type: string
-      description: >
-        This param is deprecated and will be removed in future. Its value is ignored. EC will
-        be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
-      default: ""
-
     - name: WORKERS
       type: string
       description: >

--- a/tasks/verify-conforma-konflux-vsa-ta/0.1/verify-conforma-konflux-vsa-ta.yaml
+++ b/tasks/verify-conforma-konflux-vsa-ta/0.1/verify-conforma-konflux-vsa-ta.yaml
@@ -132,13 +132,6 @@ spec:
         key=val,key2=val2
       default: ""
 
-    - name: TIMEOUT
-      type: string
-      description: >
-        Deprecated; ignored by the task. EC is run without a timeout (use
-        Tekton timeouts).
-      default: ""
-
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.

--- a/tasks/verify-enterprise-contract/0.1/README.md
+++ b/tasks/verify-enterprise-contract/0.1/README.md
@@ -40,7 +40,6 @@ kubectl apply -f https://raw.githubusercontent.com/conforma/cli/main/tasks/verif
 * **HOMEDIR**: Value for the HOME environment variable. (default: "/tekton/home")
 * **EFFECTIVE_TIME**: Run policy checks with the provided time. (default: "now")
 * **EXTRA_RULE_DATA**: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..." (default: "")
-* **TIMEOUT**: This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.) (default: "")
 * **WORKERS**: Number of parallel workers to use for policy evaluation. (default: "1")
 * **SINGLE_COMPONENT**: Reduce the Snapshot to only the component whose build caused the Snapshot to be created (default: "false")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE**: Name, including kind, of the Kubernetes resource to query for labels when single component mode is enabled, e.g. pr/somepipeline. (default: "unknown")

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -125,13 +125,6 @@ spec:
       description: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
       default: ""
 
-    - name: TIMEOUT
-      type: string
-      description: >
-        This param is deprecated and will be removed in future. Its value is ignored. EC will
-        be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
-      default: ""
-
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.


### PR DESCRIPTION
This commit removes the deprecated TIMEOUT task parameter from the following tasks:

- `verify-conforma-konflux-ta`
- `verify-conforma-konflux-vsa-ta`
- `verify-enterprise-contract`

This commit also updates the associated documentation and README files.

Ref: EC-1425