### PR TITLE
Fix bump-minor-version to treat version as major.minor integers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ debug-version:
 
 # It's not so hard to do this by hand, but let's save some typing
 bump-minor-version:
-	@yq '(((. * 10) + 1) / 10)' -i $(VERSION_FILE) && \
+	@yq '(. | to_string | split(".") | .[0] + "." + (.[1] | to_number + 1 | to_string))' -i $(VERSION_FILE) && \
 	  git add $(VERSION_FILE) && \
 	  git commit $(VERSION_FILE) \
 	    -m "Bump minor version to $$(cat $(VERSION_FILE))" \


### PR DESCRIPTION
The previous yq expression treated VERSION as a float, causing 0.9
to bump to 1.0 instead of 0.10. Replace with string-based approach
that splits on ".", increments the minor component as an integer,
and reassembles.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Ref: https://issues.redhat.com/browse/EC-1705