### PR TITLE
sigstore: Cache verify_image results across policy evaluations

### DIFF
--- a/internal/rego/sigstore/sigstore.go
+++ b/internal/rego/sigstore/sigstore.go
@@ -22,9 +22,12 @@ package sigstore
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -35,6 +38,7 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/conforma/cli/internal/attestation"
 	"github.com/conforma/cli/internal/policy"
@@ -56,6 +60,11 @@ const (
 	publicKeyAttribute                   = "public_key"
 	rekorURLAttribute                    = "rekor_url"
 	rekorPublicKeyAttribute              = "rekor_public_key"
+)
+
+var (
+	verifyImageCache  sync.Map
+	verifyImageFlight singleflight.Group
 )
 
 var ociImageReferenceParameter = types.Named("ref", types.S).Description("OCI image reference")
@@ -111,7 +120,6 @@ func registerSigstoreVerifyImage() {
 
 func sigstoreVerifyImage(bctx rego.BuiltinContext, refTerm *ast.Term, optsTerm *ast.Term) (*ast.Term, error) {
 	logger := log.WithField("function", sigstoreVerifyImageName)
-	ctx := bctx.Context
 
 	uri, err := builtins.StringOperand(refTerm.Value, 0)
 	if err != nil {
@@ -119,6 +127,33 @@ func sigstoreVerifyImage(bctx rego.BuiltinContext, refTerm *ast.Term, optsTerm *
 		return signatureFailedResult(fmt.Errorf("ref parameter: %w", err))
 	}
 	logger = logger.WithField("ref", string(uri))
+
+	// Build cache key from ref + opts hash
+	cacheKey := buildCacheKey(string(uri), optsTerm)
+
+	// Check cache first
+	if cached, ok := verifyImageCache.Load(cacheKey); ok {
+		logger.Debug("using cached image signature verification result")
+		return cached.(*ast.Term), nil
+	}
+
+	// Use singleflight to deduplicate concurrent requests. doVerifyImage never returns a Go
+	// error — failures are embedded in the result term — so the error is intentionally discarded.
+	resultIface, _, _ := verifyImageFlight.Do(cacheKey, func() (interface{}, error) {
+		return doVerifyImage(bctx, logger, uri, optsTerm)
+	})
+
+	// We cache successes and failures here. It would be possible to avoid caching
+	// failures such as transient network problems that might suceeed if tried again,
+	// but I think it's likely not worth the effort, so we won't do that now.
+	result := resultIface.(*ast.Term)
+	verifyImageCache.Store(cacheKey, result)
+
+	return result, nil
+}
+
+func doVerifyImage(bctx rego.BuiltinContext, logger *log.Entry, uri ast.String, optsTerm *ast.Term) (*ast.Term, error) {
+	ctx := bctx.Context
 
 	ref, err := name.NewDigest(string(uri))
 	if err != nil {
@@ -157,6 +192,12 @@ func sigstoreVerifyImage(bctx rego.BuiltinContext, refTerm *ast.Term, optsTerm *
 
 	logger.WithField("signatures_count", len(signatures)).Debug("image signature verification complete")
 	return signatureResult(signatures, nil)
+}
+
+func buildCacheKey(ref string, optsTerm *ast.Term) string {
+	h := sha256.Sum256([]byte(optsTerm.String()))
+	optsHash := hex.EncodeToString(h[:])
+	return ref + "|" + optsHash
 }
 
 func registerSigstoreVerifyAttestation() {
@@ -438,6 +479,11 @@ func attestationResult(attestations []oci.Signature, useBundles bool, err error)
 		ast.Item(ast.StringTerm("errors"), ast.ArrayTerm(errorTerms...)),
 		ast.Item(ast.StringTerm("attestations"), ast.ArrayTerm(attestationTerms...)),
 	), nil
+}
+
+// ClearCaches clears the verify_image cache. Used for testing.
+func ClearCaches() {
+	verifyImageCache = sync.Map{}
 }
 
 func init() {

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -176,6 +176,7 @@ func TestSigstoreVerifyImage(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			ClearCaches()
 			utils.SetTestRekorPublicKey(t)
 			utils.SetTestFulcioRoots(t)
 			utils.SetTestCTLogPublicKey(t)
@@ -208,6 +209,92 @@ func TestSigstoreVerifyImage(t *testing.T) {
 			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
 		})
 	}
+}
+
+func TestVerifyImageCache(t *testing.T) {
+	image1 := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+	image2 := name.MustParseReference(
+		"registry.local/eggs@sha256:5e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+	opts1 := options{ignoreRekor: true, publicKey: utils.TestPublicKey}
+	opts2 := options{publicKey: utils.TestPublicKey, rekorURL: "https://rekor.local"}
+
+	newFakeContext := func(t *testing.T) (*fake.FakeClient, rego.BuiltinContext) {
+		t.Helper()
+		utils.SetTestRekorPublicKey(t)
+		utils.SetTestFulcioRoots(t)
+		utils.SetTestCTLogPublicKey(t)
+
+		sig, err := static.NewSignature(
+			[]byte(`image`),
+			"signature",
+			static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+		)
+		require.NoError(t, err)
+
+		c := &fake.FakeClient{}
+		c.On("HasBundles", mock.Anything, mock.Anything).Return(false, nil)
+		c.On("VerifyImageSignatures", mock.Anything, mock.Anything).Return([]oci.Signature{sig}, false, nil)
+		ctx := o.WithClient(context.Background(), c)
+		return c, rego.BuiltinContext{Context: ctx}
+	}
+
+	t.Run("same ref and opts returns cached result", func(t *testing.T) {
+		ClearCaches()
+		c, bctx := newFakeContext(t)
+
+		r1, err := sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+
+		r2, err := sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+
+		require.Equal(t, r1, r2)
+		c.AssertNumberOfCalls(t, "VerifyImageSignatures", 1)
+	})
+
+	t.Run("different ref is a cache miss", func(t *testing.T) {
+		ClearCaches()
+		c, bctx := newFakeContext(t)
+
+		_, err := sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+
+		_, err = sigstoreVerifyImage(bctx, ast.StringTerm(image2.String()), opts1.toTerm())
+		require.NoError(t, err)
+
+		c.AssertNumberOfCalls(t, "VerifyImageSignatures", 2)
+	})
+
+	t.Run("different opts is a cache miss", func(t *testing.T) {
+		ClearCaches()
+		c, bctx := newFakeContext(t)
+
+		_, err := sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+
+		_, err = sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts2.toTerm())
+		require.NoError(t, err)
+
+		c.AssertNumberOfCalls(t, "VerifyImageSignatures", 2)
+	})
+
+	t.Run("ClearCaches forces re-verification", func(t *testing.T) {
+		ClearCaches()
+		c, bctx := newFakeContext(t)
+
+		_, err := sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+		c.AssertNumberOfCalls(t, "VerifyImageSignatures", 1)
+
+		ClearCaches()
+
+		_, err = sigstoreVerifyImage(bctx, ast.StringTerm(image1.String()), opts1.toTerm())
+		require.NoError(t, err)
+		c.AssertNumberOfCalls(t, "VerifyImageSignatures", 2)
+	})
 }
 
 func TestSigstoreVerifyAttestation(t *testing.T) {
@@ -600,6 +687,7 @@ func TestSigstoreVerifyImageWithBundles(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			ClearCaches()
 			utils.SetTestRekorPublicKey(t)
 			utils.SetTestFulcioRoots(t)
 			utils.SetTestCTLogPublicKey(t)
@@ -661,6 +749,7 @@ func TestSigstoreVerifyImageBundleFallback(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			ClearCaches()
 			utils.SetTestRekorPublicKey(t)
 			utils.SetTestFulcioRoots(t)
 			utils.SetTestCTLogPublicKey(t)


### PR DESCRIPTION
## Summary

- Add `sync.Map` + `singleflight.Group` cache for `ec.sigstore.verify_image` results keyed by `ref|hash(opts)`
- OPA's Memoize only deduplicates within a single Eval() call; this cache persists across component evaluations
- Prevents redundant signature verification when many components share task bundles (e.g., 100 components using git-clone)
- Follows the caching pattern established by `manifestCache`/`descriptorCache` in `internal/rego/oci/oci.go`

## Test plan

- [x] `go build ./internal/rego/sigstore/` compiles cleanly
- [ ] Verify caching behavior with multiple components sharing task bundles
- [ ] Benchmark signature verification with/without cache on a multi-component snapshot

Ref: EC-1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)