### PR TITLE
add structured logging to PURL and sigstore Rego builtins

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -3525,7 +3525,7 @@ Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed:
 ---
 
 [PURL functions:stderr - 1]
-time="${TIMESTAMP}" level=error msg="Parsing PURL \"this-is-not-a-valid-purl\" failed: purl scheme is not \"pkg\": \"\""
+time="${TIMESTAMP}" level=error msg="failed to parse PURL" error="purl scheme is not \"pkg\": \"\"" function=ec.purl.parse purl=this-is-not-a-valid-purl
 Error: success criteria not met
 
 ---

--- a/internal/rego/purl/purl.go
+++ b/internal/rego/purl/purl.go
@@ -108,29 +108,41 @@ func registerPURLParse() {
 }
 
 func purlIsValid(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	logger := log.WithField("function", purlIsValidName)
+
 	uri, ok := a.Value.(ast.String)
 	if !ok {
+		logger.Debug("input is not a string")
 		return ast.BooleanTerm(false), nil
 	}
+	logger = logger.WithField("purl", string(uri))
+
 	_, err := packageurl.FromString(string(uri))
 	if err != nil {
-		log.Debugf("Parsing PURL %s failed: %s", uri, err)
+		logger.WithField("error", err).Debug("failed to parse PURL")
 		return ast.BooleanTerm(false), nil
 	}
+	logger.Debug("PURL is valid")
 	return ast.BooleanTerm(true), nil
 }
 
 func purlParse(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	logger := log.WithField("function", purlParseName)
+
 	uri, ok := a.Value.(ast.String)
 	if !ok {
+		logger.Debug("input is not a string")
 		return nil, nil
 	}
+	logger = logger.WithField("purl", string(uri))
+
 	instance, err := packageurl.FromString(string(uri))
 	if err != nil {
-		log.Errorf("Parsing PURL %s failed: %s", uri, err)
+		logger.WithField("error", err).Error("failed to parse PURL")
 		return nil, nil
 	}
 
+	logger.Debug("successfully parsed PURL")
 	qualifiers := ast.NewArray()
 	for _, q := range instance.Qualifiers {
 		o := ast.NewObject(


### PR DESCRIPTION
Add log.WithField("function", ...) to PURL and sigstore custom Rego builtin functions to ease troubleshooting. This follows the same pattern already used in the OCI builtin functions.

Functions updated:
- ec.purl.is_valid
- ec.purl.parse
- ec.sigstore.verify_image
- ec.sigstore.verify_attestation

Ref: EC-1668
Resolves: #1361