### PR TITLE
Fix per-component criteria for multi-arch

### DIFF
--- a/internal/evaluator/criteria.go
+++ b/internal/evaluator/criteria.go
@@ -18,6 +18,7 @@ package evaluator
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	ecc "github.com/conforma/crds/api/v1alpha1"
@@ -106,6 +107,14 @@ func (c *Criteria) get(imageRef string, componentName string) []string {
 		if componentItems, ok := c.componentItems[componentName]; ok {
 			items = append(items, componentItems...)
 		}
+		// For multi-arch image index components, also match by the original component
+		// name. During expansion, "foo" becomes "foo-sha256:<digest>-arm64" etc., but
+		// volatile config references the original name.
+		if origName := originalComponentName(componentName); origName != componentName {
+			if componentItems, ok := c.componentItems[origName]; ok {
+				items = append(items, componentItems...)
+			}
+		}
 	}
 
 	// Add any exceptions that pertain to all images.
@@ -117,6 +126,19 @@ func (c *Criteria) getWithKey(key string) []string {
 		return items
 	}
 	return []string{}
+}
+
+// multiArchSuffixRe matches the suffix appended to component names during multi-arch
+// image index expansion (see applicationsnapshot/input.go imageIndexWorker). The format
+// is "-sha256:<hex digest>-<architecture>", e.g. "-sha256:abc123...-arm64".
+var multiArchSuffixRe = regexp.MustCompile(`-sha256:[0-9a-f]{64}-\S+$`)
+
+// originalComponentName returns the component name before multi-arch image index
+// expansion. For example, component "foo" is expanded into per-arch components like
+// "foo-sha256:<digest>-arm64". This allows component-scoped volatile config
+// (includes/excludes) to apply to per-arch components as well as the original.
+func originalComponentName(componentName string) string {
+	return multiArchSuffixRe.ReplaceAllString(componentName, "")
 }
 
 func computeIncludeExclude(src ecc.Source, p ConfigProvider) (*Criteria, *Criteria) {

--- a/internal/evaluator/criteria_test.go
+++ b/internal/evaluator/criteria_test.go
@@ -977,12 +977,101 @@ func TestCriteriaGetWithComponentName(t *testing.T) {
 			componentName: "my-component",
 			expected:      []string{"test.image_check", "test.component_check", "*"},
 		},
+		{
+			name: "Multi-arch expanded component matches original component name",
+			criteria: &Criteria{
+				digestItems: map[string][]string{},
+				componentItems: map[string][]string{
+					"my-component": {"test.component_check"},
+				},
+				defaultItems: []string{"*"},
+			},
+			imageRef:      "quay.io/repo/img@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			componentName: "my-component-sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890-arm64",
+			expected:      []string{"test.component_check", "*"},
+		},
+		{
+			name: "Multi-arch expanded component with noarch suffix",
+			criteria: &Criteria{
+				digestItems: map[string][]string{},
+				componentItems: map[string][]string{
+					"my-component": {"test.component_check"},
+				},
+				defaultItems: []string{"*"},
+			},
+			imageRef:      "quay.io/repo/img@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			componentName: "my-component-sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890-noarch-2",
+			expected:      []string{"test.component_check", "*"},
+		},
+		{
+			name: "Similar component name not incorrectly matched",
+			criteria: &Criteria{
+				digestItems: map[string][]string{},
+				componentItems: map[string][]string{
+					"my-component": {"test.component_check"},
+				},
+				defaultItems: []string{"*"},
+			},
+			imageRef:      "quay.io/repo/img@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			componentName: "my-component-libs",
+			expected:      []string{"*"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.criteria.get(tt.imageRef, tt.componentName)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOriginalComponentName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain component name unchanged",
+			input:    "my-component",
+			expected: "my-component",
+		},
+		{
+			name:     "multi-arch arm64 suffix stripped",
+			input:    "my-component-sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890-arm64",
+			expected: "my-component",
+		},
+		{
+			name:     "multi-arch amd64 suffix stripped",
+			input:    "my-component-sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890-amd64",
+			expected: "my-component",
+		},
+		{
+			name:     "multi-arch noarch suffix stripped",
+			input:    "my-component-sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890-noarch-2",
+			expected: "my-component",
+		},
+		{
+			name:     "similar name without digest not stripped",
+			input:    "my-component-libs",
+			expected: "my-component-libs",
+		},
+		{
+			name:     "similar name with sha prefix but no digest not stripped",
+			input:    "my-component-sha256",
+			expected: "my-component-sha256",
+		},
+		{
+			name:     "empty string unchanged",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, originalComponentName(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
For multi-arch images, the original component gets expanded into several components, each with a name that includes a digest and an arch. This patch makes sure those additional components can also match a volatile exclude with component name criteria.

Bug originally reported in
https://redhat.atlassian.net/browse/KFLUXSPRT-7780

Ref: https://redhat.atlassian.net/browse/EC-1800