### PR TITLE
Reset podman storage between release image pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,15 @@ jobs:
           IMAGE_REPO: quay.io/conforma/cli
         run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
+      - name: verify the ec image (quay.io/conforma/cli)
+        env:
+          IMAGE_TAG: snapshot
+          IMAGE_REPO: quay.io/conforma/cli
+        run: make verify-image
+
+      - name: Reset podman storage
+        run: podman system reset --force
+
       - name: Registry login (quay.io/enterprise-contract)
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
 
@@ -127,13 +136,6 @@ jobs:
         env:
           IMAGE_REPO: quay.io/enterprise-contract/ec-cli
         run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
-
-      # verify ec works in the image and show the version
-      - name: verify the ec image (quay.io/conforma/cli)
-        env:
-          IMAGE_TAG: snapshot
-          IMAGE_REPO: quay.io/conforma/cli
-        run: make verify-image
 
       - name: verify the ec image (quay.io/enterprise-contract/ec-cli)
         env:


### PR DESCRIPTION
This PR fixes intermittent CI failures for the Release workflow, like this one: https://github.com/conforma/cli/actions/runs/24840555290

## Summary
- The second `dist-image-push` call (enterprise-contract) intermittently fails on s390x with `image not known` in containers storage
- This is a podman storage race condition triggered by leftover state from the first build when pulling the same base image digest under QEMU emulation
- Reset podman storage between the two pushes so the second build starts clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>