### PR TITLE
chore(deps): Update ubi-minimal base image (v0.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Update ubi-minimal base image to latest digest.

Old digest: `sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0`
New digest: `sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f`

### RPM changes

```diff
- glibc-2.34-274.el9_8.x86_64
- glibc-common-2.34-274.el9_8.x86_64
- glibc-minimal-langpack-2.34-274.el9_8.x86_64
+ glibc-2.34-275.el9_8.x86_64
+ glibc-common-2.34-275.el9_8.x86_64
+ glibc-minimal-langpack-2.34-275.el9_8.x86_64
- p11-kit-0.26.2-1.el9.x86_64
- p11-kit-trust-0.26.2-1.el9.x86_64
+ p11-kit-0.26.4-1.el9_8.x86_64
+ p11-kit-trust-0.26.4-1.el9_8.x86_64
```

Ref: https://redhat.atlassian.net/browse/EC-2058