### PR TITLE
Add pin-policy-bundle acceptance tests for TA task

### DIFF
--- a/features/__snapshots__/ta_task_validate_image.snap
+++ b/features/__snapshots__/ta_task_validate_image.snap
@@ -6,9 +6,9 @@ Applying policy bundle digest override: sha256:f904979d405a39a3cc492439b379b4b11
 ---
 
 [TestFeatures/Pin policy bundle digest:pin-policy-bundle - 1]
-Applying policy bundle digest override: sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2
+Applying policy bundle digest override: sha256:2a851b5d56259ba46391f72bc4e75ed5475510dce5ae47d054b72baf1e908d26
 Replaced: oci::quay.io/conforma/release-policy:konflux
-    with: oci::quay.io/conforma/release-policy@sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2
+    with: oci::quay.io/conforma/release-policy@sha256:2a851b5d56259ba46391f72bc4e75ed5475510dce5ae47d054b72baf1e908d26
 Modified policy written to: /tekton/home/policy-with-pinned-bundle.yaml
 
 ---
@@ -19,7 +19,7 @@ Modified policy written to: /tekton/home/policy-with-pinned-bundle.yaml
     "sources": [
       {
         "policy": [
-          "oci::quay.io/conforma/release-policy@sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2"
+          "oci::quay.io/conforma/release-policy@sha256:2a851b5d56259ba46391f72bc4e75ed5475510dce5ae47d054b72baf1e908d26"
         ],
         "config": {
           "include": [

--- a/features/__snapshots__/ta_task_validate_image.snap
+++ b/features/__snapshots__/ta_task_validate_image.snap
@@ -1,4 +1,40 @@
 
+[TestFeatures/Golden container image with trusted artifacts:pin-policy-bundle - 1]
+Applying policy bundle digest override: sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2
+'oci::quay.io/conforma/release-policy:konflux' not found in policy configuration, nothing to do.
+
+---
+
+[TestFeatures/Pin policy bundle digest:pin-policy-bundle - 1]
+Applying policy bundle digest override: sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2
+Replaced: oci::quay.io/conforma/release-policy:konflux
+    with: oci::quay.io/conforma/release-policy@sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2
+Modified policy written to: /tekton/home/policy-with-pinned-bundle.yaml
+
+---
+
+[TestFeatures/Pin policy bundle digest:show-config - 1]
+{
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "oci::quay.io/conforma/release-policy@sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2"
+        ],
+        "config": {
+          "include": [
+            "slsa_provenance_available"
+          ]
+        }
+      }
+    ],
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----"
+  },
+  "key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----\n",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
 [TestFeatures/Golden container image with trusted artifacts:report-json - 1]
 {
   "success": true,

--- a/features/ta_task_validate_image.feature
+++ b/features/ta_task_validate_image.feature
@@ -128,7 +128,7 @@ Feature: Verify Conforma Trusted Artifact Tekton Task
       | SNAPSHOT_FILENAME       | snapshotartifact                                                     |
       | SOURCE_DATA_ARTIFACT    | oci:${REGISTRY}/acceptance/snapshotartifact@${BUILD_SNAPSHOT_DIGEST}  |
       | POLICY_CONFIGURATION    | ${NAMESPACE}/${POLICY_NAME}                                          |
-      | POLICY_BUNDLE_DIGEST    | sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2 |
+      | POLICY_BUNDLE_DIGEST    | sha256:2a851b5d56259ba46391f72bc4e75ed5475510dce5ae47d054b72baf1e908d26 |
       | STRICT                  | false                                                                |
       | IGNORE_REKOR            | true                                                                 |
       | TRUSTED_ARTIFACTS_DEBUG | "true"                                                               |

--- a/features/ta_task_validate_image.feature
+++ b/features/ta_task_validate_image.feature
@@ -46,6 +46,7 @@ Feature: Verify Conforma Trusted Artifact Tekton Task
       | TRUSTED_ARTIFACTS_DEBUG | "true"                                                                                                   |
       | ORAS_OPTIONS            | --plain-http                                                                                             |
     Then the task should succeed
+     And the task logs for step "pin-policy-bundle" should match the snapshot
      And the task logs for step "report-json" should match the snapshot
      And the task results should match the snapshot
      And the task logs for step "show-config" should match the snapshot
@@ -92,6 +93,51 @@ Feature: Verify Conforma Trusted Artifact Tekton Task
       | ORAS_OPTIONS            | --plain-http                                                                                             |
     Then the task should succeed
      And the task results should match the snapshot
+
+  Scenario: Pin policy bundle digest
+    Given a working namespace
+    Given a snapshot artifact with content:
+      ```
+      {
+        "components": [
+          {
+            "containerImage": "quay.io/hacbs-contract-demo/golden-container@sha256:e76a4ae9dd8a52a0d191fd34ca133af5b4f2609536d32200a4a40a09fdc93a0d"
+          }
+        ]
+      }
+      ```
+    Given a cluster policy with content:
+      ```
+      {
+        "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERhr8Zj4dZW67zucg8fDr11M4lmRp\nzN6SIcIjkvH39siYg1DkCoa2h2xMUZ10ecbM3/ECqvBV55YwQ2rcIEa7XQ==\n-----END PUBLIC KEY-----",
+        "sources": [
+          {
+            "policy": [
+              "oci::quay.io/conforma/release-policy:konflux"
+            ],
+            "config": {
+              "include": [
+                "slsa_provenance_available"
+              ]
+            }
+          }
+        ]
+      }
+      ```
+    When version 0.1 of the task named "verify-conforma-konflux-ta" is run with parameters:
+      | SNAPSHOT_FILENAME       | snapshotartifact                                                     |
+      | SOURCE_DATA_ARTIFACT    | oci:${REGISTRY}/acceptance/snapshotartifact@${BUILD_SNAPSHOT_DIGEST}  |
+      | POLICY_CONFIGURATION    | ${NAMESPACE}/${POLICY_NAME}                                          |
+      | POLICY_BUNDLE_DIGEST    | sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2 |
+      | STRICT                  | false                                                                |
+      | IGNORE_REKOR            | true                                                                 |
+      | TRUSTED_ARTIFACTS_DEBUG | "true"                                                               |
+      | ORAS_OPTIONS            | --plain-http                                                         |
+    Then the task should succeed
+     And the task logs for step "pin-policy-bundle" should match the snapshot
+     And the task logs for step "show-config" should match the snapshot
+     # The show-config step is enough to confirm the ECP was modified. No need
+     # to look at the other output
 
   Scenario: VSA generation with predicate format
     Given a working namespace


### PR DESCRIPTION
## Summary
- Add `pin-policy-bundle` step log assertion to the existing "Golden container image with trusted artifacts" scenario (no-op path: policy uses git sources, OCI tag not found)
- Add new "Pin policy bundle digest" scenario for `verify-conforma-konflux-ta` task (replacement path: OCI tag replaced with digest-pinned reference)
- Add corresponding snapshot entries

These mirror the two pin-policy-bundle scenarios already covered by the `verify-enterprise-contract` task, closing a gap where the TA task variant had zero dedicated coverage for this step.

## Test plan
- [ ] Acceptance tests pass for `ta_task_validate_image` feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)