### PR TITLE
fix(EC-1993): reject past --effective-time values by default

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -26,15 +26,17 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
+	"github.com/conforma/cli/internal/policy"
 	"github.com/conforma/cli/internal/policy/equivalence"
 )
 
 var (
-	effectiveTime string
-	imageDigest   string
-	imageRef      string
-	imageURL      string
-	outputFormat  string
+	effectiveTime          string
+	allowPastEffectiveTime bool
+	imageDigest            string
+	imageRef               string
+	imageURL               string
+	outputFormat           string
 )
 
 var CompareCmd *cobra.Command
@@ -73,7 +75,8 @@ Examples:
 		RunE: runCompare,
 	}
 
-	compareCmd.Flags().StringVar(&effectiveTime, "effective-time", "now", "Effective time for policy evaluation (RFC3339 format, 'now')")
+	compareCmd.Flags().StringVar(&effectiveTime, "effective-time", "now", "Effective time for policy evaluation ('now' for current time, 'attestation' for time from the youngest attestation, or RFC3339 format, e.g. 2022-11-18T00:00:00Z)")
+	compareCmd.Flags().BoolVar(&allowPastEffectiveTime, "allow-past-effective-time", false, "Allow setting --effective-time to a date in the past. By default, dates in the past are rejected.")
 	compareCmd.Flags().StringVar(&imageDigest, "image-digest", "", "Image digest for volatile config matching")
 	compareCmd.Flags().StringVar(&imageRef, "image-ref", "", "Image reference for volatile config matching")
 	compareCmd.Flags().StringVar(&imageURL, "image-url", "", "Image URL for volatile config matching")
