### PR TITLE
docs: add system requirements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Before building or testing `ec`, install the following tools:
 - Podman or Docker (for acceptance tests and container-based workflows)
 - Node.js 18+ (for `tekton-lint`)
 
-On Fedora/RHEL systems, acceptance tests often require Podman to run as a user service.
+On Fedora/RHEL systems, acceptance tests often require Podman to run as a system service.
 Run:
 
 ```bash
-systemctl disable --now --user podman.service
-systemctl enable --user --now podman.socket
+systemctl disable --now podman.socket podman.service
+systemctl enable --now podman.socket podman.service
 ```
 
 then run the test/build commands below.
@@ -94,10 +94,10 @@ $ systemctl disable --now podman.socket podman.service
 
 It is advised to do a reboot afterwards.
 
-To start Podman for the user:
+To start Podman:
 
 ``` bash
-$ systemctl enable --user --now podman.socket podman.service
+$ systemctl enable --now podman.socket podman.service
 ```
 
 #### **2.2. Get localhost:37837: connection reset by peer**

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On Fedora/RHEL systems, acceptance tests often require Podman to run as a user s
 Run:
 
 ```bash
-systemctl disable --now --user podman.socket podman.service
+systemctl disable --now podman.socket podman.service
 systemctl enable --user --now podman.socket podman.service
 ```
 
@@ -94,7 +94,7 @@ $ systemctl disable --now podman.socket podman.service
 
 It is advised to do a reboot afterwards.
 
-To start Podman:
+To start Podman for the user:
 
 ``` bash
 $ systemctl enable --user --now podman.socket podman.service

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Before building or testing `ec`, install the following tools:
 - Podman or Docker (for acceptance tests and container-based workflows)
 - Node.js 18+ (for `tekton-lint`)
 
-On Fedora/RHEL systems, acceptance tests often require Podman to run as a system service.
+On Fedora/RHEL systems, acceptance tests often require Podman to run as a user service.
 Run:
 
 ```bash
-systemctl disable --now podman.socket podman.service
-systemctl enable --now podman.socket podman.service
+systemctl disable --now --user podman.socket podman.service
+systemctl enable --user --now podman.socket podman.service
 ```
 
 then run the test/build commands below.
@@ -97,7 +97,7 @@ It is advised to do a reboot afterwards.
 To start Podman:
 
 ``` bash
-$ systemctl enable --now podman.socket podman.service
+$ systemctl enable --user --now podman.socket podman.service
 ```
 
 #### **2.2. Get localhost:37837: connection reset by peer**

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Before building or testing `ec`, install the following tools:
 - Node.js 18+ (for `tekton-lint`)
 
 On Fedora/RHEL systems, acceptance tests often require Podman to run as a user service.
-Use the Troubleshooting section below for the required Podman service commands and then run
-the appropriate Building or Testing commands.
+Use the troubleshooting section below for the required Podman service commands, and
+then run the appropriate Building or Testing commands.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,8 @@ Before building or testing `ec`, install the following tools:
 - Node.js 18+ (for `tekton-lint`)
 
 On Fedora/RHEL systems, acceptance tests often require Podman to run as a user service.
-Run:
-
-```bash
-systemctl disable --now podman.socket podman.service
-systemctl enable --user --now podman.socket podman.service
-```
-
-then run the test/build commands below.
+Use the Troubleshooting section below for the required Podman service commands and then run
+the appropriate Building or Testing commands.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ such as:
 Consult the [documentation][docs] for available sub-commands, descriptions and
 examples of use.
 
+## Development Requirements
+
+Before building or testing `ec`, install the following tools:
+
+- Go 1.25.8+ (matching `go.mod`)
+- Make
+- Podman or Docker (for acceptance tests and container-based workflows)
+- Node.js 18+ (for `tekton-lint`)
+
+On Fedora/RHEL systems, acceptance tests often require Podman to run as a user service.
+Run:
+
+```bash
+systemctl disable --now --user podman.service
+systemctl enable --user --now podman.socket
+```
+
+then run the test/build commands below.
+
 ## Building
 
 Run `make build` from the root directory and use the `dist/ec` executable, or

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ It is advised to do a reboot afterwards.
 To start Podman for the user:
 
 ``` bash
-$ systemctl enable --user --now podman.socket podman.service
+$ systemctl enable --user --now podman.socket
 ```
 
 #### **2.2. Get localhost:37837: connection reset by peer**


### PR DESCRIPTION
Closes #3343

## Summary
- add a new Development Requirements section to README
- list required tooling and versions:
  - Go 1.25.8+
  - Make
  - Podman or Docker
  - Node.js 18+
- add Fedora/RHEL note about running Podman as a user service for acceptance tests

## Validation
-  was attempted per repository guidance, but this repo has no  script.
- No additional automated test runs were required for this docs-only change.