### PR TITLE
fix(RELEASE-2158): refactor trusted-ca mounts in verify-conforma task

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -264,11 +264,10 @@ spec:
       - mountPath: /var/workdir
         name: workdir
       - name: trusted-ca
-        mountPath: /mnt/trusted-ca
+        mountPath: /etc/ssl/certs
         readOnly: true
       - name: trusted-ca
-        mountPath: /etc/ssl/certs/ca-custom-bundle.crt
-        subPath: ca-bundle.crt
+        mountPath: /mnt/trusted-ca
         readOnly: true
     env:
       - name: "ORAS_OPTIONS"
@@ -511,11 +510,6 @@ spec:
           memory: 2Gi
         limits:
           memory: 2Gi
-      volumeMounts:
-        - name: trusted-ca
-          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
-          subPath: ca-bundle.crt
-          readOnly: true
 
     - name: report-json
       image: quay.io/conforma/cli:latest


### PR DESCRIPTION
Refactor trusted-ca volume mounts in verify-conforma-konflux-ta to use
directory mounts (/etc/ssl/certs and /mnt/trusted-ca) instead of
subPath-based mounts. This is consistent with the mount style used
across release-service-catalog tasks and ensures that the task doesn't
exit with a failure when the configmap is not present. Remove the
redundant trusted-ca volumeMount from the report step, which does
not need CA certificate access.

Assisted-by: Cursor