### PR TITLE
feat:  pass custom cli params to e2e pipeline for pull requests

### DIFF
--- a/.tekton/cli-e2e-pull-request.yaml
+++ b/.tekton/cli-e2e-pull-request.yaml
@@ -31,6 +31,10 @@ spec:
     value: mapt-kind-secret
   - name: deprovision-aws-credentials-secret
     value: mapt-kind-secret
+  - name: custom-ec-cli-url
+    value: '{{source_url}}'
+  - name: custom-ec-cli-revision
+    value: '{{revision}}'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
The conforma/e2e-tests pipeline now supports building the CLI from source via custom-ec-cli-url and custom-ec-cli-revision parameters. Pass the PR's repo URL and commit SHA so e2e tests run against the CLI code under review instead of the released image.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Ref: https://redhat.atlassian.net/browse/EC-1913