@@ -84,20 +87,12 @@ Examples:
 
 func runCompare(cmd *cobra.Command, args []string) error {
 
-	// Parse effective time
-	var effectiveTimeValue time.Time
-	switch effectiveTime {
-	case "now":
+	effectiveTimeValue, err := policy.ParseEffectiveTime(effectiveTime, allowPastEffectiveTime)
+	if err != nil {
+		return err
+	}
+	if effectiveTimeValue.IsZero() {
 		effectiveTimeValue = time.Now().UTC()
-	case "attestation":
-		// For now, use current time as default for attestation time
-		effectiveTimeValue = time.Now().UTC()
-	default:
-		var err error
-		effectiveTimeValue, err = time.Parse(time.RFC3339, effectiveTime)
-		if err != nil {
-			return fmt.Errorf("invalid effective time format: %w", err)
-		}
 	}
 
 	// Create image info if provided

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -202,7 +202,8 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			data.policyConfiguration = policyConfiguration
 
 			policyOptions := policy.Options{
-				EffectiveTime: data.effectiveTime,
+				EffectiveTime:          data.effectiveTime,
+				AllowPastEffectiveTime: data.allowPastEffectiveTime,
 				Identity: cosign.Identity{
 					Issuer:        data.certificateOIDCIssuer,
 					IssuerRegExp:  data.certificateOIDCIssuerRegExp,
@@ -547,6 +548,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
 	`))
 
+	cmd.Flags().BoolVar(&data.allowPastEffectiveTime, "allow-past-effective-time", false, hd.Doc(`
+		Allow setting --effective-time to a date in the past. By default, dates
+		in the past are rejected.
+	`))
+
 	cmd.Flags().StringSliceVar(&data.extraRuleData, "extra-rule-data", data.extraRuleData, hd.Doc(`
 		Extra data to be provided to the Rego policy evaluator. Use format 'key=value'. May be used multiple times.
 	`))
@@ -628,6 +634,7 @@ func validateAttestationOutputPath(path string) (string, error) {
 
 // imageData is the struct that holds all image validation command data
 type imageData struct {
+	allowPastEffectiveTime      bool
 	certificateIdentity         string
 	certificateIdentityRegExp   string
 	certificateOIDCIssuer       string

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -598,6 +598,7 @@ spec:
 				"/policy.yaml",
 				"--effective-time",
 				"1970-01-01",
+				"--allow-past-effective-time",
 			}...)
 			cmd.SetArgs(args)
 

--- a/cmd/validate/input.go
+++ b/cmd/validate/input.go
@@ -43,20 +43,21 @@ type InputValidationFunc func(context.Context, string, policy.Policy, bool) (*ou
 
 func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 	data := struct {
-		effectiveTime       string
-		filePaths           []string
-		forceColor          bool
-		info                bool
-		namespaces          []string
-		noColor             bool
-		output              []string
-		policy              policy.Policy
-		policyConfiguration string
-		strict              bool
-		workers             int
-		serverMode          bool
-		serverAddress       string
-		serverPort          int
+		effectiveTime          string
+		allowPastEffectiveTime bool
+		filePaths              []string
+		forceColor             bool
+		info                   bool
+		namespaces             []string
+		noColor                bool
+		output                 []string
+		policy                 policy.Policy
+		policyConfiguration    string
+		strict                 bool
+		workers                int
+		serverMode             bool
+		serverAddress          string
+		serverPort             int
 	}{
 		strict:        true,
 		workers:       5,
@@ -168,7 +169,7 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 			}
 			data.policyConfiguration = policyConfiguration
 
-			if p, err := policy.NewInputPolicy(cmd.Context(), data.policyConfiguration, data.effectiveTime); err != nil {
+			if p, err := policy.NewInputPolicy(cmd.Context(), data.policyConfiguration, data.effectiveTime, data.allowPastEffectiveTime); err != nil {
 				allErrors = errors.Join(allErrors, err)
 			} else {
 				data.policy = p
@@ -348,6 +349,10 @@ func validateInputCmd(validate InputValidationFunc) *cobra.Command {
 		Run policy checks with the provided time. Useful for testing rules with
 		effective dates in the future. The value can be "now" (default) - for
 		current time, or a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.`))
+
+	cmd.Flags().BoolVar(&data.allowPastEffectiveTime, "allow-past-effective-time", false, hd.Doc(`
+		Allow setting --effective-time to a date in the past. By default, dates
+		in the past are rejected.`))
 
 	cmd.Flags().BoolVar(&data.info, "info", data.info, hd.Doc(`
 		Include additional information on the failures. For instance for policy

--- a/docs/modules/ROOT/pages/ec_compare.adoc
+++ b/docs/modules/ROOT/pages/ec_compare.adoc
@@ -33,7 +33,8 @@ ec compare <policy1> <policy2> [flags]
 ----
 == Options
 
---effective-time:: Effective time for policy evaluation (RFC3339 format, 'now') (Default: now)
+--allow-past-effective-time:: Allow setting --effective-time to a date in the past. By default, dates in the past are rejected. (Default: false)
+--effective-time:: Effective time for policy evaluation ('now' for current time, 'attestation' for time from the youngest attestation, or RFC3339 format, e.g. 2022-11-18T00:00:00Z) (Default: now)
 -h, --help:: help for compare (Default: false)
 --image-digest:: Image digest for volatile config matching
 --image-ref:: Image reference for volatile config matching

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -111,6 +111,9 @@ Use a regular expression to match certificate attributes.
 
 == Options
 
+--allow-past-effective-time:: Allow setting --effective-time to a date in the past. By default, dates
+in the past are rejected.
+ (Default: false)
 --attestation-format:: Attestation output format: dsse (signed envelope), predicate (raw JSON) (Default: dsse)
 --attestation-output-dir:: Directory for attestation output files. Defaults to a temp directory under /tmp. Must be under /tmp or the current working directory.
 --certificate-identity:: URL of the certificate identity for keyless verification

--- a/docs/modules/ROOT/pages/ec_validate_input.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_input.adoc
@@ -75,6 +75,8 @@ Start the server on a custom port:
 
 == Options
 
+--allow-past-effective-time:: Allow setting --effective-time to a date in the past. By default, dates
+in the past are rejected. (Default: false)
 --color:: Enable color when using text output even when the current terminal does not support it (Default: false)
 --effective-time:: Run policy checks with the provided time. Useful for testing rules with
 effective dates in the future. The value can be "now" (default) - for

--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -57,6 +57,9 @@ paths can be provided by using the `:` separator.
 *EFFECTIVE_TIME* (`string`):: Run policy checks with the provided time.
 +
 *Default*: `now`
+*ALLOW_PAST_EFFECTIVE_TIME* (`string`):: Allow setting EFFECTIVE_TIME to a date in the past.
++
+*Default*: `false`
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
 *POLICY_BUNDLE_DIGEST* (`string`):: Optional OCI digest to pin the release policy bundle. When provided, the policy configuration is resolved and the reference oci::quay.io/conforma/release-policy:konflux is replaced with oci::quay.io/conforma/release-policy@<digest>. Accepts a full digest (sha256:abc123...) or just the hex hash (abc123...).
 +

--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -68,6 +68,9 @@ paths can be provided by using the `:` separator.
 *EFFECTIVE_TIME* (`string`):: Run policy checks with the provided time.
 +
 *Default*: `now`
+*ALLOW_PAST_EFFECTIVE_TIME* (`string`):: Allow setting EFFECTIVE_TIME to a date in the past.
++
+*Default*: `false`
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
 *POLICY_BUNDLE_DIGEST* (`string`):: Optional OCI digest to pin the release policy bundle. When provided, the policy configuration is resolved and the reference oci::quay.io/conforma/release-policy:konflux is replaced with oci::quay.io/conforma/release-policy@<digest>. Accepts a full digest (sha256:abc123...) or just the hex hash (abc123...).
 +

--- a/features/task_validate_image.feature
+++ b/features/task_validate_image.feature
@@ -356,10 +356,11 @@ Feature: Verify Enterprise Contract Tekton Tasks
       {"publicKey": ${known_PUBLIC_KEY}}
       ```
     When version 0.1 of the task named "verify-enterprise-contract" is run with parameters:
-      | IMAGES               | {"components": [{"containerImage": "${REGISTRY}/acceptance/effective-time"}]} |
-      | POLICY_CONFIGURATION | ${NAMESPACE}/${POLICY_NAME}                                                   |
-      | IGNORE_REKOR         | true                                                                          |
-      | EFFECTIVE_TIME       | 2020-01-01T00:00:00Z                                                          |
+      | IMAGES                       | {"components": [{"containerImage": "${REGISTRY}/acceptance/effective-time"}]} |
+      | POLICY_CONFIGURATION         | ${NAMESPACE}/${POLICY_NAME}                                                   |
+      | IGNORE_REKOR                 | true                                                                          |
+      | EFFECTIVE_TIME               | 2020-01-01T00:00:00Z                                                          |
+      | ALLOW_PAST_EFFECTIVE_TIME    | true                                                                          |
     Then the task should succeed
       And the task logs for step "show-config" should contain `"effective-time": "2020-01-01T00:00:00Z"`
 

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -851,7 +851,7 @@ Feature: evaluate enterprise contract
       ]
     }
     """
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --output=json --effective-time 2014-05-31 --show-successes"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/image --policy acceptance/ec-policy --rekor-url ${REKOR} --public-key ${known_PUBLIC_KEY} --output=json --effective-time 2014-05-31 --allow-past-effective-time --show-successes"
     Then the exit status should be 0
     And the output should match the snapshot
 

--- a/internal/input/report_test.go
+++ b/internal/input/report_test.go
@@ -414,7 +414,7 @@ sources:
       exclude:
         []
 `
-	p, err := policy.NewInputPolicy(ctx, policyConfiguration, "now")
+	p, err := policy.NewInputPolicy(ctx, policyConfiguration, "now", false)
 	assert.NoError(t, err)
 	return p
 }

--- a/internal/input/validate_test.go
+++ b/internal/input/validate_test.go
@@ -146,7 +146,7 @@ func Test_ValidatePipeline(t *testing.T) {
 	errFile := afero.WriteFile(appFS, validFile, []byte("data"), 0o777)
 	assert.NoError(t, errFile)
 	ctx := utils.WithFS(context.Background(), appFS)
-	policy, err := policy.NewInputPolicy(ctx, "", "2023-01-01T00:00:00.00Z")
+	policy, err := policy.NewInputPolicy(ctx, "", "2023-01-01T00:00:00.00Z", true)
 	assert.NoError(t, err)
 
 	for _, tt := range tests {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -86,7 +86,7 @@ type Policy interface {
 type policy struct {
 	ecc.EnterpriseContractPolicySpec
 	checkOpts         *cosign.CheckOpts
-	choosenTime       string
+	chosenTime        string
 	effectiveTime     *time.Time
 	attestationTime   *time.Time
 	identity          cosign.Identity
@@ -167,24 +167,25 @@ func (p *policy) SigstoreOpts() (SigstoreOpts, error) {
 }
 
 type Options struct {
-	EffectiveTime     string
-	Identity          cosign.Identity
-	IgnoreRekor       bool
-	SkipImageSigCheck bool
-	SkipAttSigCheck   bool
-	PolicyRef         string
-	PublicKey         string
-	RekorURL          string
+	EffectiveTime          string
+	AllowPastEffectiveTime bool
+	Identity               cosign.Identity
+	IgnoreRekor            bool
+	SkipImageSigCheck      bool
+	SkipAttSigCheck        bool
+	PolicyRef              string
+	PublicKey              string
+	RekorURL               string
 }
 
 // NewOfflinePolicy construct and return a new instance of Policy that is used
 // in offline scenarios, i.e. without cluster or specific services access, and
 // no signature verification being performed.
 func NewOfflinePolicy(ctx context.Context, effectiveTime string) (Policy, error) {
-	if efn, err := parseEffectiveTime(effectiveTime); err == nil {
+	if efn, err := parseEffectiveTime(effectiveTime, true); err == nil {
 		return &policy{
 			effectiveTime: efn,
-			choosenTime:   effectiveTime,
+			chosenTime:    effectiveTime,
 			checkOpts:     &cosign.CheckOpts{},
 		}, nil
 	} else {
@@ -219,11 +220,11 @@ func NewInertPolicy(ctx context.Context, policyRef string) (Policy, error) {
 // resource in Kubernetes using the format: [namespace/]name
 //
 // If policyRef is blank, an empty EnterpriseContractPolicySpec is used.
-func NewInputPolicy(ctx context.Context, policyRef string, effectiveTime string) (Policy, error) {
-	if efn, err := parseEffectiveTime(effectiveTime); err == nil {
+func NewInputPolicy(ctx context.Context, policyRef string, effectiveTime string, allowPastEffectiveTime bool) (Policy, error) {
+	if efn, err := parseEffectiveTime(effectiveTime, allowPastEffectiveTime); err == nil {
 		p := policy{
-			choosenTime: effectiveTime,
-			checkOpts:   &cosign.CheckOpts{},
+			chosenTime: effectiveTime,
+			checkOpts:  &cosign.CheckOpts{},
 		}
 		if err := p.loadPolicy(ctx, policyRef); err != nil {
 			return nil, err
@@ -255,7 +256,7 @@ func NewInputPolicy(ctx context.Context, policyRef string, effectiveTime string)
 // to a kubernetes resource, for example, the cluster will be contacted.
 func NewPolicy(ctx context.Context, opts Options) (Policy, error) {
 	p := policy{
-		choosenTime: opts.EffectiveTime,
+		chosenTime: opts.EffectiveTime,
 	}
 
 	if err := p.loadPolicy(ctx, opts.PolicyRef); err != nil {
@@ -299,7 +300,7 @@ func NewPolicy(ctx context.Context, opts Options) (Policy, error) {
 		}
 	}
 
-	if efn, err := parseEffectiveTime(opts.EffectiveTime); err != nil {
+	if efn, err := parseEffectiveTime(opts.EffectiveTime, opts.AllowPastEffectiveTime); err != nil {
 		return nil, err
 	} else {
 		p.effectiveTime = efn
@@ -392,7 +393,7 @@ func (p *policy) WithSpec(spec ecc.EnterpriseContractPolicySpec) Policy {
 
 func (p *policy) AttestationTime(attestationTime time.Time) {
 	p.attestationTime = &attestationTime
-	if p.choosenTime == AtAttestation {
+	if p.chosenTime == AtAttestation {
 		p.effectiveTime = &attestationTime
 	}
 }
@@ -417,40 +418,76 @@ func (p policy) SkipAttSigCheck() bool {
 	return p.skipAttSigCheck
 }
 
-func isNow(choosenTime string) bool {
-	return strings.EqualFold(choosenTime, Now)
+func isNow(chosenTime string) bool {
+	return strings.EqualFold(chosenTime, Now)
 }
 
-func parseEffectiveTime(choosenTime string) (*time.Time, error) {
+// pastEffectiveTimeGracePeriod is the tolerance for clock skew when rejecting
+// past effective-time values. Times within this window are accepted even
+// without --allow-past-effective-time.
+const pastEffectiveTimeGracePeriod = 2 * time.Second
+
+// ParseEffectiveTime parses the effective-time string and returns the resolved
+// time. It accepts "now", "attestation", RFC3339, or YYYY-MM-DD formats. When
+// allowPast is false, dates in the past are rejected.
+// The "attestation" sentinel returns a zero time.Time — callers should handle
+// that case separately.
+func ParseEffectiveTime(chosenTime string, allowPast bool) (time.Time, error) {
+	t, err := parseEffectiveTime(chosenTime, allowPast)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return *t, nil
+}
+
+func parseEffectiveTime(chosenTime string, allowPast bool) (*time.Time, error) {
 	switch {
-	case isNow(choosenTime):
+	case isNow(chosenTime):
 		now := now().UTC()
 		log.Debugf("Chosen to use effective time of `now`, using current time %s", now.Format(time.RFC3339))
 		return &now, nil
-	case strings.EqualFold(choosenTime, AtAttestation):
+	case strings.EqualFold(chosenTime, AtAttestation):
 		log.Debugf("Chosen to use effective time of `attestation`")
 		return nil, nil
 	default:
-		var err error
-		if when, err := time.Parse(time.RFC3339, choosenTime); err == nil {
+		when, rfc3339Err := time.Parse(time.RFC3339, chosenTime)
+		if rfc3339Err == nil {
 			log.Debugf("Using provided effective time %s", when.Format(time.RFC3339))
 			whenUTC := when.UTC()
+			if err := rejectPastTime(whenUTC, allowPast); err != nil {
+				return nil, err
+			}
 			return &whenUTC, nil
 		}
+		log.Debugf("Unable to parse provided effective time `%s` using RFC3339", chosenTime)
 
-		log.Debugf("Unable to parse provided effective time `%s` using RFC3339", choosenTime)
-		errs := err
-
-		if when, err := time.Parse(DateFormat, choosenTime); err == nil {
+		when, dateErr := time.Parse(DateFormat, chosenTime)
+		if dateErr == nil {
 			log.Debugf("Using provided effective time %s", when.Format(time.RFC3339))
 			whenUTC := when.UTC()
+			if err := rejectPastTime(whenUTC, allowPast); err != nil {
+				return nil, err
+			}
 			return &whenUTC, nil
 		}
-		log.Debugf("Unable to parse provided effective time string `%s` using %s format", choosenTime, DateFormat)
-		errs = errors.Join(errs, err)
+		log.Debugf("Unable to parse provided effective time string `%s` using %s format", chosenTime, DateFormat)
 
-		return nil, fmt.Errorf("invalid policy time argument: %s", errs)
+		return nil, fmt.Errorf("invalid policy time argument: %s", errors.Join(rfc3339Err, dateErr))
 	}
+}
+
+func rejectPastTime(when time.Time, allowPast bool) error {
+	if allowPast {
+		return nil
+	}
+	threshold := now().UTC().Add(-pastEffectiveTimeGracePeriod)
+	if when.Before(threshold) {
+		return fmt.Errorf("effective time %s is in the past; use --allow-past-effective-time to override", when.Format(time.RFC3339))
+	}
+	return nil
 }
 
 // checkOpts returns an instance based on attributes of the Policy.

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -66,7 +66,7 @@ func TestNewPolicy(t *testing.T) {
 			policyRef: toJson(&ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -81,7 +81,7 @@ func TestNewPolicy(t *testing.T) {
 			}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -89,7 +89,7 @@ func TestNewPolicy(t *testing.T) {
 			policyRef: toYAML(&ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -104,7 +104,7 @@ func TestNewPolicy(t *testing.T) {
 			}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -113,7 +113,7 @@ func TestNewPolicy(t *testing.T) {
 			publicKey: utils.TestPublicKey,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -122,7 +122,7 @@ func TestNewPolicy(t *testing.T) {
 			publicKey: utils.TestPublicKey,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -130,7 +130,7 @@ func TestNewPolicy(t *testing.T) {
 			policyRef: toJson(&ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -138,7 +138,7 @@ func TestNewPolicy(t *testing.T) {
 			policyRef: toYAML(&ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL}),
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -147,7 +147,7 @@ func TestNewPolicy(t *testing.T) {
 			rekorUrl:  utils.TestRekorURL,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -156,7 +156,7 @@ func TestNewPolicy(t *testing.T) {
 			rekorUrl:  utils.TestRekorURL,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -165,7 +165,7 @@ func TestNewPolicy(t *testing.T) {
 			k8sResource: &ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey},
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -175,7 +175,7 @@ func TestNewPolicy(t *testing.T) {
 			publicKey:   utils.TestPublicKey,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -184,7 +184,7 @@ func TestNewPolicy(t *testing.T) {
 			k8sResource: &ecc.EnterpriseContractPolicySpec{PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL},
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -194,7 +194,7 @@ func TestNewPolicy(t *testing.T) {
 			rekorUrl:    utils.TestRekorURL,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey, RekorUrl: utils.TestRekorURL,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		{
@@ -202,7 +202,7 @@ func TestNewPolicy(t *testing.T) {
 			publicKey: utils.TestPublicKey,
 			expected: &policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
 				PublicKey: utils.TestPublicKey,
-			}, effectiveTime: &timeNow, choosenTime: timeNowStr},
+			}, effectiveTime: &timeNow, chosenTime: timeNowStr},
 			expectErr: false,
 		},
 		// Failure scenarios
@@ -245,10 +245,11 @@ func TestNewPolicy(t *testing.T) {
 			utils.SetTestRekorPublicKey(t)
 
 			got, err := NewPolicy(ctx, Options{
-				PolicyRef:     c.policyRef,
-				RekorURL:      c.rekorUrl,
-				PublicKey:     c.publicKey,
-				EffectiveTime: timeNowStr,
+				PolicyRef:              c.policyRef,
+				RekorURL:               c.rekorUrl,
+				PublicKey:              c.publicKey,
+				EffectiveTime:          timeNowStr,
+				AllowPastEffectiveTime: true,
 			})
 
 			if c.expectErr {
@@ -656,10 +657,10 @@ func TestIdentity(t *testing.T) {
 }
 
 func TestParseEffectiveTime(t *testing.T) {
-	_, err := parseEffectiveTime("")
+	_, err := parseEffectiveTime("", false)
 	assert.ErrorContains(t, err, "invalid policy time argument")
 
-	effective, err := parseEffectiveTime(Now)
+	effective, err := parseEffectiveTime(Now, false)
 	assert.NoError(t, err)
 	assert.Equal(t, time.UTC, effective.Location())
 
@@ -671,22 +672,72 @@ func TestParseEffectiveTime(t *testing.T) {
 	epoch := time.Unix(0, 0).UTC()
 	now = func() time.Time { return epoch }
 
-	effective, err = parseEffectiveTime(Now)
+	effective, err = parseEffectiveTime(Now, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, effective)
 	assert.Equal(t, epoch, *effective)
 
-	effective, err = parseEffectiveTime("2001-02-03T04:05:06+07:00")
+	effective, err = parseEffectiveTime("2001-02-03T04:05:06+07:00", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, effective)
 	assert.Equal(t, time.Date(2001, 2, 2, 21, 5, 6, 0, time.UTC), *effective)
 
-	effective, err = parseEffectiveTime("2001-02-03")
+	effective, err = parseEffectiveTime("2001-02-03", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, effective)
 	assert.Equal(t, time.Date(2001, 2, 3, 0, 0, 0, 0, time.UTC), *effective)
 
-	effective, err = parseEffectiveTime("attestation")
+	effective, err = parseEffectiveTime("attestation", false)
+	assert.NoError(t, err)
+	assert.Nil(t, effective)
+}
+
+func TestParseEffectiveTimePastRejection(t *testing.T) {
+	then := now
+	t.Cleanup(func() {
+		now = then
+	})
+
+	fixedNow := time.Date(2025, 7, 20, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+
+	// Past date (RFC3339) rejected by default
+	_, err := parseEffectiveTime("2025-01-01T00:00:00Z", false)
+	assert.ErrorContains(t, err, "is in the past")
+	assert.ErrorContains(t, err, "--allow-past-effective-time")
+
+	// Past date (date-only) rejected by default
+	_, err = parseEffectiveTime("2025-01-01", false)
+	assert.ErrorContains(t, err, "is in the past")
+
+	// Past date allowed with allowPast=true
+	effective, err := parseEffectiveTime("2025-01-01T00:00:00Z", true)
+	assert.NoError(t, err)
+	assert.NotNil(t, effective)
+
+	// Time within grace period is accepted
+	withinGrace := fixedNow.Add(-1 * time.Second).Format(time.RFC3339)
+	effective, err = parseEffectiveTime(withinGrace, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, effective)
+
+	// Time past the grace period is rejected
+	pastGrace := fixedNow.Add(-5 * time.Second).Format(time.RFC3339)
+	_, err = parseEffectiveTime(pastGrace, false)
+	assert.ErrorContains(t, err, "is in the past")
+
+	// Future date is always accepted
+	effective, err = parseEffectiveTime("2030-01-01T00:00:00Z", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, effective)
+
+	// "now" is unaffected
+	effective, err = parseEffectiveTime(Now, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, effective)
+
+	// "attestation" is unaffected
+	effective, err = parseEffectiveTime("attestation", false)
 	assert.NoError(t, err)
 	assert.Nil(t, effective)
 }
@@ -747,39 +798,39 @@ func TestEffectiveTimeAttestationAllowMutation(t *testing.T) {
 func TestAttestationTime(t *testing.T) {
 	cases := []struct {
 		name                      string
-		choosenTime               string
+		chosenTime                string
 		attestationTime           time.Time
 		expectEffectiveTimeUpdate bool
 		description               string
 	}{
 		{
-			name:                      "successful attestation time set with AtAttestation choosenTime",
-			choosenTime:               AtAttestation,
+			name:                      "successful attestation time set with AtAttestation chosenTime",
+			chosenTime:                AtAttestation,
 			attestationTime:           time.Date(2023, 1, 15, 10, 30, 0, 0, time.UTC),
 			expectEffectiveTimeUpdate: true,
-			description:               "Should set attestation time and update effective time when choosenTime is AtAttestation",
+			description:               "Should set attestation time and update effective time when chosenTime is AtAttestation",
 		},
 		{
-			name:                      "successful attestation time set with Now choosenTime",
-			choosenTime:               Now,
+			name:                      "successful attestation time set with Now chosenTime",
+			chosenTime:                Now,
 			attestationTime:           time.Date(2023, 2, 20, 14, 45, 0, 0, time.UTC),
 			expectEffectiveTimeUpdate: false,
-			description:               "Should set attestation time but not update effective time when choosenTime is Now",
+			description:               "Should set attestation time but not update effective time when chosenTime is Now",
 		},
 		{
 			name:                      "edge case with zero time attestation",
-			choosenTime:               AtAttestation,
+			chosenTime:                AtAttestation,
 			attestationTime:           time.Time{}, // zero time
 			expectEffectiveTimeUpdate: true,
-			description:               "Should handle zero time correctly and still update effective time when choosenTime is AtAttestation",
+			description:               "Should handle zero time correctly and still update effective time when chosenTime is AtAttestation",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			// Create a policy with the specified choosenTime
+			// Create a policy with the specified chosenTime
 			p := &policy{
-				choosenTime: c.choosenTime,
+				chosenTime: c.chosenTime,
 			}
 
 			// Store initial effective time for comparison
@@ -794,11 +845,11 @@ func TestAttestationTime(t *testing.T) {
 
 			// Verify effective time behavior
 			if c.expectEffectiveTimeUpdate {
-				assert.NotNil(t, p.effectiveTime, "Effective time should be updated when choosenTime is AtAttestation")
-				assert.Equal(t, c.attestationTime, *p.effectiveTime, "Effective time should match attestation time when choosenTime is AtAttestation")
+				assert.NotNil(t, p.effectiveTime, "Effective time should be updated when chosenTime is AtAttestation")
+				assert.Equal(t, c.attestationTime, *p.effectiveTime, "Effective time should match attestation time when chosenTime is AtAttestation")
 			} else {
 				// Effective time should remain unchanged
-				assert.Equal(t, initialEffectiveTime, p.effectiveTime, "Effective time should remain unchanged when choosenTime is not AtAttestation")
+				assert.Equal(t, initialEffectiveTime, p.effectiveTime, "Effective time should remain unchanged when chosenTime is not AtAttestation")
 			}
 		})
 	}
@@ -806,7 +857,7 @@ func TestAttestationTime(t *testing.T) {
 	// Additional test for multiple calls to AttestationTime
 	t.Run("multiple attestation time calls", func(t *testing.T) {
 		p := &policy{
-			choosenTime: AtAttestation,
+			chosenTime: AtAttestation,
 		}
 
 		firstTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -1152,7 +1203,7 @@ func TestNewInputPolicy(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			policy, err := NewInputPolicy(ctx, c.policyRef, c.effectiveTime)
+			policy, err := NewInputPolicy(ctx, c.policyRef, c.effectiveTime, true)
 
 			if c.expectErr {
 				assert.Error(t, err, "Expected error for invalid input")
@@ -1323,8 +1374,9 @@ func TestPreProcessPolicy(t *testing.T) {
 		{
 			name: "successful preprocessing with simple policy",
 			policyOptions: Options{
-				PolicyRef:     fmt.Sprintf(`{"publicKey": %s}`, utils.TestPublicKeyJSON),
-				EffectiveTime: "2023-01-01T12:00:00Z",
+				PolicyRef:              fmt.Sprintf(`{"publicKey": %s}`, utils.TestPublicKeyJSON),
+				EffectiveTime:          "2023-01-01T12:00:00Z",
+				AllowPastEffectiveTime: true,
 			},
 			expectErr:   false,
 			description: "Should successfully preprocess a simple policy without sources",
@@ -1342,7 +1394,8 @@ func TestPreProcessPolicy(t *testing.T) {
 						}
 					]
 				}`, utils.TestPublicKeyJSON),
-				EffectiveTime: "2023-01-01T12:00:00Z",
+				EffectiveTime:          "2023-01-01T12:00:00Z",
+				AllowPastEffectiveTime: true,
 			},
 			mockDownload: func(ctx context.Context, dest, source string, showMsg bool) (metadata.Metadata, error) {
 				// Mock successful download
@@ -1367,7 +1420,8 @@ func TestPreProcessPolicy(t *testing.T) {
 						}
 					]
 				}`, utils.TestPublicKeyJSON),
-				EffectiveTime: "2023-01-01T12:00:00Z",
+				EffectiveTime:          "2023-01-01T12:00:00Z",
+				AllowPastEffectiveTime: true,
 			},
 			mockDownload: func(ctx context.Context, dest, source string, showMsg bool) (metadata.Metadata, error) {
 				return nil, fmt.Errorf("network error: connection refused")
@@ -1379,8 +1433,9 @@ func TestPreProcessPolicy(t *testing.T) {
 		{
 			name: "failed preprocessing with invalid policy reference",
 			policyOptions: Options{
-				PolicyRef:     `{"invalid": "json""}`,
-				EffectiveTime: "2023-01-01T12:00:00Z",
+				PolicyRef:              `{"invalid": "json""}`,
+				EffectiveTime:          "2023-01-01T12:00:00Z",
+				AllowPastEffectiveTime: true,
 			},
 			expectErr:   true,
 			errMsg:      "unable to parse",

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -152,6 +152,10 @@ spec:
       type: string
       description: Run policy checks with the provided time.
       default: "now"
+    - name: ALLOW_PAST_EFFECTIVE_TIME
+      type: string
+      description: Allow setting EFFECTIVE_TIME to a date in the past.
+      default: "false"
     - name: EXTRA_RULE_DATA
       type: string
       description: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
@@ -431,6 +435,7 @@ spec:
           --show-successes=true
           --show-policy-docs-link=true
           --effective-time="${EFFECTIVE_TIME}"
+          --allow-past-effective-time="${ALLOW_PAST_EFFECTIVE_TIME}"
           --extra-rule-data="${EXTRA_RULE_DATA}"
           --retry-max-wait="${RETRY_MAX_WAIT}"
           --retry-max-retry="${RETRY_MAX_RETRY}"
@@ -514,6 +519,8 @@ spec:
           value: "$(params.INFO)"
         - name: EFFECTIVE_TIME
           value: "$(params.EFFECTIVE_TIME)"
+        - name: ALLOW_PAST_EFFECTIVE_TIME
+          value: "$(params.ALLOW_PAST_EFFECTIVE_TIME)"
         - name: EXTRA_RULE_DATA
           value: "$(params.EXTRA_RULE_DATA)"
         - name: RETRY_MAX_WAIT

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -159,6 +159,10 @@ spec:
       type: string
       description: Run policy checks with the provided time.
       default: "now"
+    - name: ALLOW_PAST_EFFECTIVE_TIME
+      type: string
+      description: Allow setting EFFECTIVE_TIME to a date in the past.
+      default: "false"
     - name: EXTRA_RULE_DATA
       type: string
       description: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
@@ -379,6 +383,7 @@ spec:
           --show-successes=true
           --show-policy-docs-link=true
           --effective-time="${EFFECTIVE_TIME}"
+          --allow-past-effective-time="${ALLOW_PAST_EFFECTIVE_TIME}"
           --extra-rule-data="${EXTRA_RULE_DATA}"
           --retry-max-wait="${RETRY_MAX_WAIT}"
           --retry-max-retry="${RETRY_MAX_RETRY}"
@@ -416,6 +421,8 @@ spec:
           value: "$(params.INFO)"
         - name: EFFECTIVE_TIME
           value: "$(params.EFFECTIVE_TIME)"
+        - name: ALLOW_PAST_EFFECTIVE_TIME
+          value: "$(params.ALLOW_PAST_EFFECTIVE_TIME)"
         - name: EXTRA_RULE_DATA
           value: "$(params.EXTRA_RULE_DATA)"
         - name: RETRY_MAX_WAIT


### PR DESCRIPTION
  Backdating --effective-time suppresses time-gated security rules at both
  the CLI level (severity demotion) and the Rego level (when_ns
  propagation). Reject effective-time values more than 5 minutes in the
  past unless --allow-past-effective-time is explicitly set.

  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

#### What:
  - Add validation in parseEffectiveTime() to reject times >5min in the past
  - Add --allow-past-effective-time flag to validate image, validate input, and compare commands
  - 5-minute grace period to accommodate clock skew

#### Why:
- Setting --effective-time to a past date demotes time-gated rule failures to warnings (CLI level)
    and shifts the time reference for all Rego rules via when_ns (Rego level), effectively bypassing
    security checks at the integration test gate where users control IntegrationTestScenario params 

#### Tickets:
  -  https://redhat.atlassian.net/browse/EC-1993
  - Ref: EC-1843 (Red Team findings F7-1 and F7-2) 
