### PR TITLE
Trigger conforma e2e tests on cli pull requests

### DIFF
--- a/.tekton/cli-e2e-pull-request.yaml
+++ b/.tekton/cli-e2e-pull-request.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/conforma/cli?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: ec-main
+    appstudio.openshift.io/component: cli-main
+    pipelines.appstudio.openshift.io/type: test
+  name: cli-e2e-on-pull-request
+  namespace: rhtap-contract-tenant
+spec:
+  params:
+  - name: git-url
+    value: https://github.com/conforma/e2e-tests.git
+  - name: revision
+    # renovate: datasource=git-refs depName=https://github.com/conforma/e2e-tests branch=main
+    value: f7b2b9e3f74168c3d76457c28adc2cb152773bc2
+  - name: oci-container-repo
+    value: quay.io/conforma/e2e-tests
+  - name: oci-container-repo-credentials-secret
+    value: konflux-test-infra
+  - name: aws-credentials-secret
+    value: mapt-kind-secret
+  - name: deprovision-aws-credentials-secret
+    value: mapt-kind-secret
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/conforma/e2e-tests.git
+    - name: revision
+      # renovate: datasource=git-refs depName=https://github.com/conforma/e2e-tests branch=main
+      value: f7b2b9e3f74168c3d76457c28adc2cb152773bc2
+    - name: pathInRepo
+      value: .tekton/pipelines/conforma-e2e/pipeline.yaml
+  taskRunTemplate:
+    serviceAccountName: konflux-integration-runner

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>conforma/.github//config/renovate/renovate.json"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.tekton/.*\\.yaml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=git-refs\\s+depName=(?<depName>[^\\s]+)\\s+branch=(?<currentValue>[^\\s]+)\\s*\\n\\s*value:\\s*(?<currentDigest>[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "git-refs"
+    }
   ]
 }


### PR DESCRIPTION
Add a PipelineRun that triggers the conforma/e2e-tests pipeline when a PR targets the main branch, using the Tekton git resolver.

Pin the pipeline ref to a specific commit SHA and configure Renovate
to auto-update it by adding a customManagers regex for git-refs
annotations in Tekton YAML files.

Ref: https://redhat.atlassian.net/browse/KONFLUX-14184