### PR TITLE
enable Konflux cache proxy for builds

### DIFF
--- a/.tekton/cli-v06-pull-request.yaml
+++ b/.tekton/cli-v06-pull-request.yaml
@@ -40,6 +40,8 @@ spec:
     value: quick-build-args.conf
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -122,6 +124,10 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote
         VMs
       name: privileged-nested
+      type: string
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
       type: string
     results:
     - description: ""
@@ -242,6 +248,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/cli-v06-push.yaml
+++ b/.tekton/cli-v06-push.yaml
@@ -39,6 +39,8 @@ spec:
     value: ""
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -121,6 +123,10 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote
         VMs
       name: privileged-nested
+      type: string
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
       type: string
     results:
     - description: ""
@@ -241,6 +247,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
Enable the cache proxy in the Tekton pipeline definitions to improve build performance by caching dependencies.

Ref: EC-1614