### PR TITLE
feat(tkn-bundle-oci-ta): add STEPS_IMAGE_STEP_NAMES

### DIFF
--- a/.tekton/cli-main-pull-request.yaml
+++ b/.tekton/cli-main-pull-request.yaml
@@ -301,6 +301,8 @@ spec:
         value: tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
       - name: STEPS_IMAGE
         value: $(params.bundle-cli-ref-repo)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: STEPS_IMAGE_STEP_NAMES
+        value: !use-trusted-artifact
       - name: URL
         value: $(params.git-url)
       - name: REVISION
@@ -314,7 +316,8 @@ spec:
         - name: name
           value: tkn-bundle-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:ceb35ce497159209c8a329dcf3969b337a8ea527412d098f0071ec48d76a5693
+          # need to add digest
+          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.3
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cli-main-push.yaml
+++ b/.tekton/cli-main-push.yaml
@@ -303,6 +303,8 @@ spec:
         value: tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
       - name: STEPS_IMAGE
         value: $(params.bundle-cli-ref-repo)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: STEPS_IMAGE_STEP_NAMES
+        value: !use-trusted-artifact
       - name: URL
         value: $(params.git-url)
       - name: REVISION
@@ -316,7 +318,8 @@ spec:
         - name: name
           value: tkn-bundle-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:ceb35ce497159209c8a329dcf3969b337a8ea527412d098f0071ec48d76a5693
+          # need to add digest
+          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.3
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Add STEPS_IMAGE_STEP_NAMES parameter to build-tekton-bundle task in cli-main pull-request and push pipelineRuns. This limits STEPS_IMAGE replacement to steps using quay.io/conforma/cli:latest in verify-conforma-konflux-ta, leaving other task steps unchanged.

https://issues.redhat.com/browse/EC-1685

Assisted-by: Claude Opus 4.6