### PR TITLE
feat(RELEASE-2158): Support self-hosted Quay

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -245,6 +245,13 @@ spec:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+      - name: trusted-ca
+        mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
     env:
       - name: "ORAS_OPTIONS"
         value: "$(params.ORAS_OPTIONS)"


### PR DESCRIPTION
Verify Conforma task should support images that are in a self-hosted Quay instance. This instance has a self-signed CA cert which is implicitly not trusted by 3rd party tools. This can be fixed by mounting the CA bundle to /etc/ssl/certs/, making it trusted. Mount to /mnt/trusted-ca is added to be consistent with other tasks in the pipeline.

Ref: https://issues.redhat.com/browse/RELEASE-2158