### PR TITLE
[KONFLUX-13286] Replace appstudio-utils image with task-runner

### DIFF
--- a/pkg/schema/examples/hacbs2_valid.json
+++ b/pkg/schema/examples/hacbs2_valid.json
@@ -148,7 +148,7 @@
               "arguments": null,
               "environment": {
                 "container": "appstudio-configure-build",
-                "image": "quay.io/redhat-appstudio/appstudio-utils@sha256:e1d7e2bbff7032f078df41ab4d6345ada8474f615c0e93f6268ae9ba48a81b1d"
+                "image": "quay.io/konflux-ci/task-runner:1.7.0"
               },
               "annotations": null
             }

--- a/release/cli.yaml
+++ b/release/cli.yaml
@@ -91,7 +91,7 @@ spec:
         - $(params.input)
         - $(results.cli-snapshot-spec.path)
         - $(results.bundle-snapshot-spec.path)
-        image: quay.io/konflux-ci/appstudio-utils:latest
+        image: quay.io/konflux-ci/task-runner:v1
         name: expand
         workingDir: $(workspaces.source.path)/source
       workspaces:
@@ -181,13 +181,13 @@ spec:
         - hack/copy-snapshot-image.sh
         - $(params.cli-snapshot-spec)
         - $(params.cli-target-repo)
-        image: quay.io/konflux-ci/appstudio-utils:latest
+        image: quay.io/konflux-ci/task-runner:v1
         name: copy-cli
       - command:
         - hack/copy-snapshot-image.sh
         - $(params.bundle-snapshot-spec)
         - $(params.bundle-target-repo)
-        image: quay.io/konflux-ci/appstudio-utils:latest
+        image: quay.io/konflux-ci/task-runner:v1
         name: copy-bundle
       # To ease the transtion from the old quay org to the new quay org,
       # also push the two images to the old quay org at. Rather than
@@ -200,14 +200,14 @@ spec:
         - $(params.cli-snapshot-spec)
         # Hard-coded "old" $(params.cli-target-repo):
         - quay.io/enterprise-contract/cli
-        image: quay.io/konflux-ci/appstudio-utils:latest
+        image: quay.io/konflux-ci/task-runner:v1
         name: copy-cli-old-org
       - command:
         - hack/copy-snapshot-image.sh
         - $(params.bundle-snapshot-spec)
         # Hard-coded "old" $(params.bundle-target-repo)
         - quay.io/enterprise-contract/tekton-task
-        image: quay.io/konflux-ci/appstudio-utils:latest
+        image: quay.io/konflux-ci/task-runner:v1
         name: copy-bundle-old-org
       workspaces:
       - name: source


### PR DESCRIPTION
## Summary
 - The `appstudio-utils` image is being decommissioned ,`task-runner` is the replacement.
  - Replaces `quay.io/konflux-ci/appstudio-utils:latest` with `quay.io/konflux-ci/task-runner:v1` in `release/cli.yaml`
  - Also updates test fixture image references in `pkg/schema/examples/hacbs2_valid.json` so it won't be flagged by image deprecation scans.

Issue: [KONFLUX-13286](https://issues.redhat.com/browse/KONFLUX-13286)
