### PR TITLE
Fix UPDATE_SNAPS support in make acceptance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,14 @@ acceptance: ## Run all acceptance tests
 	ACCEPTANCE_WORKDIR="$$(mktemp -d)"; \
 	cleanup() { \
 		cp "$${ACCEPTANCE_WORKDIR}"/features/__snapshots__/* "$(ROOT_DIR)"/features/__snapshots__/ || true; \
+		if [ -n "$${UPDATE_SNAPS}" ]; then \
+			for f in "$(ROOT_DIR)"/features/__snapshots__/*.snap; do \
+				[ -f "$$f" ] || continue; \
+				if [ ! -f "$${ACCEPTANCE_WORKDIR}/features/__snapshots__/$$(basename $$f)" ]; then \
+					rm -f "$$f"; \
+				fi; \
+			done; \
+		fi; \
 		rm -rf "$${ACCEPTANCE_WORKDIR}"; \
 	}; \
 	mkdir -p "$${ACCEPTANCE_WORKDIR}/coverage"; \

--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -69,7 +69,7 @@ func (e errCapture) SkipNow() {
 }
 
 func (e errCapture) Name() string {
-	return e.scenario.Name + ":" + e.qualifier
+	return "TestFeatures/" + e.scenario.Name + ":" + e.qualifier
 }
 
 func (e *errCapture) Error(args ...interface{}) {

--- a/features/__snapshots__/conftest_test.snap
+++ b/features/__snapshots__/conftest_test.snap
@@ -1,5 +1,5 @@
 
-[appstudio error nofail:stdout - 1]
+[TestFeatures/appstudio error nofail:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
@@ -11,12 +11,12 @@
 }
 ---
 
-[appstudio error nofail:stderr - 1]
+[TestFeatures/appstudio error nofail:stderr - 1]
 Error: running test: load: loading policies: load: 1 error occurred during loading: stat file/not/exist.rego: no such file or directory
 
 ---
 
-[appstudio warning:stdout - 1]
+[TestFeatures/appstudio warning:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "main",
@@ -28,11 +28,11 @@ Error: running test: load: loading policies: load: 1 error occurred during loadi
 }
 ---
 
-[appstudio warning:stderr - 1]
+[TestFeatures/appstudio warning:stderr - 1]
 
 ---
 
-[a warning:stdout - 1]
+[TestFeatures/a warning:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -50,11 +50,11 @@ Error: running test: load: loading policies: load: 1 error occurred during loadi
 ]
 ---
 
-[a warning:stderr - 1]
+[TestFeatures/a warning:stderr - 1]
 
 ---
 
-[a different appstudio error:stdout - 1]
+[TestFeatures/a different appstudio error:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
@@ -66,12 +66,12 @@ Error: running test: load: loading policies: load: 1 error occurred during loadi
 }
 ---
 
-[a different appstudio error:stderr - 1]
+[TestFeatures/a different appstudio error:stderr - 1]
 Error: running test: parse configurations: parser unmarshal: unmarshal json: invalid character '\n' in string literal, path: acceptance/examples/broken_input.json
 
 ---
 
-[appstudio success:stdout - 1]
+[TestFeatures/appstudio success:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "main",
@@ -83,7 +83,7 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 }
 ---
 
-[a deny with no-fail:stdout - 1]
+[TestFeatures/a deny with no-fail:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -101,15 +101,15 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 ]
 ---
 
-[appstudio success:stderr - 1]
+[TestFeatures/appstudio success:stderr - 1]
 
 ---
 
-[a deny with no-fail:stderr - 1]
+[TestFeatures/a deny with no-fail:stderr - 1]
 
 ---
 
-[appstudio deny:stdout - 1]
+[TestFeatures/appstudio deny:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "main",
@@ -121,7 +121,7 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 }
 ---
 
-[a deny:stdout - 1]
+[TestFeatures/a deny:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -139,15 +139,15 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 ]
 ---
 
-[appstudio deny:stderr - 1]
+[TestFeatures/appstudio deny:stderr - 1]
 
 ---
 
-[a deny:stderr - 1]
+[TestFeatures/a deny:stderr - 1]
 
 ---
 
-[a warning with fail-on-warn:stdout - 1]
+[TestFeatures/a warning with fail-on-warn:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -165,11 +165,11 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 ]
 ---
 
-[a warning with fail-on-warn:stderr - 1]
+[TestFeatures/a warning with fail-on-warn:stderr - 1]
 
 ---
 
-[appstudio skipped:stdout - 1]
+[TestFeatures/appstudio skipped:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "main",
@@ -181,22 +181,22 @@ Error: running test: parse configurations: parser unmarshal: unmarshal json: inv
 }
 ---
 
-[appstudio skipped:stderr - 1]
+[TestFeatures/appstudio skipped:stderr - 1]
 
 ---
 
-[plain text deny:stdout - 1]
+[TestFeatures/plain text deny:stdout - 1]
 FAIL - acceptance/examples/empty_input.json - main - Failure due to overripeness
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ---
 
-[plain text deny:stderr - 1]
+[TestFeatures/plain text deny:stderr - 1]
 
 ---
 
-[appstudio error:stdout - 1]
+[TestFeatures/appstudio error:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
@@ -208,21 +208,21 @@ FAIL - acceptance/examples/empty_input.json - main - Failure due to overripeness
 }
 ---
 
-[normal error:stdout - 1]
+[TestFeatures/normal error:stdout - 1]
 
 ---
 
-[appstudio error:stderr - 1]
+[TestFeatures/appstudio error:stderr - 1]
 Error: running test: load: loading policies: load: 1 error occurred during loading: stat file/not/exist.rego: no such file or directory
 
 ---
 
-[normal error:stderr - 1]
+[TestFeatures/normal error:stderr - 1]
 Error: running test: load: loading policies: load: 1 error occurred during loading: stat file/not/exist.rego: no such file or directory
 
 ---
 
-[success:stdout - 1]
+[TestFeatures/success:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -232,6 +232,6 @@ Error: running test: load: loading policies: load: 1 error occurred during loadi
 ]
 ---
 
-[success:stderr - 1]
+[TestFeatures/success:stderr - 1]
 
 ---

--- a/features/__snapshots__/initialize.snap
+++ b/features/__snapshots__/initialize.snap
@@ -1,5 +1,5 @@
 
-[success:stdout - 1]
+[TestFeatures/success:stdout - 1]
 [
   {
     "filename": "acceptance/examples/empty_input.json",
@@ -9,11 +9,11 @@
 ]
 ---
 
-[success:stderr - 1]
+[TestFeatures/success:stderr - 1]
 
 ---
 
-[appstudio success:stdout - 1]
+[TestFeatures/appstudio success:stdout - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "main",
@@ -25,6 +25,6 @@
 }
 ---
 
-[appstudio success:stderr - 1]
+[TestFeatures/appstudio success:stderr - 1]
 
 ---

--- a/features/__snapshots__/inspect_policy.snap
+++ b/features/__snapshots__/inspect_policy.snap
@@ -1,5 +1,5 @@
 
-[inspecting a data source:stdout - 1]
+[TestFeatures/inspecting a data source:stdout - 1]
 {
   "rule_data": {
     "banana_fail_reason": "spider attack"
@@ -8,29 +8,29 @@
 }
 ---
 
-[inspecting a data source:stderr - 1]
+[TestFeatures/inspecting a data source:stderr - 1]
 
 ---
 
-[short names output:stdout - 1]
+[TestFeatures/short names output:stdout - 1]
 kitty.purr
 
 ---
 
-[short names output:stderr - 1]
+[TestFeatures/short names output:stderr - 1]
 
 ---
 
-[inspecting a data source with a merge error:stdout - 1]
+[TestFeatures/inspecting a data source with a merge error:stdout - 1]
 
 ---
 
-[inspecting a data source with a merge error:stderr - 1]
+[TestFeatures/inspecting a data source with a merge error:stderr - 1]
 Error: Merge error. The 'rule_data' key was found more than once!
 
 ---
 
-[json output:stdout - 1]
+[TestFeatures/json output:stdout - 1]
 {
   "git::${GITHOST}/git/policy.git?ref=${LATEST_COMMIT}": [
     {
@@ -66,11 +66,11 @@ Error: Merge error. The 'rule_data' key was found more than once!
 }
 ---
 
-[json output:stderr - 1]
+[TestFeatures/json output:stderr - 1]
 
 ---
 
-[default output:stdout - 1]
+[TestFeatures/default output:stdout - 1]
 # Source: git::${GITHOST}/git/policy.git?ref=${LATEST_COMMIT}
 
 kitty.purr (deny)
@@ -81,11 +81,11 @@ Fluffy
 
 ---
 
-[default output:stderr - 1]
+[TestFeatures/default output:stderr - 1]
 
 ---
 
-[sources from ECP:stdout - 1]
+[TestFeatures/sources from ECP:stdout - 1]
 # Source: git::${GITHOST}/git/policy1.git?ref=f81eaf65be8da58460ff920408ba1313051184a1
 
 kitty.purr (deny)
@@ -110,6 +110,6 @@ This rule will always fail
 
 ---
 
-[sources from ECP:stderr - 1]
+[TestFeatures/sources from ECP:stderr - 1]
 
 ---

--- a/features/__snapshots__/opa.snap
+++ b/features/__snapshots__/opa.snap
@@ -1,5 +1,5 @@
 
-[OPA sub-command is available:stdout - 1]
+[TestFeatures/OPA sub-command is available:stdout - 1]
 An open source project to policy-enable your service.
 
 Usage:
@@ -42,6 +42,6 @@ Use "ec opa [command] --help" for more information about a command.
 
 ---
 
-[OPA sub-command is available:stderr - 1]
+[TestFeatures/OPA sub-command is available:stderr - 1]
 
 ---

--- a/features/__snapshots__/ta_task_validate_image.snap
+++ b/features/__snapshots__/ta_task_validate_image.snap
@@ -1,5 +1,5 @@
 
-[Golden container image with trusted artifacts:report-json - 1]
+[TestFeatures/Golden container image with trusted artifacts:report-json - 1]
 {
   "success": true,
   "components": [
@@ -131,14 +131,14 @@
 }
 ---
 
-[Golden container image with trusted artifacts:results - 1]
+[TestFeatures/Golden container image with trusted artifacts:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n",
   "VSA_GENERATED": "false"
 }
 ---
 
-[Golden container image with trusted artifacts:show-config - 1]
+[TestFeatures/Golden container image with trusted artifacts:show-config - 1]
 {
   "policy": {
     "sources": [

--- a/features/__snapshots__/task_validate_image.snap
+++ b/features/__snapshots__/task_validate_image.snap
@@ -1,39 +1,39 @@
 
-[Non strict with warnings:results - 1]
+[TestFeatures/Non strict with warnings:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":1,\"result\":\"WARNING\"}\n"
 }
 ---
 
-[Outputs are there:initialize-tuf - 1]
+[TestFeatures/Outputs are there:initialize-tuf - 1]
 ${TIMESTAMP} INFO Step was skipped due to when expressions were evaluated to false.
 
 ---
 
-[Golden container image:results - 1]
+[TestFeatures/Golden container image:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Initialize TUF fails:initialize-tuf - 1]
+[TestFeatures/Initialize TUF fails:initialize-tuf - 1]
 Error: Get "http://tuf.invalid/root.json": dial tcp: lookup tuf.invalid on 10.96.0.10:53: no such host
 
 ---
 
-[Titles and descriptions can be excluded:results - 1]
+[TestFeatures/Titles and descriptions can be excluded:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Strict with failures:results - 1]
+[TestFeatures/Strict with failures:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":0,\"failures\":1,\"warnings\":0,\"result\":\"FAILURE\"}\n"
 }
 ---
 
-[Golden container image:show-config - 1]
+[TestFeatures/Golden container image:show-config - 1]
 {
   "policy": {
     "sources": [
@@ -56,36 +56,36 @@ Error: Get "http://tuf.invalid/root.json": dial tcp: lookup tuf.invalid on 10.96
 }
 ---
 
-[Extra rule data provided to task:results - 1]
+[TestFeatures/Extra rule data provided to task:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Initialize TUF succeeds:initialize-tuf - 1]
+[TestFeatures/Initialize TUF succeeds:initialize-tuf - 1]
 ${TIMESTAMP} INFO Step was skipped due to when expressions were evaluated to false.
 
 ---
 
-[Strict with warnings:results - 1]
+[TestFeatures/Strict with warnings:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":1,\"result\":\"WARNING\"}\n"
 }
 ---
 
-[Non strict with failures:results - 1]
+[TestFeatures/Non strict with failures:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":0,\"failures\":1,\"warnings\":0,\"result\":\"FAILURE\"}\n"
 }
 ---
 
-[PUBLIC_KEY param overwrites key from policy:results - 1]
+[TestFeatures/PUBLIC_KEY param overwrites key from policy:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Outputs are there:summary - 1]
+[TestFeatures/Outputs are there:summary - 1]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
@@ -96,21 +96,21 @@ ${TIMESTAMP} INFO Step was skipped due to when expressions were evaluated to fal
 }
 ---
 
-[Initialize TUF fails:results - 1]
+[TestFeatures/Initialize TUF fails:results - 1]
 {}
 ---
 
-[Initialize TUF succeeds:results - 1]
+[TestFeatures/Initialize TUF succeeds:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Outputs are there:assert - 1]
+[TestFeatures/Outputs are there:assert - 1]
 true
 ---
 
-[Outputs are there:report-json - 1]
+[TestFeatures/Outputs are there:report-json - 1]
 {
   "success": true,
   "components": [
@@ -175,13 +175,13 @@ true
 }
 ---
 
-[Outputs are there:results - 1]
+[TestFeatures/Outputs are there:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":3,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Keyless signing verification cosign v3 style:report-json - 1]
+[TestFeatures/Keyless signing verification cosign v3 style:report-json - 1]
 {
   "success": true,
   "components": [
@@ -304,13 +304,13 @@ true
 }
 ---
 
-[Keyless signing verification cosign v3 style:results - 1]
+[TestFeatures/Keyless signing verification cosign v3 style:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Keyless signing verification cosign v2 style:report-json - 1]
+[TestFeatures/Keyless signing verification cosign v2 style:report-json - 1]
 {
   "success": true,
   "components": [
@@ -448,13 +448,13 @@ true
 }
 ---
 
-[Keyless signing verification cosign v2 style:results - 1]
+[TestFeatures/Keyless signing verification cosign v2 style:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Collect keyless signing parameters from ConfigMap:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters from ConfigMap:collect-signing-params - 1]
 Reading ConfigMap konflux-info/cluster-config
 ConfigMap found, extracting keyless signing parameters
 results.keylessSigningEnabled: true
@@ -467,7 +467,7 @@ results.tufUrl: https://tuf.internal.svc
 
 ---
 
-[Collect keyless signing parameters from ConfigMap with external url fallback:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters from ConfigMap with external url fallback:collect-signing-params - 1]
 Reading ConfigMap konflux-info/cluster-config-1
 ConfigMap found, extracting keyless signing parameters
 results.keylessSigningEnabled: true
@@ -480,7 +480,7 @@ results.tufUrl: https://tuf.example.com
 
 ---
 
-[Collect keyless signing parameters from ConfigMap with keyless signing disabled:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters from ConfigMap with keyless signing disabled:collect-signing-params - 1]
 Reading ConfigMap konflux-info/cluster-config-2
 ConfigMap found, extracting keyless signing parameters
 enableKeylessSigning is not set, using default empty values
@@ -494,7 +494,7 @@ results.tufUrl:
 
 ---
 
-[Collect keyless signing parameters when there is a malformed ConfigMap:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters when there is a malformed ConfigMap:collect-signing-params - 1]
 Reading ConfigMap konflux-info/cluster-config-3
 ConfigMap found, extracting keyless signing parameters
 enableKeylessSigning is not set, using default empty values
@@ -508,7 +508,7 @@ results.tufUrl:
 
 ---
 
-[Collect keyless signing parameters when the ConfigMap does not exist:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters when the ConfigMap does not exist:collect-signing-params - 1]
 Reading ConfigMap konflux-info/doesnt-exist-config
 ConfigMap not found, using default empty values
 results.keylessSigningEnabled: false
@@ -521,7 +521,7 @@ results.tufUrl:
 
 ---
 
-[Collect keyless signing parameters when the namespace does not exist:collect-signing-params - 1]
+[TestFeatures/Collect keyless signing parameters when the namespace does not exist:collect-signing-params - 1]
 Reading ConfigMap doesnt-exist-namespace/whatever
 ConfigMap not found, using default empty values
 results.keylessSigningEnabled: false
@@ -534,7 +534,7 @@ results.tufUrl:
 
 ---
 
-[Keyless signing verification cosign v2 style with regexp params:report-json - 1]
+[TestFeatures/Keyless signing verification cosign v2 style with regexp params:report-json - 1]
 {
   "success": true,
   "components": [
@@ -672,13 +672,13 @@ results.tufUrl:
 }
 ---
 
-[Keyless signing verification cosign v2 style with regexp params:results - 1]
+[TestFeatures/Keyless signing verification cosign v2 style with regexp params:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":5,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\"}\n"
 }
 ---
 
-[Keyless signing verification cosign v3 style with regexp params:report-json - 1]
+[TestFeatures/Keyless signing verification cosign v3 style with regexp params:report-json - 1]
 {
   "success": false,
   "components": [
@@ -729,7 +729,7 @@ results.tufUrl:
 }
 ---
 
-[Keyless signing verification cosign v3 style with regexp params:results - 1]
+[TestFeatures/Keyless signing verification cosign v3 style with regexp params:results - 1]
 {
   "TEST_OUTPUT": "{\"timestamp\":\"${TIMESTAMP}\",\"namespace\":\"\",\"successes\":0,\"failures\":2,\"warnings\":0,\"result\":\"FAILURE\"}\n"
 }

--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -1,5 +1,5 @@
 
-[Fresh tags:stdout - 1]
+[TestFeatures/Fresh tags:stdout - 1]
 /-/-/-/
 trusted_tasks:
   oci://${REGISTRY}/acceptance/bundle:tag:
@@ -9,30 +9,30 @@ trusted_tasks:
 
 ---
 
-[Fresh tags:stderr - 1]
+[TestFeatures/Fresh tags:stderr - 1]
 
 ---
 
-[Track git references, without git id:stdout - 1]
+[TestFeatures/Track git references, without git id:stdout - 1]
 
 ---
 
-[Track git references, without git id:stderr - 1]
+[TestFeatures/Track git references, without git id:stderr - 1]
 Error: expected "git+https://${GITHOST}/git/tasks.git//task.yaml" to contain the revision information following the `@`, e.g. git+https://github.com/org/repository//task/0.1/task.yaml@f0cacc1a, to fetch the latest revision from a remote URL provide the --freshen parameter
 
 ---
 
-[Pipeline definition is ignored on its own:stdout - 1]
+[TestFeatures/Pipeline definition is ignored on its own:stdout - 1]
 /-/-/-/
 {}
 
 ---
 
-[Pipeline definition is ignored on its own:stderr - 1]
+[TestFeatures/Pipeline definition is ignored on its own:stderr - 1]
 
 ---
 
-[Track tekton-task alias:stdout - 1]
+[TestFeatures/Track tekton-task alias:stdout - 1]
 /-/-/-/
 trusted_tasks:
   git+https://github.com/konflux-ci/build-definitions.git//task/buildah/0.1/buildah.yaml:
@@ -42,11 +42,11 @@ trusted_tasks:
 
 ---
 
-[Track tekton-task alias:stderr - 1]
+[TestFeatures/Track tekton-task alias:stderr - 1]
 
 ---
 
-[Track git references, with freshen:stdout - 1]
+[TestFeatures/Track git references, with freshen:stdout - 1]
 /-/-/-/
 trusted_tasks:
   git+https://${GITHOST}/git/tasks.git//task.yaml:
@@ -54,11 +54,11 @@ trusted_tasks:
 
 ---
 
-[Track git references, with freshen:stderr - 1]
+[TestFeatures/Track git references, with freshen:stderr - 1]
 
 ---
 
-[Track git references, with prune:stdout - 1]
+[TestFeatures/Track git references, with prune:stdout - 1]
 /-/-/-/
 trusted_tasks:
   git+https://forge.io/organization/repository.git//task/0.1/task.yaml:
@@ -66,11 +66,11 @@ trusted_tasks:
 
 ---
 
-[Track git references, with prune:stderr - 1]
+[TestFeatures/Track git references, with prune:stderr - 1]
 
 ---
 
-[Track git references, append to existing:stdout - 1]
+[TestFeatures/Track git references, append to existing:stdout - 1]
 /-/-/-/
 trusted_tasks:
   git+https://forge.io/organization/repository.git//task/0.1/task.yaml:
@@ -80,11 +80,11 @@ trusted_tasks:
 
 ---
 
-[Track git references, append to existing:stderr - 1]
+[TestFeatures/Track git references, append to existing:stderr - 1]
 
 ---
 
-[Pipeline definition is ignored from mixed bundle:stdout - 1]
+[TestFeatures/Pipeline definition is ignored from mixed bundle:stdout - 1]
 /-/-/-/
 trusted_tasks:
   oci://${REGISTRY}/acceptance/bundle:tag:
@@ -92,11 +92,11 @@ trusted_tasks:
 
 ---
 
-[Pipeline definition is ignored from mixed bundle:stderr - 1]
+[TestFeatures/Pipeline definition is ignored from mixed bundle:stderr - 1]
 
 ---
 
-[Track git references:stdout - 1]
+[TestFeatures/Track git references:stdout - 1]
 /-/-/-/
 trusted_tasks:
   git+https://github.com/konflux-ci/build-definitions.git//task/buildah/0.1/buildah.yaml:
@@ -104,11 +104,11 @@ trusted_tasks:
 
 ---
 
-[Track git references:stderr - 1]
+[TestFeatures/Track git references:stderr - 1]
 
 ---
 
-[:stdout - 1]
+[TestFeatures/:stdout - 1]
 /-/-/-/
 trusted_tasks:
   oci://${REGISTRY}/acceptance/bundle:tag:
@@ -116,6 +116,6 @@ trusted_tasks:
 
 ---
 
-[:stderr - 1]
+[TestFeatures/:stderr - 1]
 
 ---

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1,4 +1,5 @@
-[happy day with git config and yaml:stdout - 1]
+
+[TestFeatures/happy day with git config and yaml:stdout - 1]
 {
   "success": true,
   "components": [
@@ -71,20 +72,21 @@
 }
 ---
 
-[happy day with git config and yaml:stderr - 1]
+[TestFeatures/happy day with git config and yaml:stderr - 1]
 
 ---
 
-[JUnit and AppStudio output format:stdout - 1]
+[TestFeatures/JUnit and AppStudio output format:stdout - 1]
 <testsuites tests="7" failures="3"><testsuite name="Unnamed (${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST})" tests="7" failures="3" errors="0" id="0" time="" timestamp="${TIMESTAMP}"><properties><property name="image" value="${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}"></property><property name="key" value="${known_PUBLIC_KEY_XML}"></property><property name="success" value="false"></property><property name="keyId" value=""></property><property name="signature" value="${IMAGE_SIGNATURE_acceptance/image}"></property></properties><testcase name="builtin.attestation.signature_check: Pass" classname="builtin.attestation.signature_check: Pass"></testcase><testcase name="builtin.attestation.syntax_check: Pass" classname="builtin.attestation.syntax_check: Pass"></testcase><testcase name="builtin.image.signature_check: Pass" classname="builtin.image.signature_check: Pass"></testcase><testcase name="main.acceptor: Pass" classname="main.acceptor: Pass"></testcase><testcase name="main.reject_with_term: Fails always (term1) [term=term1]" classname="main.reject_with_term: Fails always (term1) [term=term1]"><failure message="Fails always (term1)"><![CDATA[Fails always (term1)]]></failure></testcase><testcase name="main.reject_with_term: Fails always (term2) [term=[term2 term3]]" classname="main.reject_with_term: Fails always (term2) [term=[term2 term3]]"><failure message="Fails always (term2)"><![CDATA[Fails always (term2)]]></failure></testcase><testcase name="main.rejector: Fails always" classname="main.rejector: Fails always"><failure message="Fails always"><![CDATA[Fails always]]></failure></testcase></testsuite></testsuites>
 
 ---
 
-[JUnit and AppStudio output format:stderr - 1]
+[TestFeatures/JUnit and AppStudio output format:stderr - 1]
 Error: success criteria not met
 
 ---
-[JUnit and AppStudio output format:stdout - 2]
+
+[TestFeatures/JUnit and AppStudio output format:stdout - 2]
 {
   "timestamp": "${TIMESTAMP}",
   "namespace": "",
@@ -94,11 +96,13 @@ Error: success criteria not met
   "result": "FAILURE"
 }
 ---
-[JUnit and AppStudio output format:stderr - 2]
+
+[TestFeatures/JUnit and AppStudio output format:stderr - 2]
 Error: success criteria not met
 
 ---
-[policy and data sources:stdout - 1]
+
+[TestFeatures/policy and data sources:stdout - 1]
 {
   "success": false,
   "components": [
@@ -184,12 +188,12 @@ Error: success criteria not met
 }
 ---
 
-[policy and data sources:stderr - 1]
+[TestFeatures/policy and data sources:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[inline policy:stdout - 1]
+[TestFeatures/inline policy:stdout - 1]
 {
   "success": true,
   "components": [
@@ -262,11 +266,11 @@ Error: success criteria not met
 }
 ---
 
-[inline policy:stderr - 1]
+[TestFeatures/inline policy:stderr - 1]
 
 ---
 
-[happy day with git config and json:stdout - 1]
+[TestFeatures/happy day with git config and json:stdout - 1]
 {
   "success": true,
   "components": [
@@ -339,11 +343,11 @@ Error: success criteria not met
 }
 ---
 
-[happy day with git config and json:stderr - 1]
+[TestFeatures/happy day with git config and json:stderr - 1]
 
 ---
 
-[future failure is converted to a warning:stdout - 1]
+[TestFeatures/future failure is converted to a warning:stdout - 1]
 {
   "success": true,
   "components": [
@@ -418,11 +422,11 @@ Error: success criteria not met
 }
 ---
 
-[future failure is converted to a warning:stderr - 1]
+[TestFeatures/future failure is converted to a warning:stderr - 1]
 
 ---
 
-[Custom rule data:stdout - 1]
+[TestFeatures/Custom rule data:stdout - 1]
 {
   "success": true,
   "components": [
@@ -524,11 +528,11 @@ Error: success criteria not met
 }
 ---
 
-[Custom rule data:stderr - 1]
+[TestFeatures/Custom rule data:stderr - 1]
 
 ---
 
-[multiple policy sources with multiple source groups:stdout - 1]
+[TestFeatures/multiple policy sources with multiple source groups:stdout - 1]
 {
   "success": false,
   "components": [
@@ -641,12 +645,12 @@ Error: success criteria not met
 }
 ---
 
-[multiple policy sources with multiple source groups:stderr - 1]
+[TestFeatures/multiple policy sources with multiple source groups:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[mismatched image digest in signature:stdout - 1]
+[TestFeatures/mismatched image digest in signature:stdout - 1]
 {
   "success": false,
   "components": [
@@ -715,12 +719,12 @@ Error: success criteria not met
 }
 ---
 
-[mismatched image digest in signature:stderr - 1]
+[TestFeatures/mismatched image digest in signature:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[policy rule filtering:stdout - 1]
+[TestFeatures/policy rule filtering:stdout - 1]
 {
   "success": true,
   "components": [
@@ -809,11 +813,11 @@ Error: success criteria not met
 }
 ---
 
-[policy rule filtering:stderr - 1]
+[TestFeatures/policy rule filtering:stderr - 1]
 
 ---
 
-[policy rule filtering on imageRef:stdout - 1]
+[TestFeatures/policy rule filtering on imageRef:stdout - 1]
 {
   "success": true,
   "components": [
@@ -911,11 +915,11 @@ Error: success criteria not met
 }
 ---
 
-[policy rule filtering on imageRef:stderr - 1]
+[TestFeatures/policy rule filtering on imageRef:stderr - 1]
 
 ---
 
-[policy rule filtering on imageUrl:stdout - 1]
+[TestFeatures/policy rule filtering on imageUrl:stdout - 1]
 {
   "success": true,
   "components": [
@@ -1013,11 +1017,11 @@ Error: success criteria not met
 }
 ---
 
-[policy rule filtering on imageUrl:stderr - 1]
+[TestFeatures/policy rule filtering on imageUrl:stderr - 1]
 
 ---
 
-[application snapshot reference:stdout - 1]
+[TestFeatures/application snapshot reference:stdout - 1]
 {
   "success": true,
   "snapshot": "acceptance/happy",
@@ -1091,11 +1095,11 @@ Error: success criteria not met
 }
 ---
 
-[application snapshot reference:stderr - 1]
+[TestFeatures/application snapshot reference:stderr - 1]
 
 ---
 
-[multiple policy sources with one source group:stdout - 1]
+[TestFeatures/multiple policy sources with one source group:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1200,12 +1204,12 @@ Error: success criteria not met
 }
 ---
 
-[multiple policy sources with one source group:stderr - 1]
+[TestFeatures/multiple policy sources with one source group:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[unexpected image signature cert:stdout - 1]
+[TestFeatures/unexpected image signature cert:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1245,12 +1249,12 @@ Error: success criteria not met
 }
 ---
 
-[unexpected image signature cert:stderr - 1]
+[TestFeatures/unexpected image signature cert:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[invalid image signature:stdout - 1]
+[TestFeatures/invalid image signature:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1292,12 +1296,12 @@ Error: success criteria not met
 }
 ---
 
-[invalid image signature:stderr - 1]
+[TestFeatures/invalid image signature:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[policy rule filtering for successes:stdout - 1]
+[TestFeatures/policy rule filtering for successes:stdout - 1]
 {
   "success": true,
   "components": [
@@ -1380,20 +1384,20 @@ Error: success criteria not met
 }
 ---
 
-[policy rule filtering for successes:stderr - 1]
+[TestFeatures/policy rule filtering for successes:stderr - 1]
 
 ---
 
-[happy day with missing git config:stdout - 1]
+[TestFeatures/happy day with missing git config:stdout - 1]
 
 ---
 
-[happy day with missing git config:stderr - 1]
+[TestFeatures/happy day with missing git config:stderr - 1]
 Error: no suitable config file found at git::${GITHOST}/git/happy-config.git?ref=${LATEST_COMMIT}
 
 ---
 
-[using attestation time as effective time:stdout - 1]
+[TestFeatures/using attestation time as effective time:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1468,12 +1472,12 @@ Error: no suitable config file found at git::${GITHOST}/git/happy-config.git?ref
 }
 ---
 
-[using attestation time as effective time:stderr - 1]
+[TestFeatures/using attestation time as effective time:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[inline application snapshot:stdout - 1]
+[TestFeatures/inline application snapshot:stdout - 1]
 {
   "success": true,
   "components": [
@@ -1546,11 +1550,11 @@ Error: success criteria not met
 }
 ---
 
-[inline application snapshot:stderr - 1]
+[TestFeatures/inline application snapshot:stderr - 1]
 
 ---
 
-[happy day with keyless:stdout - 1]
+[TestFeatures/happy day with keyless:stdout - 1]
 {
   "success": true,
   "components": [
@@ -1677,11 +1681,11 @@ Error: success criteria not met
 }
 ---
 
-[happy day with keyless:stderr - 1]
+[TestFeatures/happy day with keyless:stderr - 1]
 
 ---
 
-[mismatched image digest in attestation:stdout - 1]
+[TestFeatures/mismatched image digest in attestation:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1725,12 +1729,12 @@ Error: success criteria not met
 }
 ---
 
-[mismatched image digest in attestation:stderr - 1]
+[TestFeatures/mismatched image digest in attestation:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[artifact relocation:stdout - 1]
+[TestFeatures/artifact relocation:stdout - 1]
 {
   "success": true,
   "components": [
@@ -1803,10 +1807,11 @@ Error: success criteria not met
 }
 ---
 
-[artifact relocation:stderr - 1]
+[TestFeatures/artifact relocation:stderr - 1]
 
 ---
-[detailed failures output:stdout - 1]
+
+[TestFeatures/detailed failures output:stdout - 1]
 {
   "success": false,
   "components": [
@@ -1933,11 +1938,12 @@ Error: success criteria not met
 }
 ---
 
-[detailed failures output:stderr - 1]
+[TestFeatures/detailed failures output:stderr - 1]
 Error: success criteria not met
 
 ---
-[detailed failures output:${TMPDIR}/output.txt - 1]
+
+[TestFeatures/detailed failures output:${TMPDIR}/output.txt - 1]
 Success: false
 Result: FAILURE
 Violations: 3, Warnings: 0, Successes: 4
@@ -1994,7 +2000,8 @@ Results:
 For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/
 
 ---
-[future failure is a deny when using effective-date flag:stdout - 1]
+
+[TestFeatures/future failure is a deny when using effective-date flag:stdout - 1]
 {
   "success": false,
   "components": [
@@ -2069,12 +2076,12 @@ For more information about policy issues, see the policy documentation: https://
 }
 ---
 
-[future failure is a deny when using effective-date flag:stderr - 1]
+[TestFeatures/future failure is a deny when using effective-date flag:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[Using OCI bundles:stdout - 1]
+[TestFeatures/Using OCI bundles:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2148,15 +2155,15 @@ Error: success criteria not met
 }
 ---
 
-[Using OCI bundles:stderr - 1]
+[TestFeatures/Using OCI bundles:stderr - 1]
 
 ---
 
-[Dropping rego capabilities:stdout - 1]
+[TestFeatures/Dropping rego capabilities:stdout - 1]
 
 ---
 
-[Dropping rego capabilities:stderr - 1]
+[TestFeatures/Dropping rego capabilities:stderr - 1]
 Error: error validating image ${REGISTRY}/acceptance/ec-happy-day of component Unnamed: load: loading policies: get compiler: 3 errors occurred:
 ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:14: rego_type_error: undefined function opa.runtime
 ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:22: rego_type_error: undefined function http.send
@@ -2164,7 +2171,7 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:33: rego_type_error: undefi
 
 ---
 
-[happy day:stdout - 1]
+[TestFeatures/happy day:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2237,11 +2244,11 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:33: rego_type_error: undefi
 }
 ---
 
-[happy day:stderr - 1]
+[TestFeatures/happy day:stderr - 1]
 
 ---
 
-[happy day with extra rule data:stdout - 1]
+[TestFeatures/happy day with extra rule data:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2317,21 +2324,21 @@ ${TEMP}/ec-work-${RANDOM}/policy/${RANDOM}/main.rego:33: rego_type_error: undefi
 }
 ---
 
-[happy day with extra rule data:stderr - 1]
+[TestFeatures/happy day with extra rule data:stderr - 1]
 
 ---
 
-[happy day with invalid extra rule data:stdout - 1]
+[TestFeatures/happy day with invalid extra rule data:stdout - 1]
 
 ---
 
-[happy day with invalid extra rule data:stderr - 1]
+[TestFeatures/happy day with invalid extra rule data:stderr - 1]
 Error: incorrect syntax for --extra-rule-data 0
 incorrect syntax for --extra-rule-data 1
 
 ---
 
-[rule dependencies:stdout - 1]
+[TestFeatures/rule dependencies:stdout - 1]
 {
   "success": false,
   "components": [
@@ -2414,12 +2421,12 @@ incorrect syntax for --extra-rule-data 1
 }
 ---
 
-[rule dependencies:stderr - 1]
+[TestFeatures/rule dependencies:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[successes are not duplicated:stdout - 1]
+[TestFeatures/successes are not duplicated:stdout - 1]
 {
   "success": false,
   "components": [
@@ -2506,43 +2513,11 @@ Error: success criteria not met
 }
 ---
 
-[successes are not duplicated:stderr - 1]
+[TestFeatures/successes are not duplicated:stderr - 1]
 
 ---
 
-[Custom rule data:${TMPDIR}/custom-rule-data.yaml - 1]
-- - config:
-      default_sigstore_opts:
-        certificate_identity: ""
-        certificate_identity_regexp: ""
-        certificate_oidc_issuer: ""
-        certificate_oidc_issuer_regexp: ""
-        ignore_rekor: false
-        public_key: |
-${__________known_PUBLIC_KEY}
-        rekor_url: ${REKOR}
-      policy:
-        when_ns: 1401494400000000000
-    rule_data__configuration__:
-      custom: data1
-  - config:
-      default_sigstore_opts:
-        certificate_identity: ""
-        certificate_identity_regexp: ""
-        certificate_oidc_issuer: ""
-        certificate_oidc_issuer_regexp: ""
-        ignore_rekor: false
-        public_key: |
-${__________known_PUBLIC_KEY}
-        rekor_url: ${REKOR}
-      policy:
-        when_ns: 1401494400000000000
-    rule_data__configuration__:
-      other: data2
-
----
-
-[image config:stdout - 1]
+[TestFeatures/image config:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2639,11 +2614,11 @@ ${__________known_PUBLIC_KEY}
 }
 ---
 
-[image config:stderr - 1]
+[TestFeatures/image config:stderr - 1]
 
 ---
 
-[Output attestations:stdout - 1]
+[TestFeatures/Output attestations:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2690,11 +2665,11 @@ ${__________known_PUBLIC_KEY}
 }
 ---
 
-[Output attestations:stderr - 1]
+[TestFeatures/Output attestations:stderr - 1]
 
 ---
 
-[Output attestations:${TMPDIR}/attestation.jsonl - 1]
+[TestFeatures/Output attestations:${TMPDIR}/attestation.jsonl - 1]
 {
   "_type": "https://in-toto.io/Statement/v0.1",
   "predicateType": "https://slsa.dev/provenance/v0.2",
@@ -2718,7 +2693,7 @@ ${__________known_PUBLIC_KEY}
 }
 ---
 
-[policy input output:stdout - 1]
+[TestFeatures/policy input output:stdout - 1]
 {
   "attestations": [
     {
@@ -2800,11 +2775,11 @@ ${__________known_PUBLIC_KEY}
 }
 ---
 
-[policy input output:stderr - 1]
+[TestFeatures/policy input output:stderr - 1]
 
 ---
 
-[ignore rekor:stdout - 1]
+[TestFeatures/ignore rekor:stdout - 1]
 {
   "success": true,
   "components": [
@@ -2850,62 +2825,15 @@ ${__________known_PUBLIC_KEY}
 }
 ---
 
-[ignore rekor:stderr - 1]
+[TestFeatures/ignore rekor:stderr - 1]
 
 ---
 
-[rekor entries required:stdout - 1]
-{
-  "success": false,
-  "components": [
-    {
-      "name": "Unnamed",
-      "containerImage": "${REGISTRY}/acceptance/rekor-by-default@sha256:${REGISTRY_acceptance/rekor-by-default:latest_DIGEST}",
-      "source": {},
-      "violations": [
-        {
-          "msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created. Error: no matching attestations: searching log query: \u0026{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created. Error: no matching signatures: searching log query: \u0026{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        }
-      ],
-      "success": false
-    }
-  ],
-  "key": "${known_PUBLIC_KEY_JSON}",
-  "policy": {
-    "sources": [
-      {
-        "policy": [
-          "git::${GITHOST}/git/rekor-by-default.git?ref=${LATEST_COMMIT}"
-        ]
-      }
-    ],
-    "rekorUrl": "${REKOR}",
-    "publicKey": "${known_PUBLIC_KEY}"
-  },
-  "ec-version": "${EC_VERSION}",
-  "effective-time": "${TIMESTAMP}"
-}
----
-
-[rekor entries required:stderr - 1]
-Error: success criteria not met
+[TestFeatures/OLM manifests:stderr - 1]
 
 ---
 
-[OLM manifests:stderr - 1]
-
----
-
-[OLM manifests:${TMPDIR}/input.json - 1]
+[TestFeatures/OLM manifests:${TMPDIR}/input.json - 1]
 {
   "attestations": [
     {
@@ -3174,7 +3102,7 @@ Error: success criteria not met
 }
 ---
 
-[OLM manifests:stdout - 1]
+[TestFeatures/OLM manifests:stdout - 1]
 {
   "success": true,
   "components": [
@@ -3252,16 +3180,16 @@ Error: success criteria not met
 }
 ---
 
-[Unsupported policies:stdout - 1]
+[TestFeatures/Unsupported policies:stdout - 1]
 
 ---
 
-[Unsupported policies:stderr - 1]
+[TestFeatures/Unsupported policies:stderr - 1]
 Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed: the rule "deny = true if { true }" returns an unsupported value, at main.rego:5
 
 ---
 
-[fetch OCI blob:stdout - 1]
+[TestFeatures/fetch OCI blob:stdout - 1]
 {
   "success": true,
   "components": [
@@ -3340,11 +3268,11 @@ Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed:
 }
 ---
 
-[fetch OCI blob:stderr - 1]
+[TestFeatures/fetch OCI blob:stderr - 1]
 
 ---
 
-[policy rule filtering per source:stdout - 1]
+[TestFeatures/policy rule filtering per source:stdout - 1]
 {
   "success": true,
   "components": [
@@ -3427,11 +3355,11 @@ Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed:
 }
 ---
 
-[policy rule filtering per source:stderr - 1]
+[TestFeatures/policy rule filtering per source:stderr - 1]
 
 ---
 
-[PURL functions:stdout - 1]
+[TestFeatures/PURL functions:stdout - 1]
 {
   "success": false,
   "components": [
@@ -3524,13 +3452,13 @@ Error: error validating image ${REGISTRY}/acceptance/image of component Unnamed:
 }
 ---
 
-[PURL functions:stderr - 1]
+[TestFeatures/PURL functions:stderr - 1]
 time="${TIMESTAMP}" level=error msg="failed to parse PURL" error="purl scheme is not \"pkg\": \"\"" function=ec.purl.parse purl=this-is-not-a-valid-purl
 Error: success criteria not met
 
 ---
 
-[fetch OCI image manifest:stdout - 1]
+[TestFeatures/fetch OCI image manifest:stdout - 1]
 {
   "success": true,
   "components": [
@@ -3603,11 +3531,11 @@ Error: success criteria not met
 }
 ---
 
-[fetch OCI image manifest:stderr - 1]
+[TestFeatures/fetch OCI image manifest:stderr - 1]
 
 ---
 
-[sigstore functions:stdout - 1]
+[TestFeatures/sigstore functions:stdout - 1]
 {
   "success": true,
   "components": [
@@ -3680,1163 +3608,11 @@ Error: success criteria not met
 }
 ---
 
-[sigstore functions:stderr - 1]
+[TestFeatures/sigstore functions:stderr - 1]
 
 ---
 
-[many components and sources:stdout - 1]
-{
-  "success": true,
-  "snapshot": "acceptance/multitude",
-  "components": [
-    {
-      "name": "component9",
-      "containerImage": "${REGISTRY}/multitude/image-9@sha256:${REGISTRY_multitude/image-9:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-9}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-9}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component8",
-      "containerImage": "${REGISTRY}/multitude/image-8@sha256:${REGISTRY_multitude/image-8:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-8}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-8}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component7",
-      "containerImage": "${REGISTRY}/multitude/image-7@sha256:${REGISTRY_multitude/image-7:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-7}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-7}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component6",
-      "containerImage": "${REGISTRY}/multitude/image-6@sha256:${REGISTRY_multitude/image-6:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-6}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-6}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component5",
-      "containerImage": "${REGISTRY}/multitude/image-5@sha256:${REGISTRY_multitude/image-5:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-5}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-5}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component4",
-      "containerImage": "${REGISTRY}/multitude/image-4@sha256:${REGISTRY_multitude/image-4:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-4}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-4}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component3",
-      "containerImage": "${REGISTRY}/multitude/image-3@sha256:${REGISTRY_multitude/image-3:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-3}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-3}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component2",
-      "containerImage": "${REGISTRY}/multitude/image-2@sha256:${REGISTRY_multitude/image-2:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-2}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-2}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component1",
-      "containerImage": "${REGISTRY}/multitude/image-1@sha256:${REGISTRY_multitude/image-1:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-1}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-1}"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "component0",
-      "containerImage": "${REGISTRY}/multitude/image-0@sha256:${REGISTRY_multitude/image-0:latest_DIGEST}",
-      "source": {},
-      "successes": [
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.attestation.syntax_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "builtin.image.signature_check"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        },
-        {
-          "msg": "Pass",
-          "metadata": {
-            "code": "main.acceptor"
-          }
-        }
-      ],
-      "success": true,
-      "signatures": [
-        {
-          "keyid": "",
-          "sig": "${IMAGE_SIGNATURE_multitude/image-0}"
-        }
-      ],
-      "attestations": [
-        {
-          "type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
-          "signatures": [
-            {
-              "keyid": "",
-              "sig": "${ATTESTATION_SIGNATURE_multitude/image-0}"
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "key": "${known_PUBLIC_KEY_JSON}",
-  "policy": {
-    "sources": [
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "key": "value"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "something": "here"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "key": "different"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "hello": "world"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "foo": "bar"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "peek": "poke"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "hide": "seek"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "hokus": "pokus"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "mr": "mxyzptlk"
-        }
-      },
-      {
-        "policy": [
-          "git::${GITHOST}/git/multitude-policy.git?ref=${LATEST_COMMIT}"
-        ],
-        "ruleData": {
-          "more": "data"
-        }
-      }
-    ],
-    "rekorUrl": "${REKOR}",
-    "publicKey": "${known_PUBLIC_KEY}"
-  },
-  "ec-version": "${EC_VERSION}",
-  "effective-time": "${TIMESTAMP}"
-}
----
-
-[many components and sources:stderr - 1]
-
----
-
-[Format options:stdout - 1]
+[TestFeatures/Format options:stdout - 1]
 Success: false
 Result: FAILURE
 Violations: 3, Warnings: 0, Successes: 4
@@ -4862,12 +3638,12 @@ For more information about policy issues, see the policy documentation: https://
 
 ---
 
-[Format options:stderr - 1]
+[TestFeatures/Format options:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[Format options:${TMPDIR}/output.json - 1]
+[TestFeatures/Format options:${TMPDIR}/output.json - 1]
 {
   "success": false,
   "components": [
@@ -4965,7 +3741,7 @@ Error: success criteria not met
 }
 ---
 
-[fetch OCI image files:stdout - 1]
+[TestFeatures/fetch OCI image files:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5038,11 +3814,11 @@ Error: success criteria not met
 }
 ---
 
-[fetch OCI image files:stderr - 1]
+[TestFeatures/fetch OCI image files:stderr - 1]
 
 ---
 
-[severity is dynamically adjusted:stdout - 1]
+[TestFeatures/severity is dynamically adjusted:stdout - 1]
 {
   "success": false,
   "components": [
@@ -5143,12 +3919,12 @@ Error: success criteria not met
 }
 ---
 
-[severity is dynamically adjusted:stderr - 1]
+[TestFeatures/severity is dynamically adjusted:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[policy rule filtering fails due to inexistent inclusion patterns:stdout - 1]
+[TestFeatures/policy rule filtering fails due to inexistent inclusion patterns:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5243,11 +4019,11 @@ Error: success criteria not met
 }
 ---
 
-[policy rule filtering fails due to inexistent inclusion patterns:stderr - 1]
+[TestFeatures/policy rule filtering fails due to inexistent inclusion patterns:stderr - 1]
 
 ---
 
-[signatures with embedded bundles verify without external rekor queries:stdout - 1]
+[TestFeatures/signatures with embedded bundles verify without external rekor queries:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5294,11 +4070,11 @@ Error: success criteria not met
 }
 ---
 
-[signatures with embedded bundles verify without external rekor queries:stderr - 1]
+[TestFeatures/signatures with embedded bundles verify without external rekor queries:stderr - 1]
 
 ---
 
-[SLSA v1 attestation support:stdout - 1]
+[TestFeatures/SLSA v1 attestation support:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5371,11 +4147,11 @@ Error: success criteria not met
 }
 ---
 
-[SLSA v1 attestation support:stderr - 1]
+[TestFeatures/SLSA v1 attestation support:stderr - 1]
 
 ---
 
-[volatile config warnings schema contract:stdout - 1]
+[TestFeatures/volatile config warnings schema contract:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5460,11 +4236,11 @@ Error: success criteria not met
 }
 ---
 
-[volatile config warnings schema contract:stderr - 1]
+[TestFeatures/volatile config warnings schema contract:stderr - 1]
 
 ---
 
-[invalid image signature with valid att sig and skip-image-sig-check flag:stdout - 1]
+[TestFeatures/invalid image signature with valid att sig and skip-image-sig-check flag:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5525,11 +4301,11 @@ Error: success criteria not met
 }
 ---
 
-[invalid image signature with valid att sig and skip-image-sig-check flag:stderr - 1]
+[TestFeatures/invalid image signature with valid att sig and skip-image-sig-check flag:stderr - 1]
 
 ---
 
-[happy day with skip-image-sig-check flag:stdout - 1]
+[TestFeatures/happy day with skip-image-sig-check flag:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5590,11 +4366,11 @@ Error: success criteria not met
 }
 ---
 
-[happy day with skip-image-sig-check flag:stderr - 1]
+[TestFeatures/happy day with skip-image-sig-check flag:stderr - 1]
 
 ---
 
-[discover tag-based artifact references:stdout - 1]
+[TestFeatures/discover tag-based artifact references:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5685,11 +4461,11 @@ Error: success criteria not met
 }
 ---
 
-[discover tag-based artifact references:stderr - 1]
+[TestFeatures/discover tag-based artifact references:stderr - 1]
 
 ---
 
-[discover artifact referrers via OCI Referrers API:stdout - 1]
+[TestFeatures/discover artifact referrers via OCI Referrers API:stdout - 1]
 {
   "success": true,
   "components": [
@@ -5774,6 +4550,6 @@ Error: success criteria not met
 }
 ---
 
-[discover artifact referrers via OCI Referrers API:stderr - 1]
+[TestFeatures/discover artifact referrers via OCI Referrers API:stderr - 1]
 
 ---

--- a/features/__snapshots__/validate_input.snap
+++ b/features/__snapshots__/validate_input.snap
@@ -1,5 +1,5 @@
 
-[valid policy URL:stdout - 1]
+[TestFeatures/valid policy URL:stdout - 1]
 {
   "success": true,
   "filepaths": [
@@ -26,10 +26,11 @@
 }
 ---
 
-[valid policy URL:stderr - 1]
+[TestFeatures/valid policy URL:stderr - 1]
 
 ---
-[valid policy URL with text output:stdout - 1]
+
+[TestFeatures/valid policy URL with text output:stdout - 1]
 Success: true
 Result: SUCCESS
 Violations: 0, Warnings: 0, Successes: 1
@@ -42,11 +43,11 @@ Results:
 
 ---
 
-[valid policy URL with text output:stderr - 1]
+[TestFeatures/valid policy URL with text output:stderr - 1]
 
 ---
 
-[policy with multiple sources:stdout - 1]
+[TestFeatures/policy with multiple sources:stdout - 1]
 {
   "success": false,
   "filepaths": [
@@ -91,30 +92,30 @@ Results:
 }
 ---
 
-[policy with multiple sources:stderr - 1]
+[TestFeatures/policy with multiple sources:stderr - 1]
 Error: success criteria not met
 
 ---
 
-[multiple data source top level key clash:stdout - 1]
+[TestFeatures/multiple data source top level key clash:stdout - 1]
 
 ---
 
-[multiple data source top level key clash:stderr - 1]
+[TestFeatures/multiple data source top level key clash:stderr - 1]
 Error: error validating file ${TMPDIR}/input.json: evaluating policy: load: load documents: 1 error occurred during loading: ${TEMP}/ec-work-${RANDOM}/dat${RANDOM}/${RANDOM}/data.yaml: merge error
 
 ---
 
-[policy URL with no rego files:stdout - 1]
+[TestFeatures/policy URL with no rego files:stdout - 1]
 
 ---
 
-[policy URL with no rego files:stderr - 1]
+[TestFeatures/policy URL with no rego files:stderr - 1]
 Error: error validating file pipeline_definition.yaml: evaluating policy: no rego files found in policy subdirectory
 
 ---
 
-[multiple data source top level key map merging:stdout - 1]
+[TestFeatures/multiple data source top level key map merging:stdout - 1]
 ec-version: ${EC_VERSION}
 effective-time: "${TIMESTAMP}"
 filepaths:
@@ -136,11 +137,11 @@ success: true
 
 ---
 
-[multiple data source top level key map merging:stderr - 1]
+[TestFeatures/multiple data source top level key map merging:stderr - 1]
 
 ---
 
-[valid policy URL with publicKey in policy config:stdout - 1]
+[TestFeatures/valid policy URL with publicKey in policy config:stdout - 1]
 {
   "success": true,
   "filepaths": [
@@ -168,6 +169,6 @@ success: true
 }
 ---
 
-[valid policy URL with publicKey in policy config:stderr - 1]
+[TestFeatures/valid policy URL with publicKey in policy config:stderr - 1]
 
 ---

--- a/features/__snapshots__/vsa.snap
+++ b/features/__snapshots__/vsa.snap
@@ -1,5 +1,5 @@
 
-[VSA expiration flag functionality:stdout - 1]
+[TestFeatures/VSA expiration flag functionality:stdout - 1]
 {
   "success": true,
   "components": [
@@ -46,12 +46,12 @@
 }
 ---
 
-[VSA expiration flag functionality:stderr - 1]
+[TestFeatures/VSA expiration flag functionality:stderr - 1]
 time="${TIMESTAMP}" level=warning msg="Failed to check for existing VSA for image ${REGISTRY}/acceptance/vsa-expiration-image@sha256:${REGISTRY_acceptance/vsa-expiration-image:latest_DIGEST}: failed to retrieve VSA envelope: no entries found in Rekor for image digest: sha256:${REGISTRY_acceptance/vsa-expiration-image:latest_DIGEST}"
 
 ---
 
-[VSA generation with local storage backend:stdout - 1]
+[TestFeatures/VSA generation with local storage backend:stdout - 1]
 {
   "success": true,
   "components": [
@@ -98,11 +98,11 @@ time="${TIMESTAMP}" level=warning msg="Failed to check for existing VSA for imag
 }
 ---
 
-[VSA generation with local storage backend:stderr - 1]
+[TestFeatures/VSA generation with local storage backend:stderr - 1]
 
 ---
 
-[VSA expiration with existing valid VSA:stdout - 1]
+[TestFeatures/VSA expiration with existing valid VSA:stdout - 1]
 {
   "success": true,
   "components": [
@@ -149,11 +149,11 @@ time="${TIMESTAMP}" level=warning msg="Failed to check for existing VSA for imag
 }
 ---
 
-[VSA expiration with existing valid VSA:stderr - 1]
+[TestFeatures/VSA expiration with existing valid VSA:stderr - 1]
 
 ---
 
-[VSA generation with Rekor storage backend:stdout - 1]
+[TestFeatures/VSA generation with Rekor storage backend:stdout - 1]
 {
   "success": true,
   "components": [
@@ -200,11 +200,11 @@ time="${TIMESTAMP}" level=warning msg="Failed to check for existing VSA for imag
 }
 ---
 
-[VSA generation with Rekor storage backend:stderr - 1]
+[TestFeatures/VSA generation with Rekor storage backend:stderr - 1]
 
 ---
 
-[VSA generation with invalid storage backend configuration:stdout - 1]
+[TestFeatures/VSA generation with invalid storage backend configuration:stdout - 1]
 {
   "success": true,
   "components": [
@@ -251,13 +251,13 @@ time="${TIMESTAMP}" level=warning msg="Failed to check for existing VSA for imag
 }
 ---
 
-[VSA generation with invalid storage backend configuration:stderr - 1]
+[TestFeatures/VSA generation with invalid storage backend configuration:stderr - 1]
 time="${TIMESTAMP}" level=warning msg="invalid storage config 'invalid-backend@somewhere': unsupported backend 'invalid-backend'. Supported backends: rekor, local"
 time="${TIMESTAMP}" level=warning msg="invalid storage config 'invalid-backend@somewhere': unsupported backend 'invalid-backend'. Supported backends: rekor, local"
 
 ---
 
-[VSA generation with multiple storage backends:stdout - 1]
+[TestFeatures/VSA generation with multiple storage backends:stdout - 1]
 {
   "success": true,
   "components": [
@@ -304,11 +304,11 @@ time="${TIMESTAMP}" level=warning msg="invalid storage config 'invalid-backend@s
 }
 ---
 
-[VSA generation with multiple storage backends:stderr - 1]
+[TestFeatures/VSA generation with multiple storage backends:stderr - 1]
 
 ---
 
-[VSA generation without upload backends shows warning:stdout - 1]
+[TestFeatures/VSA generation without upload backends shows warning:stdout - 1]
 {
   "success": true,
   "components": [
@@ -355,7 +355,7 @@ time="${TIMESTAMP}" level=warning msg="invalid storage config 'invalid-backend@s
 }
 ---
 
-[VSA generation without upload backends shows warning:stderr - 1]
+[TestFeatures/VSA generation without upload backends shows warning:stderr - 1]
 time="${TIMESTAMP}" level=error msg="[VSA] VSA files generated but not uploaded (no --vsa-upload backends specified)"
 
 ---


### PR DESCRIPTION
The go-snaps v0.5.19 upgrade broke UPDATE_SNAPS=true for acceptance
tests. The library's Clean() function requires snapshot entry headers
to start with "[Test", but errCapture.Name() returned bare scenario
names. In v0.5.7 this was harmless because Clean() only truncated
files when obsolete entries were found; in v0.5.19 it always truncates
when UPDATE_SNAPS is set, then rewrites from parsed entries — since
nothing parsed, every snap file was emptied.

- Prefix errCapture.Name() with "TestFeatures/" so Clean() can parse
  the entries, and update all existing snapshot headers to match
- Fix the acceptance Makefile target to propagate snap file deletions
  back from the temp workdir when UPDATE_SNAPS is set

Ref: https://redhat.atlassian.net/browse/EC-1813