### PR TITLE
Set CPE label for new v0.8 release branch build

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -49,7 +49,8 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL \
-  name="ec" \
+  name="rhtas/ec-rhel9" \
+  cpe="cpe:/a:redhat:trusted_artifact_signer:1.4::el9" \
   description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   summary="Provides the binaries for downloading the Conforma CLI. Also used as a runner image for Tekton tasks." \


### PR DESCRIPTION
The Red Hat builds of Conforma need a proper CPE, otherwise the "check-labels" task in the release pipeline fails.

(This is a new step in the release branch preparation process, will need to get it documented/and or scripted.)

I changed the "name" label as well to be consistent with what we have for v0.7 and v0.6, and actually the release pipeline also requires this exact name.

Ref: https://redhat.atlassian.net/browse/EC-1658