### PR TITLE
Scope blob and imageFiles caches per component to reduce peak memory

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -42,6 +42,7 @@ import (
 	"github.com/conforma/cli/internal/output"
 	"github.com/conforma/cli/internal/policy"
 	"github.com/conforma/cli/internal/policy/source"
+	regooci "github.com/conforma/cli/internal/rego/oci"
 	"github.com/conforma/cli/internal/utils"
 	"github.com/conforma/cli/internal/utils/oci"
 	validate_utils "github.com/conforma/cli/internal/validate"
@@ -348,6 +349,12 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 						ctx, task = trace.NewTask(ctx, "ec:validate-component")
 						trace.Logf(ctx, "", "workerID=%d", id)
 					}
+
+					// Scope heavy OCI caches (blobs, image files) to this component's
+					// evaluation. Each component has unique image refs, so caching across
+					// components just accumulates dead data. When this iteration ends,
+					// the component-scoped cache is released for GC.
+					ctx = regooci.WithComponentCache(ctx)
 
 					log.Debugf("Worker %d got a component %q", id, comp.ContainerImage)
 


### PR DESCRIPTION
Blob and imageFiles caches are now scoped per component evaluation via a ComponentCache attached to the context. Within a component, multiple policy packages still benefit from cache + singleflight dedup across Eval() calls. When the component finishes, its cache is released for GC.

Manifest, descriptor, and imageIndex caches remain global since they are small and benefit from cross-component sharing (e.g. shared task bundles).

Ref: https://issues.redhat.com/browse/EC-1672