### PR TITLE
chore(deps): Update ubi-minimal base image (v0.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:2e8edce823a48e51858f1fad3ff4cbf6875ce8a3f86b9eecf298bc2050c8652a
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:2e8edce823a48e51858f1fad3ff4cbf6875ce8a3f86b9eecf298bc2050c8652a
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Update ubi-minimal base image to latest digest.

Old digest: `sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c`
New digest: `sha256:2e8edce823a48e51858f1fad3ff4cbf6875ce8a3f86b9eecf298bc2050c8652a`

### RPM changes
```diff
- glib2-2.68.4-19.el9_8.1.x86_64
- glibc-2.34-272.el9_8.x86_64
- glibc-common-2.34-272.el9_8.x86_64
- glibc-minimal-langpack-2.34-272.el9_8.x86_64
+ glib2-2.68.4-19.el9_8.2.x86_64
+ glibc-2.34-274.el9_8.x86_64
+ glibc-common-2.34-274.el9_8.x86_64
+ glibc-minimal-langpack-2.34-274.el9_8.x86_64
- libacl-2.3.1-4.el9.x86_64
+ libacl-2.4.0-1.el9_8.x86_64
- libsolv-0.7.24-5.el9_8.x86_64
+ libsolv-0.7.24-6.el9_8.x86_64
- libxml2-2.9.13-14.el9_8.1.x86_64
+ libxml2-2.9.13-14.el9_8.2.x86_64
- openssl-libs-3.5.5-4.el9_8.x86_64
+ openssl-libs-3.5.5-5.el9_8.x86_64
```