### PR TITLE
Run e2e tests on push to main instead of on every PR

### DIFF
--- a/.tekton/cli-e2e-push.yaml
+++ b/.tekton/cli-e2e-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/conforma/cli?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ec-main
     appstudio.openshift.io/component: cli-main
     pipelines.appstudio.openshift.io/type: test
-  name: cli-e2e-on-pull-request
+  name: cli-e2e-on-push
   namespace: rhtap-contract-tenant
 spec:
   params:


### PR DESCRIPTION
The cli-e2e PipelineRun runs the conforma/e2e-tests pipeline which takes ~25 minutes per run. Moving it from pull_request to push trigger means e2e tests run post-merge on main.

Ref: https://issues.redhat.com/browse/EC-1930