### PR TITLE
Enable godog strict mode to fail on undefined steps

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -132,12 +132,6 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		logger, ctx := log.LoggerFor(ctx)
 		logger.Name(sc.Name)
 
-		// Log scenario start - write to /dev/tty to bypass all output capture
-		if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
-			fmt.Fprintf(tty, "\n▶ STARTING: %s (%s)\n", sc.Name, sc.Uri)
-			tty.Close()
-		}
-
 		return context.WithValue(ctx, testenv.Scenario, sc), nil
 	})
 
@@ -145,9 +139,9 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		// Log scenario end with status - write to /dev/tty to bypass capture
 		if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
 			if scenarioErr != nil {
-				fmt.Fprintf(tty, "✗ FAILED: %s (%s)\n\n", scenario.Name, scenario.Uri)
+				fmt.Fprintf(tty, "✗ FAILED: %s (%s)\n", scenario.Name, scenario.Uri)
 			} else {
-				fmt.Fprintf(tty, "✓ PASSED: %s (%s)\n\n", scenario.Name, scenario.Uri)
+				fmt.Fprintf(tty, "✓ PASSED: %s (%s)\n", scenario.Name, scenario.Uri)
 			}
 			tty.Close()
 		}


### PR DESCRIPTION
Add Strict: true to godog.Options to ensure undefined steps cause
test failures instead of being silently ignored. This prevents false
positives where tests appear to pass despite missing step definitions.

This commit also reduces logging verbosity in acceptance tests.