### PR TITLE
Restore tekton task memory limits

### DIFF
--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -512,9 +512,9 @@ spec:
       computeResources:
         requests:
           cpu: 250m
-          memory: 2Gi
+          memory: 8Gi
         limits:
-          memory: 2Gi
+          memory: 8Gi
 
     - name: report-json
       image: quay.io/conforma/cli:latest


### PR DESCRIPTION
Some tenants are experiencing OOM issues due to the much lower limit, so let's restore it to the original value.