### PR TITLE
chore(deps): Remove Renovate annotations from .tekton files

### DIFF
--- a/.tekton/cli-e2e-push.yaml
+++ b/.tekton/cli-e2e-push.yaml
@@ -20,7 +20,6 @@ spec:
   - name: git-url
     value: https://github.com/conforma/e2e-tests.git
   - name: revision
-    # renovate: datasource=git-refs depName=https://github.com/conforma/e2e-tests branch=main
     value: 2f3c8026b9389b490bd53a878dc216f9847155f7
   - name: oci-container-repo
     value: quay.io/conforma/e2e-tests
@@ -40,7 +39,6 @@ spec:
     - name: url
       value: https://github.com/conforma/e2e-tests.git
     - name: revision
-      # renovate: datasource=git-refs depName=https://github.com/conforma/e2e-tests branch=main
       value: 2f3c8026b9389b490bd53a878dc216f9847155f7
     - name: pathInRepo
       value: .tekton/pipelines/conforma-e2e/pipeline.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -2,15 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>conforma/.github//config/renovate/renovate.json"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["\\.tekton/.*\\.yaml$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=git-refs\\s+depName=(?<depName>[^\\s]+)\\s+branch=(?<currentValue>[^\\s]+)\\s*\\n\\s*value:\\s*(?<currentDigest>[a-f0-9]+)"
-      ],
-      "datasourceTemplate": "git-refs"
-    }
   ]
 }


### PR DESCRIPTION
MintMaker natively detects Tekton resolver git-ref digests without needing # renovate: annotations. The overlap caused duplicate PRs for every e2e-tests digest bump, doubling CI and review agent runs.

Resolves: EC-2009

