### PR TITLE
enable Konflux cache proxy for builds

### DIFF
--- a/.tekton/cli-v07-pull-request.yaml
+++ b/.tekton/cli-v07-pull-request.yaml
@@ -40,6 +40,8 @@ spec:
     value: quick-build-args.conf
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -109,6 +111,10 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote
         VMs
       name: privileged-nested
+      type: string
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
       type: string
     results:
     - description: ""
@@ -229,6 +235,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/cli-v07-push.yaml
+++ b/.tekton/cli-v07-push.yaml
@@ -39,6 +39,8 @@ spec:
     value: ""
   - name: hermetic
     value: "true"
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -108,6 +110,10 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote
         VMs
       name: privileged-nested
+      type: string
+    - default: "true"
+      description: Enable cache proxy
+      name: enable-cache-proxy
       type: string
     results:
     - description: ""
@@ -228,6 +234,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ENABLE_CACHE_PROXY
+        value: $(params.enable-cache-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
Enable the cache proxy in the Tekton pipeline definitions to improve build performance by caching dependencies.

Ref: EC-1614