### PR TITLE
docs(EC-1980): add product naming guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Tests use build tags with different timeouts:
   Run `go mod tidy` in the right module.
 - **Debug mode:** `EC_DEBUG=1` preserves `ec-work-*` temp directories for inspection.
   The `--debug` flag only increases log verbosity.
+- **Product name:** This project is "Conforma CLI" (binary name: `ec`). Use "Conforma CLI" in new
+  user-facing strings, error messages, and documentation. Legacy identifiers required for
+  compatibility (e.g., `quay.io/enterprise-contract/ec-cli`, Tekton parameter names) must be
+  preserved as-is.
 
 ## CGO and DNS Resolution
 


### PR DESCRIPTION
## Summary
- Add product naming guidance to Key Conventions in AGENTS.md
- Explicitly states the project name is "Conforma CLI" (binary: `ec`)
- Instructs AI agents not to use the former name "ec-cli" in user-facing strings, even if issue descriptions reference the old name

Ref: EC-1980
Upstream: https://github.com/conforma/cli/issues/3389

## Test plan
- [ ] Verify AI code agents use "Conforma CLI" instead of "ec-cli" in generated strings on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)