### PR TITLE
chore(deps): Pin Go builder image by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ## Build
 
-FROM docker.io/library/golang:1.26.3 AS build
+FROM docker.io/library/golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Pins the Go builder image by digest, matching Dockerfile.dist and the final image in this file.
Digest taken from the manifest list, so all platforms in `BUILD_LIST` still resolve. Other FROM in this file is already pinned.
Fixes #3358