### PR TITLE
feat(EC-1829): include annotations in OCI referrers response

### DIFF
--- a/docs/modules/ROOT/pages/ec_oci_image_referrers.adoc
+++ b/docs/modules/ROOT/pages/ec_oci_image_referrers.adoc
@@ -12,4 +12,4 @@ Discover artifacts attached to an image via OCI Referrers API.
 
 == Return
 
-`referrers` (`array<object<artifactType: string, digest: string, mediaType: string, ref: string, size: number>>`): list of referrer descriptors discovered via OCI Referrers API
+`referrers` (`array<object<annotations: object[string: string], artifactType: string, digest: string, mediaType: string, ref: string, size: number>>`): list of referrer descriptors discovered via OCI Referrers API

--- a/internal/rego/oci/oci.go
+++ b/internal/rego/oci/oci.go
@@ -446,6 +446,7 @@ func registerOCIImageTagRefs() {
 }
 
 func registerOCIImageReferrers() {
+	annotations := types.NewObject(nil, types.NewDynamicProperty(types.S, types.S))
 	descriptor := types.NewObject(
 		[]*types.StaticProperty{
 			{Key: "mediaType", Value: types.S},
@@ -453,6 +454,7 @@ func registerOCIImageReferrers() {
 			{Key: "digest", Value: types.S},
 			{Key: "artifactType", Value: types.S},
 			{Key: "ref", Value: types.S},
+			{Key: "annotations", Value: annotations},
 		},
 		nil,
 	)
@@ -1511,6 +1513,7 @@ func ociImageReferrers(bctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error)
 			ast.Item(ast.StringTerm("digest"), ast.StringTerm(descriptor.Digest.String())),
 			ast.Item(ast.StringTerm("artifactType"), ast.StringTerm(descriptor.ArtifactType)),
 			ast.Item(ast.StringTerm("ref"), ast.StringTerm(referrerRef)),
+			ast.Item(ast.StringTerm("annotations"), newAnnotationsTerm(descriptor.Annotations)),
 		)
 
 		referrerDescriptors = append(referrerDescriptors, descriptorTerm)

--- a/internal/rego/oci/oci_test.go
+++ b/internal/rego/oci/oci_test.go
@@ -1771,6 +1771,7 @@ func TestOCIImageReferrers(t *testing.T) {
 					require.NotNil(t, obj.Get(ast.StringTerm("mediaType")), "descriptor should have mediaType")
 					require.NotNil(t, obj.Get(ast.StringTerm("size")), "descriptor should have size")
 					require.NotNil(t, obj.Get(ast.StringTerm("artifactType")), "descriptor should have artifactType")
+					require.NotNil(t, obj.Get(ast.StringTerm("annotations")), "descriptor should have annotations")
 				}
 
 				// Verify the referrers match (order-independent)
@@ -1778,4 +1779,29 @@ func TestOCIImageReferrers(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify annotations field is present as an object on every referrer descriptor
+	t.Run("annotations field is an object", func(t *testing.T) {
+		ClearCaches()
+
+		bctx := rego.BuiltinContext{Context: context.Background()}
+		got, err := ociImageReferrers(bctx, ast.StringTerm(digestRef))
+		require.NoError(t, err)
+		require.NotNil(t, got)
+
+		arr, ok := got.Value.(*ast.Array)
+		require.True(t, ok)
+		require.Greater(t, arr.Len(), 0)
+
+		for i := 0; i < arr.Len(); i++ {
+			obj, ok := arr.Elem(i).Value.(ast.Object)
+			require.True(t, ok)
+
+			annTerm := obj.Get(ast.StringTerm("annotations"))
+			require.NotNil(t, annTerm, "descriptor %d should have annotations field", i)
+
+			_, ok = annTerm.Value.(ast.Object)
+			require.True(t, ok, "descriptor %d annotations should be an object", i)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Adds `annotations` field (map[string]string) to the `ec.oci.image_referrers` Rego builtin response
- Enables Rego policies to access manifest annotations on referrer descriptors, allowing filtering/sorting of duplicate referrers (e.g., by timestamp annotation)
- Uses the existing `newAnnotationsTerm()` helper, consistent with how annotations are handled in other OCI builtins

## Changes
- `internal/rego/oci/oci.go`: Added annotations to the descriptor type declaration and response building
- `internal/rego/oci/oci_test.go`: Added annotations field presence assertion and dedicated structural test

## Test plan
- [x] All existing `TestOCIImageReferrers` subtests pass
- [x] New `annotations field is an object` subtest validates annotations are returned as an object on every descriptor
- [x] Full `internal/rego/oci` unit test suite passes with no regressions

Jira: EC-1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)