### PR TITLE
test(EC-1824): add acceptance tests for multi-arch volatile exceptions

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -5916,3 +5916,228 @@ time="${TIMESTAMP}" level=warning msg="Attestation signature check skipped, fetc
 time="${TIMESTAMP}" level=warning msg="Both --skip-image-sig-check and --skip-att-sig-check are active, all cryptographic verification is disabled"
 
 ---
+
+[TestFeatures/volatile config exclude matches multi-arch expanded component name:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "multi-arch-test-sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2-arm64",
+      "containerImage": "${REGISTRY}/acceptance/multi-arch-volatile@sha256:${REGISTRY_acceptance/multi-arch-volatile:latest_DIGEST}",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass_with_collection"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/multi-arch-volatile}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/multi-arch-volatile}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::${GITHOST}/git/happy-day-policy.git?ref=${LATEST_COMMIT}"
+        ],
+        "config": {
+          "include": [
+            "@stamps",
+            "filtering.always_pass",
+            "filtering.always_fail"
+          ]
+        },
+        "volatileConfig": {
+          "exclude": [
+            {
+              "value": "filtering.always_fail",
+              "componentNames": [
+                "multi-arch-test"
+              ]
+            },
+            {
+              "value": "filtering.always_fail_with_collection",
+              "componentNames": [
+                "multi-arch-test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[TestFeatures/volatile config exclude matches multi-arch expanded component name:stderr - 1]
+
+---
+
+[TestFeatures/volatile config exclude does not match different multi-arch component:stdout - 1]
+{
+  "success": false,
+  "components": [
+    {
+      "name": "other-component-sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2-amd64",
+      "containerImage": "${REGISTRY}/acceptance/multi-arch-volatile-neg@sha256:${REGISTRY_acceptance/multi-arch-volatile-neg:latest_DIGEST}",
+      "source": {},
+      "violations": [
+        {
+          "msg": "always fail",
+          "metadata": {
+            "code": "filtering.always_fail"
+          }
+        },
+        {
+          "msg": "always fail with collection",
+          "metadata": {
+            "code": "filtering.always_fail_with_collection"
+          }
+        }
+      ],
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "filtering.always_pass_with_collection"
+          }
+        }
+      ],
+      "success": false,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/multi-arch-volatile-neg}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/multi-arch-volatile-neg}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${known_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::${GITHOST}/git/happy-day-policy.git?ref=${LATEST_COMMIT}"
+        ],
+        "config": {
+          "include": [
+            "@stamps",
+            "filtering.always_pass",
+            "filtering.always_fail"
+          ]
+        },
+        "volatileConfig": {
+          "exclude": [
+            {
+              "value": "filtering.always_fail",
+              "componentNames": [
+                "multi-arch-test"
+              ]
+            },
+            {
+              "value": "filtering.always_fail_with_collection",
+              "componentNames": [
+                "multi-arch-test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "publicKey": "${known_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[TestFeatures/volatile config exclude does not match different multi-arch component:stderr - 1]
+Error: success criteria not met
+
+---

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1115,13 +1115,8 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
-  # Tests for EC-1824: multi-arch per-component volatile exceptions.
-  # When validate image encounters an image index, imageIndexWorker (input.go:264) expands
-  # the component name from "foo" to "foo-sha256:<digest>-<arch>". The fix in Criteria.get()
-  # uses originalComponentName() to strip that suffix so volatile config componentNames
-  # entries referencing the original name still match.
-  # These tests use --images with an ApplicationSnapshot file to set the component name
-  # to the expanded format directly, validating the originalComponentName() wiring.
+  # EC-1824: verify volatile config componentNames excludes work with
+  # multi-arch expanded component names (e.g., "foo-sha256:<digest>-arm64").
 
   Scenario: volatile config exclude matches multi-arch expanded component name
     Given a key pair named "known"

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1115,6 +1115,112 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  # Tests for EC-1824: multi-arch per-component volatile exceptions.
+  # When validate image encounters an image index, imageIndexWorker (input.go:264) expands
+  # the component name from "foo" to "foo-sha256:<digest>-<arch>". The fix in Criteria.get()
+  # uses originalComponentName() to strip that suffix so volatile config componentNames
+  # entries referencing the original name still match.
+  # These tests use --images with an ApplicationSnapshot file to set the component name
+  # to the expanded format directly, validating the originalComponentName() wiring.
+
+  Scenario: volatile config exclude matches multi-arch expanded component name
+    Given a key pair named "known"
+    Given an image named "acceptance/multi-arch-volatile"
+    Given a valid image signature of "acceptance/multi-arch-volatile" image signed by the "known" key
+    Given a valid attestation of "acceptance/multi-arch-volatile" signed by the "known" key
+    Given a git repository named "happy-day-policy" with
+      | filtering.rego | examples/filtering.rego |
+    Given a file named "${TMPDIR}/multi-arch-images.json" containing
+    """
+    {
+      "components": [
+        {
+          "containerImage": "${REGISTRY}/acceptance/multi-arch-volatile",
+          "name": "multi-arch-test-sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2-arm64"
+        }
+      ]
+    }
+    """
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "volatileConfig": {
+            "exclude": [
+              {
+                "value": "filtering.always_fail",
+                "componentNames": ["multi-arch-test"]
+              },
+              {
+                "value": "filtering.always_fail_with_collection",
+                "componentNames": ["multi-arch-test"]
+              }
+            ]
+          },
+          "config": {
+            "include": ["@stamps", "filtering.always_pass", "filtering.always_fail"]
+          },
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --images ${TMPDIR}/multi-arch-images.json --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --ignore-rekor --show-successes --output json"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
+  Scenario: volatile config exclude does not match different multi-arch component
+    Given a key pair named "known"
+    Given an image named "acceptance/multi-arch-volatile-neg"
+    Given a valid image signature of "acceptance/multi-arch-volatile-neg" image signed by the "known" key
+    Given a valid attestation of "acceptance/multi-arch-volatile-neg" signed by the "known" key
+    Given a git repository named "happy-day-policy" with
+      | filtering.rego | examples/filtering.rego |
+    Given a file named "${TMPDIR}/multi-arch-images-neg.json" containing
+    """
+    {
+      "components": [
+        {
+          "containerImage": "${REGISTRY}/acceptance/multi-arch-volatile-neg",
+          "name": "other-component-sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2-amd64"
+        }
+      ]
+    }
+    """
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "volatileConfig": {
+            "exclude": [
+              {
+                "value": "filtering.always_fail",
+                "componentNames": ["multi-arch-test"]
+              },
+              {
+                "value": "filtering.always_fail_with_collection",
+                "componentNames": ["multi-arch-test"]
+              }
+            ]
+          },
+          "config": {
+            "include": ["@stamps", "filtering.always_pass", "filtering.always_fail"]
+          },
+          "policy": [
+            "git::https://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --images ${TMPDIR}/multi-arch-images-neg.json --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --ignore-rekor --show-successes --output json"
+    Then the exit status should be 1
+    Then the output should match the snapshot
+
   Scenario: Unsupported policies
     Given a key pair named "known"
     Given an image named "acceptance/image"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add acceptance tests for multi-arch volatileConfig componentNames excludes
<code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- Adds two acceptance test scenarios verifying volatile config `componentNames` excludes work with multi-arch expanded component names
- Tests the `originalComponentName()` wiring in `Criteria.get()` end-to-end through `validate image`
- Uses `--images` with ApplicationSnapshot file to set component names to the expanded format (e.g., `foo-sha256:<digest>-arm64`)

## Test plan

- [ ] Positive: exclude matches when expanded name's base matches `componentNames` (exit 0)
- [ ] Negative: exclude does NOT match when base name differs (exit 1)
- [ ] Both acceptance tests pass locally

resolves: EC-1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add end-to-end acceptance coverage for multi-arch expanded component name excludes.
• Verify Criteria.get() uses originalComponentName() so volatileConfig componentNames still match.
• Exercise validate image via --images ApplicationSnapshot inputs and assert exit codes + snapshots.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Acceptance scenarios"] --> B["ec validate image"] --> C["Load --images snapshot"] --> D["Expanded component name"] --> E["Criteria.get(): originalComponentName"] --> F{"Exclude matches componentNames?"}
  F -->|"yes"| G["Skip excluded checks"] --> H["Exit status"]
  F -->|"no"| I["Run failing rule"] --> H
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Add focused unit tests for component name normalization</b></summary>

- ➕ Faster, less brittle than acceptance tests
- ➕ Pinpoints behavior of originalComponentName() and matching logic directly
- ➖ May miss CLI wiring/regressions in validate image path
- ➖ Does not validate ApplicationSnapshot/--images integration

</details>

<details>
<summary><b>2. Add a smaller integration test around Criteria.get() + volatile config parsing</b></summary>

- ➕ Covers wiring without full signature/attestation setup
- ➕ Less runtime and fewer external test fixtures
- ➖ Still may not cover the exact validate image execution path and output formatting
- ➖ Requires bespoke harness if one doesn’t already exist

</details>

**Recommendation:** Keep the acceptance tests as implemented because they validate the bug-prone end-to-end path (validate image + snapshot-provided expanded names + volatile excludes). If future failures become flaky/slow, consider complementing with a narrow unit test for name normalization to reduce reliance on full acceptance setup.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>validate_image.feature</strong> <code>Add EC-1824 acceptance scenarios for multi-arch volatile excludes</code> <code>+106/-0</code></summary>

<br/>

>Add EC-1824 acceptance scenarios for multi-arch volatile excludes
>
><pre>
>• Adds two new acceptance test scenarios to ensure volatileConfig &#x27;exclude.componentNames&#x27; matches against the original (base) component name when validate image operates on expanded multi-arch component names. Uses &#x27;--images&#x27; with ApplicationSnapshot JSON to inject expanded component names and asserts correct exit statuses and output snapshots for both matching and non-matching cases.
></pre>
>
><a href='https://github.com/conforma/cli/pull/3333/files#diff-a0dac62a97967a1438905b18c44af0189f3e0994527aaeac5dd756eb0268e96f'>features/validate_image.feature</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>