### PR TITLE
[troubleshooting] Add ryuk troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ This issue may be resolved by increasing the total number of keys by executing t
 $ echo kernel.keys.maxkeys=1000 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
+#### **2.4. Ryuk reaper container fails to start**
+
+Acceptance tests may fail with errors like `No such container` or `unexpected container status "removing"` when the testcontainers' ryuk reaper container cannot access the Docker socket. To diagnose, run ryuk manually in the foreground:
+``` bash
+$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testcontainers/ryuk:0.11.0
+```
+If the error is `permission denied while trying to connect to the Docker daemon socket`, create or update `~/.testcontainers.properties` with:
+```
+ryuk.container.privileged=true
+```
+
+This tells testcontainers to run the ryuk container with `--privileged`, granting it access to the Docker socket.
+
 #### **3. Apiserver and Rekor Host Resolution Failure**
 
 While running the acceptance tests, you might encounter issues related to apiserver and rekor hosts, like:


### PR DESCRIPTION
## Summary
  - Add troubleshooting entry for ryuk reaper container failures in acceptance tests
  - Documents how to diagnose the issue by running ryuk manually and how to fix it via `~/.testcontainers.properties`
